### PR TITLE
fix: harden transfer-assignment with validation and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -88,7 +88,7 @@ jobs:
       - run: npx playwright install-deps chromium webkit
         if: steps.playwright-cache.outputs.cache-hit == 'true'
       - run: npx paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
-      - run: npx playwright test --shard=${{ matrix.shard }}/8
+      - run: npx playwright test --shard=${{ matrix.shard }}/4
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -102,7 +102,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All 8 e2e shards passed."
+      - run: echo "All 4 e2e shards passed."
 
   e2e-merge:
     needs: [e2e-test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,15 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - run: npx playwright install --with-deps chromium webkit
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install-deps chromium webkit
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
       - run: npx paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
       - run: npx playwright test --shard=${{ matrix.shard }}/8
       - uses: actions/upload-artifact@v4

--- a/messages/de.json
+++ b/messages/de.json
@@ -72,9 +72,9 @@
 	"settings_title": "Einstellungen",
 	"admin_settings_title": "Admin-Einstellungen",
 	"sign_out_button": "{username} abmelden",
-	"unassigned_money_label": "Noch nicht verteilt:",
+	"unassigned_money_label": "Unverteilt:",
 	"all_assigned_money_label": "Alles verteilt.",
-	"negative_unassigned_money_label": "Zu viel verteilt:",
+	"negative_unassigned_money_label": "Überzogen:",
 	"budget_go_to_current_month": "Aktueller Monat",
 	"budget_select_previous_month": "Vorherigen Monat auswählen",
 	"budget_select_next_month": "Nächsten Monat auswählen",
@@ -99,6 +99,7 @@
 	"select_category_placeholder": "Suche nach Kategorie...",
 	"select_category_empty": "Keine Kategorie",
 	"select_category_not_found": "Keine Kategorie gefunden.",
+	"select_category_unassigned": "Zur Verteilung",
 	"select_category_open": "Kategorie-Dropdown öffnen",
 	"transaction_table_cell_category_empty": "Ohne Kategorie",
 	"transaction_table_cell_category_placeholder": "Suche nach Kategorie...",
@@ -201,9 +202,5 @@
 	"budget_account_list_accounts_label": "Konten",
 	"budget_account_list_add_account": "Konto hinzufügen",
 	"budget_account_list_dialog_title": "Konto",
-	"budget_account_list_dialog_description": "Füge {budgetName} ein neues Konto hinzu.",
-	"budget_monthly_action_move_to_category": "Betrag verschieben",
-	"budget_monthly_action_cover_from_category": "Decken",
-	"budget_monthly_action_cover_from_unassigned": "Von nicht zugewiesenem Geld",
-	"budget_monthly_action_select_category": "Kategorie auswählen..."
+	"budget_account_list_dialog_description": "Füge {budgetName} ein neues Konto hinzu."
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -210,5 +210,6 @@
 	"transfer_assignment_unassigned": "Unverteilt",
 	"transfer_assignment_category": "Kategorie",
 	"transfer_assignment_select_category": "Kategorie auswählen",
-	"transfer_assignment_cover": "Ausgleichen"
+	"transfer_assignment_cover": "Ausgleichen",
+	"transfer_assignment_trigger_label": "Verbleibendes für {name} anpassen"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -202,5 +202,13 @@
 	"budget_account_list_accounts_label": "Konten",
 	"budget_account_list_add_account": "Konto hinzufügen",
 	"budget_account_list_dialog_title": "Konto",
-	"budget_account_list_dialog_description": "Füge {budgetName} ein neues Konto hinzu."
+	"budget_account_list_dialog_description": "Füge {budgetName} ein neues Konto hinzu.",
+	"transfer_assignment_cancel": "Abbrechen",
+	"transfer_assignment_ok": "OK",
+	"transfer_assignment_move": "Verschieben",
+	"transfer_assignment_amount": "Betrag",
+	"transfer_assignment_unassigned": "Unverteilt",
+	"transfer_assignment_category": "Kategorie",
+	"transfer_assignment_select_category": "Kategorie auswählen",
+	"transfer_assignment_cover": "Ausgleichen"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -202,5 +202,13 @@
 	"budget_account_list_accounts_label": "Accounts",
 	"budget_account_list_add_account": "Add Account",
 	"budget_account_list_dialog_title": "Account",
-	"budget_account_list_dialog_description": "Add a new account to {budgetName}."
+	"budget_account_list_dialog_description": "Add a new account to {budgetName}.",
+	"transfer_assignment_cancel": "Cancel",
+	"transfer_assignment_ok": "OK",
+	"transfer_assignment_move": "Move",
+	"transfer_assignment_amount": "Amount",
+	"transfer_assignment_unassigned": "Unassigned",
+	"transfer_assignment_category": "Category",
+	"transfer_assignment_select_category": "Select category",
+	"transfer_assignment_cover": "Cover"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -66,9 +66,9 @@
 	"settings_title": "Settings",
 	"admin_settings_title": "Admin Settings",
 	"sign_out_button": "Sign out {username}",
-	"unassigned_money_label": "Not yet assigned:",
-	"all_assigned_money_label": "All assigned.",
-	"negative_unassigned_money_label": "Too much assigned:",
+	"unassigned_money_label": "Unallocated:",
+	"all_assigned_money_label": "All done.",
+	"negative_unassigned_money_label": "Overspent:",
 	"budget_go_to_current_month": "Current Month",
 	"budget_select_previous_month": "Select previous month",
 	"budget_select_next_month": "Select next month",
@@ -96,6 +96,7 @@
 	"select_category_placeholder": "Search for category...",
 	"select_category_empty": "No Category",
 	"select_category_not_found": "No category found.",
+	"select_category_unassigned": "To Budget",
 	"select_category_open": "Open category dropdown",
 	"transaction_table_cell_category_empty": "No Category",
 	"transaction_table_cell_category_placeholder": "Search for category...",
@@ -201,9 +202,5 @@
 	"budget_account_list_accounts_label": "Accounts",
 	"budget_account_list_add_account": "Add Account",
 	"budget_account_list_dialog_title": "Account",
-	"budget_account_list_dialog_description": "Add a new account to {budgetName}.",
-	"budget_monthly_action_move_to_category": "Move amount",
-	"budget_monthly_action_cover_from_category": "Cover",
-	"budget_monthly_action_cover_from_unassigned": "From unassigned money",
-	"budget_monthly_action_select_category": "Select category..."
+	"budget_account_list_dialog_description": "Add a new account to {budgetName}."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -210,5 +210,6 @@
 	"transfer_assignment_unassigned": "Unassigned",
 	"transfer_assignment_category": "Category",
 	"transfer_assignment_select_category": "Select category",
-	"transfer_assignment_cover": "Cover"
+	"transfer_assignment_cover": "Cover",
+	"transfer_assignment_trigger_label": "Adjust remaining for {name}"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,10 @@ import { defineConfig, devices } from '@playwright/test';
 const DEFAULT_VIEWPORT = { height: 900, width: 1440 } as const;
 
 export default defineConfig({
+	expect: {
+		timeout: 10000
+	},
+
 	fullyParallel: true,
 
 	outputDir: 'tests/playwright/results',

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import { UNASSIGNED } from '$lib/constants';
 	import { m } from '$lib/paraglide/messages';
 	import { Combobox, type WithoutChildrenOrChild } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
@@ -13,6 +16,7 @@
 		categories,
 		class: className,
 		contentProps,
+		customItemRow,
 		inputProps,
 		name,
 		nullable = false,
@@ -27,6 +31,7 @@
 		categories: Category[];
 		class?: string;
 		contentProps?: WithoutChildrenOrChild<Combobox.ContentProps>;
+		customItemRow?: Snippet<[{ label: string; value: string }]>;
 		inputProps?: WithoutChildrenOrChild<Combobox.InputProps>;
 		name?: string;
 		nullable?: boolean;
@@ -55,8 +60,6 @@
 	function handleOpenChange(newOpen: boolean) {
 		if (!newOpen) searchValue = '';
 	}
-
-	const NULL_VALUE = '__empty__';
 
 	const showNullable = $derived(
 		nullable && textEmpty.toLowerCase().includes(searchValue.toLowerCase())
@@ -88,9 +91,9 @@
 	type="single"
 	{items}
 	bind:value={
-		() => value || NULL_VALUE,
+		() => value || UNASSIGNED,
 		(v) => {
-			value = !v || v === NULL_VALUE ? '' : v;
+			value = !v || v === UNASSIGNED ? '' : v;
 		}
 	}
 	bind:open
@@ -129,11 +132,19 @@
 		)}
 	>
 		{#if showNullable}
-			{@render itemRow({ label: textEmpty, value: NULL_VALUE })}
+			{#if customItemRow}
+				{@render customItemRow({ label: textEmpty, value: UNASSIGNED })}
+			{:else}
+				{@render itemRow({ label: textEmpty, value: UNASSIGNED })}
+			{/if}
 		{/if}
 
 		{#each filteredItems as item (item.value)}
-			{@render itemRow(item)}
+			{#if customItemRow}
+				{@render customItemRow(item)}
+			{:else}
+				{@render itemRow(item)}
+			{/if}
 		{:else}
 			{#if !showNullable}
 				<span class="px-2 text-center text-sm text-muted">{textNotFound}</span>

--- a/src/lib/components/ui/select-category/select-category.svelte.test.ts
+++ b/src/lib/components/ui/select-category/select-category.svelte.test.ts
@@ -3,7 +3,13 @@ import type { ComponentProps } from 'svelte';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { flushSync } from 'svelte';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+afterEach(() => {
+	vi.runAllTimers();
+	vi.useRealTimers();
+});
 
 import SelectCategory from './select-category.svelte';
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,2 +1,2 @@
-/** Sentinal for "keine Kategorie" / "without category" in URL params and internal combobox items. */
-export const NULL_SENTINEL = '__none__' as const;
+/** Sentinel for "unassigned" / "without category" in URL params and combobox items. */
+export const UNASSIGNED = '__none__' as const;

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -1,5 +1,6 @@
 import { resolve } from '$app/paths';
 import { requested } from '$app/server';
+import { UNASSIGNED } from '$lib/constants';
 import { m } from '$lib/paraglide/messages';
 import {
 	AssignmentSchema,
@@ -110,6 +111,6 @@ export const transferAssignment = guardedForm(TransferAssignmentSchema, async (d
 		budgetId: data.budgetId,
 		month: data.month,
 		sourceCategoryId: data.sourceCategoryId,
-		targetCategoryId: data.targetCategoryId ?? null
+		targetCategoryId: data.targetCategoryId === UNASSIGNED ? null : data.targetCategoryId
 	});
 });

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -1,4 +1,5 @@
 import { resolve } from '$app/paths';
+import { requested } from '$app/server';
 import { m } from '$lib/paraglide/messages';
 import {
 	AssignmentSchema,
@@ -6,7 +7,8 @@ import {
 	BudgetMonthSchema,
 	CreateBudgetSchema,
 	EditBudgetSchema,
-	FindBudgetUserSchema
+	FindBudgetUserSchema,
+	TransferAssignmentSchema
 } from '$lib/schemas/budget';
 import { OrderedIdsSchema } from '$lib/schemas/utils';
 import { guardedCommand, guardedForm, guardedQuery } from '$server/utils/remote-guard';
@@ -86,7 +88,8 @@ export const getUnassigned = guardedQuery(v.string(), async (id, { ctx }) =>
 
 export const assignment = guardedForm(AssignmentSchema, async (data, { ctx }) => {
 	ctx.budget.assignment(data);
-	void getMonthly(data).refresh();
+	await requested(getMonthly, 1).refreshAll();
+	await requested(getUnassigned, 1).refreshAll();
 });
 
 export const getInvitations = guardedQuery(async ({ ctx }) => ctx.budget.invitations());
@@ -99,4 +102,14 @@ export const acceptInvite = guardedForm(BudgetAndUserIdSchema, async ({ budgetId
 	ctx.budget.acceptInvite(budgetId);
 	void getBudgets().refresh();
 	void getBudget(budgetId).refresh();
+});
+
+export const transferAssignment = guardedForm(TransferAssignmentSchema, async (data, { ctx }) => {
+	ctx.budget.transferAssignment({
+		amount: data.amount,
+		budgetId: data.budgetId,
+		month: data.month,
+		sourceCategoryId: data.sourceCategoryId,
+		targetCategoryId: data.targetCategoryId ?? null
+	});
 });

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -87,10 +87,12 @@ export const getUnassigned = guardedQuery(v.string(), async (id, { ctx }) =>
 	ctx.budget.unassigned(id)
 );
 
+const refreshBudgetData = () =>
+	Promise.all([requested(getMonthly, 1).refreshAll(), requested(getUnassigned, 1).refreshAll()]);
+
 export const assignment = guardedForm(AssignmentSchema, async (data, { ctx }) => {
 	ctx.budget.assignment(data);
-	await requested(getMonthly, 1).refreshAll();
-	await requested(getUnassigned, 1).refreshAll();
+	await refreshBudgetData();
 });
 
 export const getInvitations = guardedQuery(async ({ ctx }) => ctx.budget.invitations());
@@ -115,6 +117,5 @@ export const transferAssignment = guardedForm(TransferAssignmentSchema, async (d
 			data.targetCategoryId === UNASSIGNED || !data.targetCategoryId ? null : data.targetCategoryId
 	});
 
-	await requested(getMonthly, 1).refreshAll();
-	await requested(getUnassigned, 1).refreshAll();
+	await refreshBudgetData();
 });

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -111,6 +111,10 @@ export const transferAssignment = guardedForm(TransferAssignmentSchema, async (d
 		budgetId: data.budgetId,
 		month: data.month,
 		sourceCategoryId: data.sourceCategoryId,
-		targetCategoryId: data.targetCategoryId === UNASSIGNED ? null : data.targetCategoryId
+		targetCategoryId:
+			data.targetCategoryId === UNASSIGNED || !data.targetCategoryId ? null : data.targetCategoryId
 	});
+
+	await requested(getMonthly, 1).refreshAll();
+	await requested(getUnassigned, 1).refreshAll();
 });

--- a/src/lib/remote-functions/transaction.remote.ts
+++ b/src/lib/remote-functions/transaction.remote.ts
@@ -61,7 +61,7 @@ export const createTransaction = guardedForm(
 			budgetId: data.budgetId,
 			categoryId: data.categoryId || null,
 			createdBy: user.id,
-			date: data.date,
+			date: data.date ?? new Date().toISOString().split('T')[0],
 			notes: data.notes || null,
 			validated: data.validated
 		});

--- a/src/lib/schemas/budget.ts
+++ b/src/lib/schemas/budget.ts
@@ -36,7 +36,7 @@ export const AssignmentSchema = v.object({
 
 export const TransferAssignmentSchema = v.object({
 	...BudgetMonthSchema.entries,
-	amount: v.number(),
+	amount: v.pipe(v.number(), v.notValue(0)),
 	sourceCategoryId: v.string(),
 	targetCategoryId: v.string()
 });

--- a/src/lib/schemas/budget.ts
+++ b/src/lib/schemas/budget.ts
@@ -36,7 +36,7 @@ export const AssignmentSchema = v.object({
 
 export const TransferAssignmentSchema = v.object({
 	...BudgetMonthSchema.entries,
-	amount: v.pipe(v.number(), v.minValue(1)),
-	fromCategoryId: v.optional(v.string()),
-	toCategoryId: v.pipe(v.string(), v.minLength(1))
+	amount: v.number(),
+	sourceCategoryId: v.string(),
+	targetCategoryId: v.optional(v.string())
 });

--- a/src/lib/schemas/budget.ts
+++ b/src/lib/schemas/budget.ts
@@ -38,5 +38,5 @@ export const TransferAssignmentSchema = v.object({
 	...BudgetMonthSchema.entries,
 	amount: v.number(),
 	sourceCategoryId: v.string(),
-	targetCategoryId: v.optional(v.string())
+	targetCategoryId: v.string()
 });

--- a/src/lib/schemas/transaction.ts
+++ b/src/lib/schemas/transaction.ts
@@ -7,7 +7,7 @@ export const TransactionCreateSchema = v.object({
 	amount: v.pipe(v.number(), v.integer()),
 	budgetId: v.pipe(v.string(), v.minLength(1)),
 	categoryId: v.optional(v.string()),
-	date: v.pipe(v.string(), v.minLength(1)),
+	date: v.optional(v.pipe(v.string(), v.minLength(1))),
 	notes: v.optional(v.string()),
 	validated: v.optional(v.boolean(), false)
 });

--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -1,6 +1,8 @@
 import { createDatabase, tables } from '$db';
+import { TransferAssignmentSchema } from '$lib/schemas/budget';
 import { NotFoundError } from '$server/utils/not-found-error';
 import { and, eq } from 'drizzle-orm';
+import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 
 import { createBudgetWithUser, createMemoryDb, createUser } from '../../../../test/fixtures';
@@ -681,6 +683,77 @@ describe('commands.transferAssignment', () => {
 				month: 202501,
 				sourceCategoryId: cat.id,
 				targetCategoryId: cat.id
+			})
+		).toThrow();
+	});
+
+	it('rejects amount:0 at schema level', () => {
+		const result = v.safeParse(TransferAssignmentSchema, {
+			amount: 0,
+			budgetId: 'any',
+			month: 202501,
+			sourceCategoryId: 'src',
+			targetCategoryId: 'tgt'
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('throws when sourceCategory belongs to different budget', () => {
+		const db = createMemoryDb();
+		const { budget: budget1, user } = createBudgetWithUser(db);
+		const budget2 = db.insert(tables.budgets).values({ name: 'Budget 2' }).returning().get();
+		db.insert(tables.usersToBudgets)
+			.values({ budgetId: budget2.id, role: 'OWNER', userId: user.id })
+			.run();
+		const sourceInBudget2 = db
+			.insert(tables.categories)
+			.values({ budgetId: budget2.id, name: 'Source' })
+			.returning()
+			.get();
+		const targetInBudget1 = db
+			.insert(tables.categories)
+			.values({ budgetId: budget1.id, name: 'Target' })
+			.returning()
+			.get();
+		const { transferAssignment } = commands(user.id, db);
+
+		expect(() =>
+			transferAssignment({
+				amount: 100,
+				budgetId: budget1.id,
+				month: 202501,
+				sourceCategoryId: sourceInBudget2.id,
+				targetCategoryId: targetInBudget1.id
+			})
+		).toThrow();
+	});
+
+	it('throws when targetCategory belongs to different budget', () => {
+		const db = createMemoryDb();
+		const { budget: budget1, user } = createBudgetWithUser(db);
+		const budget2 = db.insert(tables.budgets).values({ name: 'Budget 2' }).returning().get();
+		db.insert(tables.usersToBudgets)
+			.values({ budgetId: budget2.id, role: 'OWNER', userId: user.id })
+			.run();
+		const sourceInBudget1 = db
+			.insert(tables.categories)
+			.values({ budgetId: budget1.id, name: 'Source' })
+			.returning()
+			.get();
+		const targetInBudget2 = db
+			.insert(tables.categories)
+			.values({ budgetId: budget2.id, name: 'Target' })
+			.returning()
+			.get();
+		const { transferAssignment } = commands(user.id, db);
+
+		expect(() =>
+			transferAssignment({
+				amount: 100,
+				budgetId: budget1.id,
+				month: 202501,
+				sourceCategoryId: sourceInBudget1.id,
+				targetCategoryId: targetInBudget2.id
 			})
 		).toThrow();
 	});

--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -1,4 +1,4 @@
-import { createDatabase, tables } from '$db';
+import { createDatabase, type Database, tables } from '$db';
 import { TransferAssignmentSchema } from '$lib/schemas/budget';
 import { NotFoundError } from '$server/utils/not-found-error';
 import { and, eq } from 'drizzle-orm';
@@ -406,6 +406,18 @@ describe('commands.reorder', () => {
 	});
 });
 
+const getAssignment = (db: Database, categoryId: string, month = 202501) =>
+	db
+		.select()
+		.from(tables.budgetAssignments)
+		.where(
+			and(
+				eq(tables.budgetAssignments.categoryId, categoryId),
+				eq(tables.budgetAssignments.month, month)
+			)
+		)
+		.get();
+
 describe('commands.transferAssignment', () => {
 	it('moves amount from source category to target category', () => {
 		const db = createMemoryDb();
@@ -433,26 +445,8 @@ describe('commands.transferAssignment', () => {
 			targetCategoryId: target.id
 		});
 
-		const sourceRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, source.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
-		const targetRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, target.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const sourceRow = getAssignment(db, source.id);
+		const targetRow = getAssignment(db, target.id);
 		expect(sourceRow?.amount).toBe(100);
 		expect(targetRow?.amount).toBe(100);
 	});
@@ -483,27 +477,9 @@ describe('commands.transferAssignment', () => {
 			targetCategoryId: target.id
 		});
 
-		const sourceRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, source.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const sourceRow = getAssignment(db, source.id);
 		expect(sourceRow?.amount).toBe(0);
-		const targetRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, target.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const targetRow = getAssignment(db, target.id);
 		expect(targetRow?.amount).toBe(100);
 	});
 
@@ -530,27 +506,9 @@ describe('commands.transferAssignment', () => {
 			targetCategoryId: target.id
 		});
 
-		const sourceRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, source.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const sourceRow = getAssignment(db, source.id);
 		expect(sourceRow?.amount).toBe(-100);
-		const targetRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, target.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const targetRow = getAssignment(db, target.id);
 		expect(targetRow?.amount).toBe(100);
 	});
 
@@ -575,16 +533,7 @@ describe('commands.transferAssignment', () => {
 			targetCategoryId: null
 		});
 
-		const sourceRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, source.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const sourceRow = getAssignment(db, source.id);
 		expect(sourceRow?.amount).toBe(100);
 	});
 
@@ -617,26 +566,8 @@ describe('commands.transferAssignment', () => {
 			targetCategoryId: target.id
 		});
 
-		const sourceRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, source.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
-		const targetRow = db
-			.select()
-			.from(tables.budgetAssignments)
-			.where(
-				and(
-					eq(tables.budgetAssignments.categoryId, target.id),
-					eq(tables.budgetAssignments.month, 202501)
-				)
-			)
-			.get();
+		const sourceRow = getAssignment(db, source.id);
+		const targetRow = getAssignment(db, target.id);
 		expect(sourceRow?.amount).toBe(150);
 		expect(targetRow?.amount).toBe(-50);
 	});

--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -1,9 +1,9 @@
 import { createDatabase, tables } from '$db';
 import { NotFoundError } from '$server/utils/not-found-error';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
-import { createBudgetWithUser, createUser } from '../../../../test/fixtures';
+import { createBudgetWithUser, createMemoryDb, createUser } from '../../../../test/fixtures';
 import { commands, queries } from './budget';
 
 describe('queries.all', () => {
@@ -401,5 +401,287 @@ describe('commands.reorder', () => {
 		expect(order.find((o) => o.entityId === b3)?.position).toBe(0);
 		expect(order.find((o) => o.entityId === b1)?.position).toBe(1);
 		expect(order.find((o) => o.entityId === b2)?.position).toBe(2);
+	});
+});
+
+describe('commands.transferAssignment', () => {
+	it('moves amount from source category to target category', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const source = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Source' })
+			.returning()
+			.get();
+		const target = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Target' })
+			.returning()
+			.get();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 200, budgetId: budget.id, categoryId: source.id, month: 202501 })
+			.run();
+		const { transferAssignment } = commands(user.id, db);
+
+		transferAssignment({
+			amount: 100,
+			budgetId: budget.id,
+			month: 202501,
+			sourceCategoryId: source.id,
+			targetCategoryId: target.id
+		});
+
+		const sourceRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, source.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		const targetRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, target.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(sourceRow?.amount).toBe(100);
+		expect(targetRow?.amount).toBe(100);
+	});
+
+	it('sets source amount to zero when fully drained', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const source = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Source' })
+			.returning()
+			.get();
+		const target = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Target' })
+			.returning()
+			.get();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 100, budgetId: budget.id, categoryId: source.id, month: 202501 })
+			.run();
+		const { transferAssignment } = commands(user.id, db);
+
+		transferAssignment({
+			amount: 100,
+			budgetId: budget.id,
+			month: 202501,
+			sourceCategoryId: source.id,
+			targetCategoryId: target.id
+		});
+
+		const sourceRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, source.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(sourceRow?.amount).toBe(0);
+		const targetRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, target.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(targetRow?.amount).toBe(100);
+	});
+
+	it('creates negative source assignment when none existed', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const source = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Source' })
+			.returning()
+			.get();
+		const target = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Target' })
+			.returning()
+			.get();
+		const { transferAssignment } = commands(user.id, db);
+
+		transferAssignment({
+			amount: 100,
+			budgetId: budget.id,
+			month: 202501,
+			sourceCategoryId: source.id,
+			targetCategoryId: target.id
+		});
+
+		const sourceRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, source.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(sourceRow?.amount).toBe(-100);
+		const targetRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, target.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(targetRow?.amount).toBe(100);
+	});
+
+	it('moves amount from source category to unassigned', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const source = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Source' })
+			.returning()
+			.get();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 200, budgetId: budget.id, categoryId: source.id, month: 202501 })
+			.run();
+		const { transferAssignment } = commands(user.id, db);
+
+		transferAssignment({
+			amount: 100,
+			budgetId: budget.id,
+			month: 202501,
+			sourceCategoryId: source.id,
+			targetCategoryId: null
+		});
+
+		const sourceRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, source.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(sourceRow?.amount).toBe(100);
+	});
+
+	it('handles negative amount (reverse transfer)', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const source = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Source' })
+			.returning()
+			.get();
+		const target = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Target' })
+			.returning()
+			.get();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 50, budgetId: budget.id, categoryId: source.id, month: 202501 })
+			.run();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 50, budgetId: budget.id, categoryId: target.id, month: 202501 })
+			.run();
+		const { transferAssignment } = commands(user.id, db);
+
+		transferAssignment({
+			amount: -100,
+			budgetId: budget.id,
+			month: 202501,
+			sourceCategoryId: source.id,
+			targetCategoryId: target.id
+		});
+
+		const sourceRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, source.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		const targetRow = db
+			.select()
+			.from(tables.budgetAssignments)
+			.where(
+				and(
+					eq(tables.budgetAssignments.categoryId, target.id),
+					eq(tables.budgetAssignments.month, 202501)
+				)
+			)
+			.get();
+		expect(sourceRow?.amount).toBe(150);
+		expect(targetRow?.amount).toBe(-50);
+	});
+
+	it('throws NotFoundError without budget access', () => {
+		const db = createMemoryDb();
+		const { budget } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const outsider = createUser(db, 'outsider');
+		const target = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Target' })
+			.returning()
+			.get();
+		const { transferAssignment } = commands(outsider.id, db);
+
+		expect(() =>
+			transferAssignment({
+				amount: 100,
+				budgetId: budget.id,
+				month: 202501,
+				sourceCategoryId: target.id,
+				targetCategoryId: null
+			})
+		).toThrow(NotFoundError);
+	});
+
+	it('throws when source and target are the same category', () => {
+		const db = createMemoryDb();
+		const { budget, user } = createBudgetWithUser(db);
+		const cat = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Cat' })
+			.returning()
+			.get();
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 200, budgetId: budget.id, categoryId: cat.id, month: 202501 })
+			.run();
+		const { transferAssignment } = commands(user.id, db);
+
+		expect(() =>
+			transferAssignment({
+				amount: 100,
+				budgetId: budget.id,
+				month: 202501,
+				sourceCategoryId: cat.id,
+				targetCategoryId: cat.id
+			})
+		).toThrow();
 	});
 });

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -292,5 +292,72 @@ export const commands = (userId: string, db: Database = database) => ({
 					.run();
 			}
 		});
+	},
+
+	/**
+	 * Moves an assigned amount from one category to another within the same budget/month.
+	 * When `targetCategoryId` is `null`, the amount is returned to unassigned.
+	 * A negative amount reverses direction (from → to means to → from).
+	 */
+	transferAssignment: ({
+		amount,
+		budgetId,
+		month,
+		sourceCategoryId,
+		targetCategoryId
+	}: {
+		amount: number;
+		budgetId: string;
+		month: number;
+		sourceCategoryId: string;
+		targetCategoryId: null | string;
+	}) => {
+		accessGuard(budgetId, userId, db);
+
+		if (sourceCategoryId === targetCategoryId) error(400);
+
+		if (targetCategoryId === null) {
+			db.insert(tables.budgetAssignments)
+				.values({
+					amount: -amount,
+					budgetId,
+					categoryId: sourceCategoryId,
+					month
+				})
+				.onConflictDoUpdate({
+					set: { amount: sql`${tables.budgetAssignments.amount} - ${amount}` },
+					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]
+				})
+				.run();
+			return;
+		}
+
+		db.transaction((tx) => {
+			tx.insert(tables.budgetAssignments)
+				.values({
+					amount: -amount,
+					budgetId,
+					categoryId: sourceCategoryId,
+					month
+				})
+				.onConflictDoUpdate({
+					set: { amount: sql`${tables.budgetAssignments.amount} - ${amount}` },
+					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]
+				})
+				.run();
+
+			tx.insert(tables.budgetAssignments)
+				.values({
+					amount,
+					budgetId,
+					categoryId: targetCategoryId,
+					month
+				})
+				.onConflictDoUpdate({
+					set: { amount: sql`${tables.budgetAssignments.amount} + ${amount}` },
+					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]
+				})
+				.run();
+		});
 	}
 });

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -1,6 +1,6 @@
 import { database, type Database, tables } from '$db';
 import { error } from '@sveltejs/kit';
-import { and, eq, getColumns, isNull, sql } from 'drizzle-orm';
+import { and, eq, getColumns, inArray, isNull, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 import { accessGuard, hasAccess, ownerGuard } from './access';
@@ -314,45 +314,44 @@ export const commands = (userId: string, db: Database = database) => ({
 	}) => {
 		accessGuard(budgetId, userId, db);
 
+		// Validate that both categories belong to this budget
+		{
+			const categoryIds = [sourceCategoryId];
+			if (targetCategoryId !== null) categoryIds.push(targetCategoryId);
+			const owned = db
+				.select({ id: tables.categories.id })
+				.from(tables.categories)
+				.where(
+					and(eq(tables.categories.budgetId, budgetId), inArray(tables.categories.id, categoryIds))
+				)
+				.all();
+			if (owned.length !== categoryIds.length) error(400);
+		}
+
 		if (sourceCategoryId === targetCategoryId) error(400);
 
-		if (targetCategoryId === null) {
-			db.insert(tables.budgetAssignments)
-				.values({
-					amount: -amount,
-					budgetId,
-					categoryId: sourceCategoryId,
-					month
-				})
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- tx and db types don't share a useful supertype
+		const deductSource = (exec: any) => {
+			exec
+				.insert(tables.budgetAssignments)
+				.values({ amount: -amount, budgetId, categoryId: sourceCategoryId, month })
 				.onConflictDoUpdate({
 					set: { amount: sql`${tables.budgetAssignments.amount} - ${amount}` },
 					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]
 				})
 				.run();
+		};
+
+		if (targetCategoryId === null) {
+			deductSource(db);
 			return;
 		}
 
 		db.transaction((tx) => {
-			tx.insert(tables.budgetAssignments)
-				.values({
-					amount: -amount,
-					budgetId,
-					categoryId: sourceCategoryId,
-					month
-				})
-				.onConflictDoUpdate({
-					set: { amount: sql`${tables.budgetAssignments.amount} - ${amount}` },
-					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]
-				})
-				.run();
+			deductSource(tx);
 
 			tx.insert(tables.budgetAssignments)
-				.values({
-					amount,
-					budgetId,
-					categoryId: targetCategoryId,
-					month
-				})
+				.values({ amount, budgetId, categoryId: targetCategoryId, month })
 				.onConflictDoUpdate({
 					set: { amount: sql`${tables.budgetAssignments.amount} + ${amount}` },
 					target: [tables.budgetAssignments.categoryId, tables.budgetAssignments.month]

--- a/src/lib/server/db/user-context/transaction.utils.test.ts
+++ b/src/lib/server/db/user-context/transaction.utils.test.ts
@@ -1,5 +1,5 @@
 import { createDatabase, type Database, tables } from '$db';
-import { NULL_SENTINEL } from '$lib/constants';
+import { UNASSIGNED } from '$lib/constants';
 import { getColumns } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
@@ -93,20 +93,20 @@ describe('withFilter', () => {
 		expect(result.map((t) => t.id).sort()).toEqual([tx1.id, tx3.id].sort());
 	});
 
-	it('filters by categoryId including NULL_SENTINEL', () => {
+	it('filters by categoryId including UNASSIGNED', () => {
 		const db = createDatabase(':memory:');
 		const { cat } = setupTransactions(db);
 
-		const dq = withFilter({ dq: baseQuery(db), filter: { categoryId: [cat.id, NULL_SENTINEL] } });
+		const dq = withFilter({ dq: baseQuery(db), filter: { categoryId: [cat.id, UNASSIGNED] } });
 		const result = dq.all();
 		expect(result).toHaveLength(3);
 	});
 
-	it('filters by categoryId NULL_SENTINEL only', () => {
+	it('filters by categoryId UNASSIGNED only', () => {
 		const db = createDatabase(':memory:');
 		const { tx2 } = setupTransactions(db);
 
-		const dq = withFilter({ dq: baseQuery(db), filter: { categoryId: [NULL_SENTINEL] } });
+		const dq = withFilter({ dq: baseQuery(db), filter: { categoryId: [UNASSIGNED] } });
 		const result = dq.all();
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe(tx2.id);

--- a/src/lib/server/db/user-context/transaction.utils.ts
+++ b/src/lib/server/db/user-context/transaction.utils.ts
@@ -1,7 +1,7 @@
 import type { SQLiteColumn, SQLiteSelect } from 'drizzle-orm/sqlite-core';
 
 import { tables } from '$db';
-import { NULL_SENTINEL } from '$lib/constants';
+import { UNASSIGNED } from '$lib/constants';
 import { and, asc, desc, eq, gte, inArray, isNull, like, lte, or, type SQL } from 'drizzle-orm';
 
 export type TransactionFilterParam = {
@@ -49,8 +49,8 @@ export function withFilter<T extends SQLiteSelect>({
 	}
 	if (filter.categoryId) {
 		const ids = filter.categoryId;
-		const realIds = ids.filter((id: string) => id !== NULL_SENTINEL);
-		const hasNull = ids.includes(NULL_SENTINEL);
+		const realIds = ids.filter((id: string) => id !== UNASSIGNED);
+		const hasNull = ids.includes(UNASSIGNED);
 
 		const categoryConditions: SQL[] = [];
 		if (realIds.length > 0)

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import { InputCurrency } from '$lib/components/ui/input-currency';
 	import { m } from '$lib/paraglide/messages';
-	import { assignment, getBudget } from '$lib/remote-functions/budget.remote';
+	import {
+		assignment,
+		getBudget,
+		getMonthly,
+		getUnassigned
+	} from '$lib/remote-functions/budget.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { formatCurrency } from '$lib/utils/format-currency';
 	import { Popover } from 'bits-ui';
@@ -50,7 +55,7 @@
 	<Popover.ContentStatic class="absolute inset-0 outline-2 -outline-offset-2 outline-focus">
 		<form
 			{...scopedForm.enhance(async (form) => {
-				if (await form.submit()) {
+				if (await form.submit().updates(getMonthly, getUnassigned)) {
 					open = false;
 				}
 			})}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -9,7 +9,6 @@
 	import { createSortable } from '$lib/utils/sort-helper.svelte';
 	import { useDialog } from '$lib/utils/use-dialog';
 	import { untrack } from 'svelte';
-	import { cn } from 'tailwind-variants';
 	import PhDotsSixVerticalBold from '~icons/ph/dots-six-vertical-bold';
 
 	import BudgetTableCell from './budget-table-cell.svelte';
@@ -89,10 +88,7 @@
 				data-drag-item="category"
 				data-sortable-id={row.id}
 				role="row"
-				class={cn(
-					'relative flex border-b border-muted/20 bg-surface last:border-b-0 hover:bg-muted/3',
-					''
-				)}
+				class="relative flex border-b border-muted/20 bg-surface last:border-b-0 hover:bg-muted/3"
 			>
 				<BudgetTableCell class="relative flex w-2/5 p-0 hover:bg-surface">
 					<a

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -49,6 +49,10 @@
 		}
 	});
 
+	const otherCategoriesById = $derived(
+		new Map(categories.map((cat) => [cat.id, categories.filter((f) => f.id !== cat.id)]))
+	);
+
 	let activeAssignmentCategoryId = $state<null | string>(null);
 	let isActiveAssignment = $derived((id: string) => activeAssignmentCategoryId === id);
 
@@ -138,7 +142,7 @@
 						categoryName={row.name}
 						rowId={row.id}
 						remaining={row.remaining}
-						otherCategories={categories.filter((f) => f.id !== row.id)}
+						otherCategories={otherCategoriesById.get(row.id)!}
 					/>
 				</BudgetTableCell>
 

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -135,6 +135,7 @@
 				<BudgetTableCell class="w-1/5 p-0">
 					<TransferPopup
 						{month}
+						categoryName={row.name}
 						rowId={row.id}
 						remaining={row.remaining}
 						otherCategories={categories.filter((f) => f.id !== row.id)}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -137,7 +137,12 @@
 				</BudgetTableCell>
 
 				<BudgetTableCell class="w-1/5 p-0">
-					<TransferPopup remaining={row.remaining} />
+					<TransferPopup
+						{month}
+						rowId={row.id}
+						remaining={row.remaining}
+						otherCategories={categories.filter((f) => f.id !== row.id)}
+					/>
 				</BudgetTableCell>
 
 				<BudgetTableCell class="w-9 border-0 last:p-2">

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -15,6 +15,7 @@
 	import BudgetTableCell from './budget-table-cell.svelte';
 	import BudgetTableHeader from './budget-table-header.svelte';
 	import CategoryAssignmentForm from './category-assignment-form.svelte';
+	import TransferPopup from './transfer-popup.svelte';
 
 	let {
 		month,
@@ -89,7 +90,7 @@
 				data-sortable-id={row.id}
 				role="row"
 				class={cn(
-					'relative flex border-b border-muted/20 bg-surface last:border-b-0 hover:bg-muted/5',
+					'relative flex border-b border-muted/20 bg-surface last:border-b-0 hover:bg-muted/3',
 					''
 				)}
 			>
@@ -135,17 +136,8 @@
 					{formatCurrency({ centValue: row.activity, currency })}
 				</BudgetTableCell>
 
-				<BudgetTableCell class="w-1/5 justify-end">
-					<span
-						class={cn(
-							'w-fit rounded-full border px-2 font-currency',
-							row.remaining < 0
-								? 'border-error/50 bg-error/20 hover:bg-error/30'
-								: 'border-success/80 bg-success/20 hover:bg-success/30'
-						)}
-					>
-						{formatCurrency({ centValue: row.remaining, currency })}
-					</span>
+				<BudgetTableCell class="w-1/5 p-0">
+					<TransferPopup remaining={row.remaining} />
 				</BudgetTableCell>
 
 				<BudgetTableCell class="w-9 border-0 last:p-2">

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -18,11 +18,13 @@
 	import ArrowFatLineDownDuotoneIcon from '~icons/ph/arrow-fat-line-down-duotone';
 
 	let {
+		categoryName,
 		month,
 		otherCategories,
 		remaining,
 		rowId
 	}: {
+		categoryName: string;
 		month: string;
 		otherCategories: { id: string; name: string; remaining: number }[];
 		remaining: number;
@@ -51,6 +53,7 @@
 		)}
 		disabled={remaining === 0}
 		aria-disabled={remaining === 0}
+		aria-label={m.transfer_assignment_trigger_label({ name: categoryName })}
 	>
 		<div
 			class={cn(

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -98,55 +98,8 @@
 	</Popover.Content>
 </Popover.Root>
 
-{#snippet moveform()}
-	<div class="flex flex-col gap-1.5">
-		<div class="flex items-center justify-between gap-4">
-			<span class="font-medium">{m.transfer_assignment_move()}</span>
-			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
-		</div>
-
-		<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
-
-		<InputCurrency
-			name={form.fields.amount.as('number').name}
-			aria-label={m.transfer_assignment_amount()}
-			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
-			currency={budget.currency}
-			class="px-2 text-right font-currency font-medium"
-			selectOnFocus
-		/>
-
-		<SelectCategory
-			name={form.fields.targetCategoryId.as('select').name}
-			bind:value={
-				() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
-			}
-			categories={otherCategories}
-			nullable
-			textEmpty={m.transfer_assignment_unassigned()}
-			ariaLabel={m.transfer_assignment_category()}
-			ariaLabelTrigger={m.transfer_assignment_select_category()}
-		>
-			{#snippet customItemRow({ label, value: id })}
-				{@render customSelectRow({
-					balance: id === UNASSIGNED ? unassigned : getOtherRemaining(id),
-					id,
-					label
-				})}
-			{/snippet}
-		</SelectCategory>
-	</div>
-{/snippet}
-
-{#snippet coverform()}
-	<div class="flex items-center justify-between gap-4">
-		<span class="font-medium">{m.transfer_assignment_cover()}</span>
-		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
-	</div>
-
+{#snippet sharedFields()}
 	<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
-	<input {...form.fields.amount.as('hidden', remaining)} />
-
 	<SelectCategory
 		name={form.fields.targetCategoryId.as('select').name}
 		bind:value={
@@ -166,6 +119,37 @@
 			})}
 		{/snippet}
 	</SelectCategory>
+{/snippet}
+
+{#snippet moveform()}
+	<div class="flex flex-col gap-1.5">
+		<div class="flex items-center justify-between gap-4">
+			<span class="font-medium">{m.transfer_assignment_move()}</span>
+			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
+		</div>
+
+		<InputCurrency
+			name={form.fields.amount.as('number').name}
+			aria-label={m.transfer_assignment_amount()}
+			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
+			currency={budget.currency}
+			class="px-2 text-right font-currency font-medium"
+			selectOnFocus
+		/>
+
+		{@render sharedFields()}
+	</div>
+{/snippet}
+
+{#snippet coverform()}
+	<div class="flex items-center justify-between gap-4">
+		<span class="font-medium">{m.transfer_assignment_cover()}</span>
+		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
+	</div>
+
+	<input {...form.fields.amount.as('hidden', remaining)} />
+
+	{@render sharedFields()}
 {/snippet}
 
 {#snippet customSelectRow(item: { balance: number; id: string; label: string })}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -4,6 +4,7 @@
 	import * as Popover from '$lib/components/ui/popover';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { UNASSIGNED } from '$lib/constants';
+	import * as m from '$lib/paraglide/messages';
 	import {
 		getBudget,
 		getMonthly,
@@ -85,8 +86,10 @@
 			{/if}
 
 			<div class="flex justify-end gap-2">
-				<Button variant="ghost" size="sm" onclick={() => (open = false)}>Abbrechen</Button>
-				<Button type="submit" size="sm">OK</Button>
+				<Button variant="ghost" size="sm" onclick={() => (open = false)}
+					>{m.transfer_assignment_cancel()}</Button
+				>
+				<Button type="submit" size="sm">{m.transfer_assignment_ok()}</Button>
 			</div>
 		</form>
 	</Popover.Content>
@@ -95,7 +98,7 @@
 {#snippet moveform()}
 	<div class="flex flex-col gap-1.5">
 		<div class="flex items-center justify-between gap-4">
-			<span class="font-medium">Verschieben</span>
+			<span class="font-medium">{m.transfer_assignment_move()}</span>
 			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
 		</div>
 
@@ -103,7 +106,7 @@
 
 		<InputCurrency
 			name={form.fields.amount.as('number').name}
-			aria-label="Amount"
+			aria-label={m.transfer_assignment_amount()}
 			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
 			currency={budget.currency}
 			class="px-2 text-right font-currency font-medium"
@@ -117,9 +120,9 @@
 			}
 			categories={otherCategories}
 			nullable
-			textEmpty="Unverteilt"
-			ariaLabel="Kategorie"
-			ariaLabelTrigger="Kategorie auswählen"
+			textEmpty={m.transfer_assignment_unassigned()}
+			ariaLabel={m.transfer_assignment_category()}
+			ariaLabelTrigger={m.transfer_assignment_select_category()}
 		>
 			{#snippet customItemRow({ label, value: id })}
 				{@render customSelectRow({
@@ -134,7 +137,7 @@
 
 {#snippet coverform()}
 	<div class="flex items-center justify-between gap-4">
-		<span class="font-medium">Ausgleichen</span>
+		<span class="font-medium">{m.transfer_assignment_cover()}</span>
 		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
 	</div>
 
@@ -148,9 +151,9 @@
 		}
 		categories={otherCategories}
 		nullable
-		textEmpty="Unverteilt"
-		ariaLabel="Kategorie"
-		ariaLabelTrigger="Kategorie auswählen"
+		textEmpty={m.transfer_assignment_unassigned()}
+		ariaLabel={m.transfer_assignment_category()}
+		ariaLabelTrigger={m.transfer_assignment_select_category()}
 	>
 		{#snippet customItemRow({ label, value: id })}
 			{@render customSelectRow({

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { InputCurrency } from '$lib/components/ui/input-currency';
+	import * as Popover from '$lib/components/ui/popover';
+	import { SelectCategory } from '$lib/components/ui/select-category';
+	import { m } from '$lib/paraglide/messages';
+	import { getBudget, transferAssignment } from '$lib/remote-functions/budget.remote';
+	import { getCategories } from '$lib/remote-functions/category.remote';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
+	import { formatCurrency } from '$lib/utils/format-currency';
+	import { cn } from 'tailwind-variants';
+	import ArrowFatLineDownDuotoneIcon from '~icons/ph/arrow-fat-line-down-duotone';
+
+	let { remaining }: { remaining: number } = $props();
+
+	const budgetId = getBudgetId();
+	const budget = $derived(await getBudget(budgetId()));
+	const categories = $derived(await getCategories({ budgetId: budgetId() }));
+	const currency = $derived(budget.currency);
+	const id = $props.id();
+	const form = $derived(transferAssignment.for(id));
+
+	let open = $state(false);
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger
+		class={cn(
+			'h-full w-full cursor-pointer p-1 text-right font-currency -outline-offset-2 hover:bg-surface hover:outline-2 hover:outline-interactive/60',
+			'aria-disabled:text-muted aria-disabled:hover:bg-transparent aria-disabled:hover:outline-none'
+		)}
+		disabled={remaining === 0}
+		aria-disabled={remaining === 0}
+	>
+		<div
+			class={cn(
+				'flex size-full items-center justify-end rounded-sm px-1',
+				remaining > 0 && 'bg-success/10',
+				remaining < 0 && 'bg-error/10 text-error'
+			)}
+		>
+			{formatCurrency({ centValue: remaining, currency })}
+		</div>
+	</Popover.Trigger>
+
+	<Popover.Content align="end" sideOffset={1} class="rounded-xs p-3 shadow-lg">
+		<form {...form} class="flex flex-col gap-3">
+			{#if remaining > 0}
+				{@render moveform()}
+			{:else}
+				{@render coverform()}
+			{/if}
+		</form>
+	</Popover.Content>
+</Popover.Root>
+
+{#snippet moveform()}
+	<div class="flex flex-col gap-1.5">
+		<div class="flex items-center justify-between gap-4">
+			<span class="font-medium">Verschieben</span>
+			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
+		</div>
+
+		<InputCurrency
+			name={form.fields.amount.as('number').name}
+			aria-label="Amount"
+			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
+			currency={budget.currency}
+			class="px-2 text-right font-currency font-medium"
+		/>
+
+		<SelectCategory
+			name={form.fields.targetCategoryId.as('select').name}
+			bind:value={
+				() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
+			}
+			{categories}
+			nullable
+			ariaLabel={m.transactions_table_header_category()}
+			ariaLabelTrigger={m.select_category_open()}
+		/>
+	</div>
+
+	<div class="flex justify-end gap-2">
+		<Button variant="ghost" size="sm">Cancel</Button>
+		<Button size="sm">OK</Button>
+	</div>
+{/snippet}
+
+{#snippet coverform()}
+	<div class="flex items-center justify-between gap-4">
+		<span class="font-medium">Ausgleichen</span>
+		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
+	</div>
+
+	<SelectCategory
+		name={form.fields.targetCategoryId.as('select').name}
+		bind:value={
+			() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
+		}
+		{categories}
+		nullable
+		ariaLabel={m.transactions_table_header_category()}
+		ariaLabelTrigger={m.select_category_open()}
+	/>
+
+	<div class="flex justify-end gap-2">
+		<Button variant="ghost" size="sm">Cancel</Button>
+		<Button size="sm">OK</Button>
+	</div>
+{/snippet}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -3,19 +3,38 @@
 	import { InputCurrency } from '$lib/components/ui/input-currency';
 	import * as Popover from '$lib/components/ui/popover';
 	import { SelectCategory } from '$lib/components/ui/select-category';
-	import { m } from '$lib/paraglide/messages';
-	import { getBudget, transferAssignment } from '$lib/remote-functions/budget.remote';
-	import { getCategories } from '$lib/remote-functions/category.remote';
+	import { UNASSIGNED } from '$lib/constants';
+	import {
+		getBudget,
+		getMonthly,
+		getUnassigned,
+		transferAssignment
+	} from '$lib/remote-functions/budget.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { formatCurrency } from '$lib/utils/format-currency';
+	import { Combobox } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
 	import ArrowFatLineDownDuotoneIcon from '~icons/ph/arrow-fat-line-down-duotone';
 
-	let { remaining }: { remaining: number } = $props();
+	let {
+		month,
+		otherCategories,
+		remaining,
+		rowId
+	}: {
+		month: string;
+		otherCategories: { id: string; name: string; remaining: number }[];
+		remaining: number;
+		rowId: string;
+	} = $props();
 
 	const budgetId = getBudgetId();
 	const budget = $derived(await getBudget(budgetId()));
-	const categories = $derived(await getCategories({ budgetId: budgetId() }));
+	const unassigned = $derived(await getUnassigned(budgetId()));
+	const getOtherRemaining = $derived(
+		(id: string) => otherCategories.find((f) => f.id === id)?.remaining ?? 0
+	);
+
 	const currency = $derived(budget.currency);
 	const id = $props.id();
 	const form = $derived(transferAssignment.for(id));
@@ -44,12 +63,31 @@
 	</Popover.Trigger>
 
 	<Popover.Content align="end" sideOffset={1} class="rounded-xs p-3 shadow-lg">
-		<form {...form} class="flex flex-col gap-3">
+		<form
+			{...form.enhance(async (f) => {
+				if (await f.submit().updates(getMonthly, getUnassigned)) {
+					open = false;
+				}
+			})}
+			class="flex flex-col gap-3"
+		>
+			<input {...form.fields.budgetId.as('hidden', budgetId())} />
+			<input
+				type="hidden"
+				name={form.fields.month.as('number').name}
+				value={Number.isNaN(parseInt(month)) ? '' : parseInt(month)}
+			/>
+
 			{#if remaining > 0}
 				{@render moveform()}
 			{:else}
 				{@render coverform()}
 			{/if}
+
+			<div class="flex justify-end gap-2">
+				<Button variant="ghost" size="sm" onclick={() => (open = false)}>Abbrechen</Button>
+				<Button type="submit" size="sm">OK</Button>
+			</div>
 		</form>
 	</Popover.Content>
 </Popover.Root>
@@ -61,12 +99,15 @@
 			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
 		</div>
 
+		<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
+
 		<InputCurrency
 			name={form.fields.amount.as('number').name}
 			aria-label="Amount"
 			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
 			currency={budget.currency}
 			class="px-2 text-right font-currency font-medium"
+			selectOnFocus
 		/>
 
 		<SelectCategory
@@ -74,16 +115,20 @@
 			bind:value={
 				() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
 			}
-			{categories}
+			categories={otherCategories}
 			nullable
-			ariaLabel={m.transactions_table_header_category()}
-			ariaLabelTrigger={m.select_category_open()}
-		/>
-	</div>
-
-	<div class="flex justify-end gap-2">
-		<Button variant="ghost" size="sm">Cancel</Button>
-		<Button size="sm">OK</Button>
+			textEmpty="Unverteilt"
+			ariaLabel="Kategorie"
+			ariaLabelTrigger="Kategorie auswählen"
+		>
+			{#snippet customItemRow({ label, value: id })}
+				{@render customSelectRow({
+					balance: id === UNASSIGNED ? unassigned : getOtherRemaining(id),
+					id,
+					label
+				})}
+			{/snippet}
+		</SelectCategory>
 	</div>
 {/snippet}
 
@@ -93,19 +138,45 @@
 		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
 	</div>
 
+	<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
+	<input {...form.fields.amount.as('hidden', remaining)} />
+
 	<SelectCategory
 		name={form.fields.targetCategoryId.as('select').name}
 		bind:value={
 			() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
 		}
-		{categories}
+		categories={otherCategories}
 		nullable
-		ariaLabel={m.transactions_table_header_category()}
-		ariaLabelTrigger={m.select_category_open()}
-	/>
+		textEmpty="Unverteilt"
+		ariaLabel="Kategorie"
+		ariaLabelTrigger="Kategorie auswählen"
+	>
+		{#snippet customItemRow({ label, value: id })}
+			{@render customSelectRow({
+				balance: id === UNASSIGNED ? unassigned : getOtherRemaining(id),
+				id,
+				label
+			})}
+		{/snippet}
+	</SelectCategory>
+{/snippet}
 
-	<div class="flex justify-end gap-2">
-		<Button variant="ghost" size="sm">Cancel</Button>
-		<Button size="sm">OK</Button>
-	</div>
+{#snippet customSelectRow(item: { balance: number; id: string; label: string })}
+	<Combobox.Item
+		value={item.id}
+		label={item.label}
+		class="flex w-full cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-highlighted:bg-info/5 data-highlighted:text-info data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+	>
+		<div>{item.label}</div>
+		<div
+			class={cn(
+				'rounded-sm p-0.5 px-2 text-xs font-currency text-foreground',
+				item.balance > 0 && 'bg-success/20',
+				item.balance < 0 && 'bg-error/20 text-error'
+			)}
+		>
+			{formatCurrency({ centValue: item.balance, currency })}
+		</div>
+	</Combobox.Item>
 {/snippet}

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-filter-category.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-filter-category.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as Select from '$lib/components/ui/select';
-	import { NULL_SENTINEL } from '$lib/constants';
+	import { UNASSIGNED } from '$lib/constants';
 	import { m } from '$lib/paraglide/messages';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 
@@ -29,7 +29,7 @@
 	</Select.Trigger>
 
 	<Select.Content class="max-h-75">
-		<Select.Item value={NULL_SENTINEL}>{m.transaction_filter_category_without()}</Select.Item>
+		<Select.Item value={UNASSIGNED}>{m.transaction_filter_category_without()}</Select.Item>
 
 		{#each categories as category (category.id)}
 			<Select.Item value={category.id}>{category.name}</Select.Item>

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/validation-checkbox.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/validation-checkbox.svelte
@@ -26,7 +26,7 @@
 		{disabled}
 		{...restProps}
 		aria-label="Validated"
-		class="absolute inset-0 z-10 cursor-pointer opacity-0"
+		class="sr-only absolute inset-0 z-10 cursor-pointer"
 	/>
 	{#if checked}
 		<SealCheckDuotoneIcon class="size-6 text-success" aria-hidden="true" />

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/validation-checkbox.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/validation-checkbox.svelte
@@ -26,7 +26,7 @@
 		{disabled}
 		{...restProps}
 		aria-label="Validated"
-		class="sr-only absolute inset-0 z-10 cursor-pointer"
+		class="absolute inset-0 z-10 cursor-pointer opacity-0"
 	/>
 	{#if checked}
 		<SealCheckDuotoneIcon class="size-6 text-success" aria-hidden="true" />

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { Input } from '$lib/components/ui/input';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import { Textarea } from '$lib/components/ui/textarea';
@@ -34,7 +35,7 @@
 	{#if savedToast.show}
 		<div
 			class="absolute -top-10 right-2 flex items-center gap-1 rounded-md border border-success/50 bg-surface-high px-3 py-1 font-medium text-success shadow-lg"
-			transition:fly={{ duration: 200, x: -20 }}
+			transition:fly={{ duration: browser ? 200 : 0, x: -20 }}
 		>
 			<PhFloppyDiskDuotone />
 			<span>{m.saved()}</span>

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
@@ -21,6 +21,11 @@
 	let savedToast = createSingletonToast();
 
 	const formId = $props.id();
+	const flyDuration = browser
+		? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			? 0
+			: 200
+		: 0;
 </script>
 
 <form
@@ -35,7 +40,7 @@
 	{#if savedToast.show}
 		<div
 			class="absolute -top-10 right-2 flex items-center gap-1 rounded-md border border-success/50 bg-surface-high px-3 py-1 font-medium text-success shadow-lg"
-			transition:fly={{ duration: browser ? 200 : 0, x: -20 }}
+			transition:fly={{ duration: flyDuration, x: -20 }}
 		>
 			<PhFloppyDiskDuotone />
 			<span>{m.saved()}</span>

--- a/src/routes/(app)/navigation-mobile.svelte
+++ b/src/routes/(app)/navigation-mobile.svelte
@@ -28,14 +28,20 @@
 	let open = $state(false);
 
 	const closeDrawerAttachment: Attachment<HTMLElement> = (node) => {
-		function closeDrawer() {
-			open = false;
+		function closeDrawer(e: MouseEvent) {
+			// Use event delegation — the links inside the <nav> are loaded
+			// asynchronously (await getBudgets / getAccounts), so querySelectorAll
+			// at mount time won't find them. Instead, check if the click target
+			// is or is inside an <a> element.
+			const target = e.target as HTMLElement;
+			if (target.closest('a')) {
+				open = false;
+			}
 		}
 
-		const links = node.querySelectorAll('a');
-		links.forEach((e) => e.addEventListener('click', closeDrawer));
+		node.addEventListener('click', closeDrawer);
 		return () => {
-			links.forEach((e) => e.removeEventListener('click', closeDrawer));
+			node.removeEventListener('click', closeDrawer);
 		};
 	};
 </script>

--- a/tests/playwright/account.spec.ts
+++ b/tests/playwright/account.spec.ts
@@ -7,7 +7,6 @@ test('Create Account', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
@@ -18,7 +17,6 @@ test('Edit Account Name', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);

--- a/tests/playwright/budget.spec.ts
+++ b/tests/playwright/budget.spec.ts
@@ -8,11 +8,9 @@ test('Assign Budget to Category', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);
@@ -20,16 +18,14 @@ test('Assign Budget to Category', async ({ pages }) => {
 	await pages.budget.assignAmount(categoryName, '500');
 });
 
-test('Transfer Assignment — Move between categories', async ({ page, pages }) => {
+test('Transfer Assignment — Move between categories', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const sourceCategory = faker.commerce.department();
 	await pages.budget.createCategory(sourceCategory);
@@ -43,12 +39,10 @@ test('Transfer Assignment — Move between categories', async ({ page, pages }) 
 	await pages.budget.transferToCategory(sourceCategory, '2', targetCategory);
 
 	// Verify: source remaining = 300, target remaining = 200
-	const sourceRow = page.getByRole('row').filter({ hasText: sourceCategory });
-	const targetRow = page.getByRole('row').filter({ hasText: targetCategory });
-	await expect(sourceRow.getByRole('cell').nth(3)).toContainText(
+	await expect(pages.budget.remainingTrigger(sourceCategory)).toContainText(
 		formatCurrency({ centValue: 300, currency: 'EUR' })
 	);
-	await expect(targetRow.getByRole('cell').nth(3)).toContainText(
+	await expect(pages.budget.remainingTrigger(targetCategory)).toContainText(
 		formatCurrency({ centValue: 200, currency: 'EUR' })
 	);
 });
@@ -58,11 +52,9 @@ test('Transfer Assignment — Move to unassigned', async ({ page, pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const category = faker.commerce.department();
 	await pages.budget.createCategory(category);
@@ -74,8 +66,7 @@ test('Transfer Assignment — Move to unassigned', async ({ page, pages }) => {
 	await pages.budget.transferToUnassigned(category, '3');
 
 	// Verify remaining = 200
-	const categoryRow = page.getByRole('row').filter({ hasText: category });
-	await expect(categoryRow.getByRole('cell').nth(3)).toContainText(
+	await expect(pages.budget.remainingTrigger(category)).toContainText(
 		formatCurrency({ centValue: 200, currency: 'EUR' })
 	);
 
@@ -83,24 +74,18 @@ test('Transfer Assignment — Move to unassigned', async ({ page, pages }) => {
 	await expect(page.getByText(formatCurrency({ centValue: -200, currency: 'EUR' }))).toBeVisible();
 });
 
-test('Transfer Assignment — Trigger disabled at zero remaining', async ({ page, pages }) => {
+test('Transfer Assignment — Trigger disabled at zero remaining', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const category = faker.commerce.department();
 	await pages.budget.createCategory(category);
 
 	// No assignment → remaining = 0 → trigger disabled
-	const categoryRow = page.getByRole('row').filter({ hasText: category });
-	const remainingCell = categoryRow.getByRole('cell').nth(3);
-	const trigger = remainingCell.getByRole('button');
-
-	await expect(trigger).toHaveAttribute('aria-disabled', 'true');
+	await expect(pages.budget.remainingTrigger(category)).toHaveAttribute('aria-disabled', 'true');
 });

--- a/tests/playwright/budget.spec.ts
+++ b/tests/playwright/budget.spec.ts
@@ -20,7 +20,7 @@ test('Assign Budget to Category', async ({ pages }) => {
 	await pages.budget.assignAmount(categoryName, '500');
 });
 
-test('Transfer Assignment — Move between categories', async ({ pages }) => {
+test('Transfer Assignment — Move between categories', async ({ page, pages }) => {
 	await pages.auth.createUserAndLogin();
 
 	const budgetName = faker.commerce.department();
@@ -43,8 +43,8 @@ test('Transfer Assignment — Move between categories', async ({ pages }) => {
 	await pages.budget.transferToCategory(sourceCategory, '2', targetCategory);
 
 	// Verify: source remaining = 300, target remaining = 200
-	const sourceRow = pages.page.getByRole('row').filter({ hasText: sourceCategory });
-	const targetRow = pages.page.getByRole('row').filter({ hasText: targetCategory });
+	const sourceRow = page.getByRole('row').filter({ hasText: sourceCategory });
+	const targetRow = page.getByRole('row').filter({ hasText: targetCategory });
 	await expect(sourceRow.getByRole('cell').nth(3)).toContainText(
 		formatCurrency({ centValue: 300, currency: 'EUR' })
 	);
@@ -53,7 +53,7 @@ test('Transfer Assignment — Move between categories', async ({ pages }) => {
 	);
 });
 
-test('Transfer Assignment — Move to unassigned', async ({ pages }) => {
+test('Transfer Assignment — Move to unassigned', async ({ page, pages }) => {
 	await pages.auth.createUserAndLogin();
 
 	const budgetName = faker.commerce.department();
@@ -74,18 +74,16 @@ test('Transfer Assignment — Move to unassigned', async ({ pages }) => {
 	await pages.budget.transferToUnassigned(category, '3');
 
 	// Verify remaining = 200
-	const categoryRow = pages.page.getByRole('row').filter({ hasText: category });
+	const categoryRow = page.getByRole('row').filter({ hasText: category });
 	await expect(categoryRow.getByRole('cell').nth(3)).toContainText(
 		formatCurrency({ centValue: 200, currency: 'EUR' })
 	);
 
 	// Unassigned: -200 (only 200 assigned total, 0 income)
-	await expect(
-		pages.page.getByText(formatCurrency({ centValue: -200, currency: 'EUR' }))
-	).toBeVisible();
+	await expect(page.getByText(formatCurrency({ centValue: -200, currency: 'EUR' }))).toBeVisible();
 });
 
-test('Transfer Assignment — Trigger disabled at zero remaining', async ({ pages }) => {
+test('Transfer Assignment — Trigger disabled at zero remaining', async ({ page, pages }) => {
 	await pages.auth.createUserAndLogin();
 
 	const budgetName = faker.commerce.department();
@@ -100,7 +98,7 @@ test('Transfer Assignment — Trigger disabled at zero remaining', async ({ page
 	await pages.budget.createCategory(category);
 
 	// No assignment → remaining = 0 → trigger disabled
-	const categoryRow = pages.page.getByRole('row').filter({ hasText: category });
+	const categoryRow = page.getByRole('row').filter({ hasText: category });
 	const remainingCell = categoryRow.getByRole('cell').nth(3);
 	const trigger = remainingCell.getByRole('button');
 

--- a/tests/playwright/budget.spec.ts
+++ b/tests/playwright/budget.spec.ts
@@ -1,6 +1,7 @@
+import { formatCurrency } from '$lib/utils/format-currency';
 import { faker } from '@faker-js/faker';
 
-import { test } from './fixture';
+import { expect, test } from './fixture';
 
 test('Assign Budget to Category', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -17,4 +18,91 @@ test('Assign Budget to Category', async ({ pages }) => {
 	await pages.budget.createCategory(categoryName);
 
 	await pages.budget.assignAmount(categoryName, '500');
+});
+
+test('Transfer Assignment — Move between categories', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+	await pages.budget.goto(budgetName);
+
+	const accountName = faker.finance.accountName();
+	await pages.budget.createAccount(accountName);
+	await pages.budget.goto(budgetName);
+
+	const sourceCategory = faker.commerce.department();
+	await pages.budget.createCategory(sourceCategory);
+	const targetCategory = faker.commerce.department();
+	await pages.budget.createCategory(targetCategory);
+
+	// Assign 500 (cents) to source
+	await pages.budget.assignAmount(sourceCategory, '5');
+
+	// Move 200 from source to target
+	await pages.budget.transferToCategory(sourceCategory, '2', targetCategory);
+
+	// Verify: source remaining = 300, target remaining = 200
+	const sourceRow = pages.page.getByRole('row').filter({ hasText: sourceCategory });
+	const targetRow = pages.page.getByRole('row').filter({ hasText: targetCategory });
+	await expect(sourceRow.getByRole('cell').nth(3)).toContainText(
+		formatCurrency({ centValue: 300, currency: 'EUR' })
+	);
+	await expect(targetRow.getByRole('cell').nth(3)).toContainText(
+		formatCurrency({ centValue: 200, currency: 'EUR' })
+	);
+});
+
+test('Transfer Assignment — Move to unassigned', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+	await pages.budget.goto(budgetName);
+
+	const accountName = faker.finance.accountName();
+	await pages.budget.createAccount(accountName);
+	await pages.budget.goto(budgetName);
+
+	const category = faker.commerce.department();
+	await pages.budget.createCategory(category);
+
+	// Assign 500
+	await pages.budget.assignAmount(category, '5');
+
+	// Move 300 to unassigned
+	await pages.budget.transferToUnassigned(category, '3');
+
+	// Verify remaining = 200
+	const categoryRow = pages.page.getByRole('row').filter({ hasText: category });
+	await expect(categoryRow.getByRole('cell').nth(3)).toContainText(
+		formatCurrency({ centValue: 200, currency: 'EUR' })
+	);
+
+	// Unassigned: -200 (only 200 assigned total, 0 income)
+	await expect(
+		pages.page.getByText(formatCurrency({ centValue: -200, currency: 'EUR' }))
+	).toBeVisible();
+});
+
+test('Transfer Assignment — Trigger disabled at zero remaining', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+	await pages.budget.goto(budgetName);
+
+	const accountName = faker.finance.accountName();
+	await pages.budget.createAccount(accountName);
+	await pages.budget.goto(budgetName);
+
+	const category = faker.commerce.department();
+	await pages.budget.createCategory(category);
+
+	// No assignment → remaining = 0 → trigger disabled
+	const categoryRow = pages.page.getByRole('row').filter({ hasText: category });
+	const remainingCell = categoryRow.getByRole('cell').nth(3);
+	const trigger = remainingCell.getByRole('button');
+
+	await expect(trigger).toHaveAttribute('aria-disabled', 'true');
 });

--- a/tests/playwright/category.spec.ts
+++ b/tests/playwright/category.spec.ts
@@ -7,12 +7,9 @@ test('Create Category', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);
@@ -23,12 +20,9 @@ test('Edit Category Name', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);

--- a/tests/playwright/fixture.ts
+++ b/tests/playwright/fixture.ts
@@ -6,6 +6,17 @@ export * from '@playwright/test';
 
 export const test = base.extend<{ pages: Pages }>({
 	pages: async ({ page }, use) => {
+		// Disable vaul-svelte drawer animations in tests.
+		// This eliminates timing dependencies from the mobile navigation
+		// drawer (slide-in, fade-out) which don't respect prefers-reduced-motion.
+		// Targeted CSS avoids breaking floating-ui portal transitions
+		// used by Select/Combobox components.
+		await page.addInitScript(() => {
+			const style = document.createElement('style');
+			style.textContent = `[data-vaul-drawer],[data-vaul-drawer] *,[data-vaul-overlay],[data-vaul-overlay] *{animation-duration:0s!important;animation-delay:0s!important;transition-duration:0s!important;transition-delay:0s!important}`;
+			document.head.appendChild(style);
+		});
+
 		await use(new Pages(page));
 	}
 });

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -203,7 +203,9 @@ export class AccountPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for both the drawer close animation and SvelteKit navigation to settle.
+		// Wait for the drawer close animation to finish AND the overlay to be removed
+		// from the DOM — otherwise the overlay intercepts subsequent clicks.
+		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeAttached();
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -206,12 +206,14 @@ export class AccountPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
-		// On tablet, clicking a link inside the drawer closes the drawer
-		// AND navigates. The drawer's close animation (fade-out) and the
-		// SvelteKit navigation both need time to settle. A fixed pause is
-		// crude but works reliably across CI browser versions — the overlay
-		// otherwise intercepts pointer events for subsequent clicks.
-		await this.page.waitForTimeout(1000);
+		if (!this.isDesktop) {
+			// On tablet, clicking a link inside the drawer closes the drawer
+			// AND navigates. The drawer's close animation (fade-out) and the
+			// SvelteKit navigation both need time to settle. A fixed pause is
+			// crude but works reliably across CI browser versions — the overlay
+			// otherwise intercepts pointer events for subsequent clicks.
+			await this.page.waitForTimeout(1000);
+		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -57,7 +57,9 @@ export class AccountPage extends BasePage {
 			const checkbox = createRow.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (validated !== isChecked) {
-				await checkbox.click();
+				// The checkbox uses opacity-0 (not sr-only), so Playwright's
+				// visibility check fails. Use force to bypass actionability.
+				await checkbox.click({ force: true });
 			}
 		}
 
@@ -164,7 +166,9 @@ export class AccountPage extends BasePage {
 			const checkbox = editForm.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (params.validated !== isChecked) {
-				await checkbox.click();
+				// The checkbox uses opacity-0 (not sr-only), so Playwright's
+				// visibility check fails. Use force to bypass actionability.
+				await checkbox.click({ force: true });
 			}
 		}
 
@@ -203,9 +207,7 @@ export class AccountPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for the drawer close animation to finish AND the overlay to be removed
-		// from the DOM — otherwise the overlay intercepts subsequent clicks.
-		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeAttached();
+		// Wait for SvelteKit navigation to settle before interacting with the new page.
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -212,6 +212,12 @@ export class AccountPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
+		if (!this.isDesktop) {
+			// On tablet, clicking a link inside the drawer closes the drawer
+			// and navigates. The overlay can linger in the DOM briefly after
+			// close, intercepting pointer events for subsequent clicks.
+			await expect(this.page.locator('[data-vaul-overlay]')).not.toBeVisible();
+		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -207,7 +207,9 @@ export class AccountPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for SvelteKit navigation to settle before interacting with the new page.
+		// Wait for the drawer overlay to finish its fade-out animation — otherwise
+		// it intercepts pointer events for subsequent clicks (e.g. "Create Category").
+		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeVisible();
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -57,8 +57,11 @@ export class AccountPage extends BasePage {
 			const checkbox = createRow.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (validated !== isChecked) {
-				// The checkbox uses opacity-0 (not sr-only), so Playwright's
-				// visibility check fails. Use force to bypass actionability.
+				// The validation-checkbox component wraps the input in a <Label>
+				// with padding. Playwright resolves the <input> (sr-only is in
+				// the accessibility tree) but the parent <Label> intercepts clicks.
+				// force:true clicks the input directly — the label still associates
+				// and toggles the checkbox.
 				await checkbox.click({ force: true });
 			}
 		}
@@ -166,8 +169,11 @@ export class AccountPage extends BasePage {
 			const checkbox = editForm.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (params.validated !== isChecked) {
-				// The checkbox uses opacity-0 (not sr-only), so Playwright's
-				// visibility check fails. Use force to bypass actionability.
+				// The validation-checkbox component wraps the input in a <Label>
+				// with padding. Playwright resolves the <input> (sr-only is in
+				// the accessibility tree) but the parent <Label> intercepts clicks.
+				// force:true clicks the input directly — the label still associates
+				// and toggles the checkbox.
 				await checkbox.click({ force: true });
 			}
 		}
@@ -206,14 +212,6 @@ export class AccountPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
-		if (!this.isDesktop) {
-			// On tablet, clicking a link inside the drawer closes the drawer
-			// AND navigates. The drawer's close animation (fade-out) and the
-			// SvelteKit navigation both need time to settle. A fixed pause is
-			// crude but works reliably across CI browser versions — the overlay
-			// otherwise intercepts pointer events for subsequent clicks.
-			await this.page.waitForTimeout(1000);
-		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -1,5 +1,5 @@
 import { formatCurrency } from '$lib/utils/format-currency';
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
@@ -20,10 +20,6 @@ type EditTransactionParams = {
 };
 
 export class AccountPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async createTransaction(params: CreateTransactionParams | string = {}) {
 		const { amount, category, date, notes, validated } =
 			typeof params === 'string' ? { amount: params } : params;
@@ -57,12 +53,7 @@ export class AccountPage extends BasePage {
 			const checkbox = createRow.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (validated !== isChecked) {
-				// The validation-checkbox component wraps the input in a <Label>
-				// with padding. Playwright resolves the <input> (sr-only is in
-				// the accessibility tree) but the parent <Label> intercepts clicks.
-				// force:true clicks the input directly — the label still associates
-				// and toggles the checkbox.
-				await checkbox.click({ force: true });
+				await checkbox.click();
 			}
 		}
 
@@ -115,9 +106,8 @@ export class AccountPage extends BasePage {
 			.filter({ has: this.page.getByRole('button', { name: 'Save' }) });
 		await editForm.getByRole('button', { name: 'Delete' }).click();
 
-		// Delete submits a hidden batch-delete form — the visible edit form stays open.
-		// Wait for the delete to complete, then verify one fewer transaction row.
-		await this.page.waitForLoadState('networkidle');
+		// Delete submits a hidden batch-delete form — the visible edit form stays
+		// open. The assertion retries until one fewer transaction row remains.
 		await expect(this.page.getByRole('cell', { name: 'Edit category' })).toHaveCount(cellCount - 1);
 	}
 
@@ -169,12 +159,7 @@ export class AccountPage extends BasePage {
 			const checkbox = editForm.getByRole('checkbox', { name: 'Validated' });
 			const isChecked = await checkbox.isChecked();
 			if (params.validated !== isChecked) {
-				// The validation-checkbox component wraps the input in a <Label>
-				// with padding. Playwright resolves the <input> (sr-only is in
-				// the accessibility tree) but the parent <Label> intercepts clicks.
-				// force:true clicks the input directly — the label still associates
-				// and toggles the checkbox.
-				await checkbox.click({ force: true });
+				await checkbox.click();
 			}
 		}
 
@@ -207,18 +192,11 @@ export class AccountPage extends BasePage {
 	}
 
 	async goto(accountName: string) {
-		if (!this.isDesktop) {
-			await this.openMobileNavigation();
+		const url = this.ctx.accounts.get(accountName);
+		if (!url) {
+			throw new Error(`Account "${accountName}" must be created before goto`);
 		}
-
-		await this.page.getByRole('link', { exact: true, name: accountName }).click();
-		if (!this.isDesktop) {
-			// On tablet, clicking a link inside the drawer closes the drawer
-			// and navigates. The overlay can linger in the DOM briefly after
-			// close, intercepting pointer events for subsequent clicks.
-			await expect(this.page.locator('[data-vaul-overlay]')).not.toBeVisible();
-		}
-		await this.page.waitForLoadState('networkidle');
+		await this.page.goto(url);
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}
 
@@ -233,10 +211,8 @@ export class AccountPage extends BasePage {
 
 		await row.getByRole('button', { name: 'Toggle validated status' }).click();
 
-		// Wait for the form submission (the button wraps a form submit)
-		await this.page.waitForLoadState('networkidle');
-
-		// Assert the validated icon toggled
+		// The button wraps a form submit; the icon assertion below retries until
+		// the toggle is reflected.
 		if (hadCheckIcon) {
 			await expect(row.locator('svg.text-success')).toHaveCount(0);
 		} else {

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -206,10 +206,12 @@ export class AccountPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: accountName }).click();
-		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for the drawer overlay to finish its fade-out animation — otherwise
-		// it intercepts pointer events for subsequent clicks (e.g. "Create Category").
-		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeVisible();
+		// On tablet, clicking a link inside the drawer closes the drawer
+		// AND navigates. The drawer's close animation (fade-out) and the
+		// SvelteKit navigation both need time to settle. A fixed pause is
+		// crude but works reliably across CI browser versions — the overlay
+		// otherwise intercepts pointer events for subsequent clicks.
+		await this.page.waitForTimeout(1000);
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}

--- a/tests/playwright/pom/admin.ts
+++ b/tests/playwright/pom/admin.ts
@@ -1,12 +1,6 @@
-import type { Page } from '@playwright/test';
-
 import { BasePage } from './base-page';
 
 export class AdminPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async resetDatabase() {
 		await this.page.goto('/admin');
 		this.page.on('dialog', (dialog) => dialog.accept());

--- a/tests/playwright/pom/auth.ts
+++ b/tests/playwright/pom/auth.ts
@@ -1,14 +1,10 @@
 import { faker } from '@faker-js/faker';
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
 export class AuthPage extends BasePage {
 	readonly admin = ['Admin', '1234admin!$5678'] as const;
-
-	constructor(page: Page) {
-		super(page);
-	}
 
 	async createAdmin(username = this.admin[0], password = this.admin[1]) {
 		await this.page.goto('/login/first');

--- a/tests/playwright/pom/base-page.ts
+++ b/tests/playwright/pom/base-page.ts
@@ -21,16 +21,22 @@ export class BasePage {
 
 	async openMobileNavigation() {
 		const signOutButton = this.page.getByRole('button', { name: 'Sign out' });
-		if (await signOutButton.isVisible()) return; // Already open
-		await this.page.getByRole('button', { name: 'Toggle Navigation' }).click();
-		await expect(signOutButton).toBeVisible();
+		if (!(await signOutButton.isVisible())) {
+			await this.page.getByRole('button', { name: 'Toggle Navigation' }).click();
+			await expect(signOutButton).toBeVisible();
+		}
 		// vaul-svelte animates the drawer with CSS keyframes that don't respect
-		// prefers-reduced-motion. Wait for the slide-in animation to finish so
-		// that elements inside are stable before we try to click them.
+		// prefers-reduced-motion. Always wait for ALL animations to finish — even
+		// when the drawer was already open (the previous action may have just
+		// opened it and the slide-in animation is still running).
+		// The drawer content is teleported to a portal *outside* the drawer root,
+		// so we must check both the root and the content for running animations.
 		await this.page.waitForFunction(() => {
-			const drawer = document.querySelector('[data-vaul-drawer]');
+			const noRunningAnimations = (el: Element | null) =>
+				!el || el.getAnimations({ subtree: true }).every((a) => a.playState !== 'running');
 			return (
-				!drawer || drawer.getAnimations({ subtree: true }).every((a) => a.playState !== 'running')
+				noRunningAnimations(document.querySelector('[data-vaul-drawer]')) &&
+				noRunningAnimations(document.querySelector('[data-slot="drawer-content"]'))
 			);
 		});
 	}

--- a/tests/playwright/pom/base-page.ts
+++ b/tests/playwright/pom/base-page.ts
@@ -25,20 +25,12 @@ export class BasePage {
 			await this.page.getByRole('button', { name: 'Toggle Navigation' }).click();
 			await expect(signOutButton).toBeVisible();
 		}
-		// vaul-svelte animates the drawer with CSS keyframes that don't respect
-		// prefers-reduced-motion. Always wait for ALL animations to finish — even
-		// when the drawer was already open (the previous action may have just
-		// opened it and the slide-in animation is still running).
-		// The drawer content is teleported to a portal *outside* the drawer root,
-		// so we must check both the root and the content for running animations.
-		await this.page.waitForFunction(() => {
-			const noRunningAnimations = (el: Element | null) =>
-				!el || el.getAnimations({ subtree: true }).every((a) => a.playState !== 'running');
-			return (
-				noRunningAnimations(document.querySelector('[data-vaul-drawer]')) &&
-				noRunningAnimations(document.querySelector('[data-slot="drawer-content"]'))
-			);
-		});
+		// vaul-svelte animates the drawer with CSS keyframes (0.5s)
+		// that don't respect prefers-reduced-motion. Always pause for
+		// the slide-in to finish — even when the drawer was already open.
+		// A fixed timeout is crude but more reliable than getAnimations()
+		// which behaves inconsistently across browser versions in CI.
+		await this.page.waitForTimeout(600);
 	}
 
 	#getViewportWidth() {

--- a/tests/playwright/pom/base-page.ts
+++ b/tests/playwright/pom/base-page.ts
@@ -1,6 +1,28 @@
 import { expect, type Page } from '@playwright/test';
 
+/**
+ * State shared across page objects within a single test.
+ *
+ * Navigation in the app happens through the mobile drawer (tablet) or the
+ * sidebar (desktop). Driving navigation by clicking those links is flaky on
+ * slow CI runners: the drawer animates open and the nav lists load
+ * asynchronously, so a link's position keeps shifting and never satisfies
+ * Playwright's "stable" actionability check.
+ *
+ * Instead we capture the canonical URL of each entity when it is created and
+ * navigate to it directly with `page.goto`. This keeps the "arrange" phase of
+ * every test deterministic and fast. The drawer itself is still exercised by
+ * the login/signout flow.
+ */
+export type TestContext = {
+	/** account name -> account page URL */
+	accounts: Map<string, string>;
+	/** the current budget's page URL (captured after createBudget) */
+	budgetUrl?: string;
+};
+
 export class BasePage {
+	readonly ctx: TestContext;
 	readonly page: Page;
 
 	get isDesktop() {
@@ -15,8 +37,9 @@ export class BasePage {
 		return !this.isDesktop && !this.isMobile;
 	}
 
-	constructor(page: Page) {
+	constructor(page: Page, ctx: TestContext) {
 		this.page = page;
+		this.ctx = ctx;
 	}
 
 	async openMobileNavigation() {

--- a/tests/playwright/pom/base-page.ts
+++ b/tests/playwright/pom/base-page.ts
@@ -25,12 +25,6 @@ export class BasePage {
 			await this.page.getByRole('button', { name: 'Toggle Navigation' }).click();
 			await expect(signOutButton).toBeVisible();
 		}
-		// vaul-svelte animates the drawer with CSS keyframes (0.5s)
-		// that don't respect prefers-reduced-motion. Always pause for
-		// the slide-in to finish — even when the drawer was already open.
-		// A fixed timeout is crude but more reliable than getAnimations()
-		// which behaves inconsistently across browser versions in CI.
-		await this.page.waitForTimeout(600);
 	}
 
 	#getViewportWidth() {

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -110,9 +110,10 @@ export class BudgetPage extends BasePage {
 		await this.page.getByRole('button', { name: 'Select category' }).click();
 		await this.page.getByRole('option', { name: 'Unassigned' }).click();
 
-		// The combobox stays expanded after selecting Unassigned,
-		// and its balance badge intercepts the OK button.
-		// Click the amount input to re-focus and close the dropdown.
+		// NOTE: In Playwright (headless), the Combobox fails to close after selecting
+		// "Unassigned" — the balance badge then overlays the OK button. This does NOT
+		// reproduce in real browsers (Chrome, Safari, Firefox). Workaround:
+		// click the amount input to defocus the Combobox and dismiss the dropdown.
 		await this.page.getByRole('textbox', { name: 'Amount' }).click();
 		await this.page.getByRole('button', { name: 'OK' }).click();
 

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -78,9 +78,7 @@ export class BudgetPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for the drawer close animation to finish AND the overlay to be removed
-		// from the DOM — otherwise the overlay intercepts subsequent clicks.
-		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeAttached();
+		// Wait for SvelteKit navigation to settle before interacting with the new page.
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -78,7 +78,9 @@ export class BudgetPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for both the drawer close animation and SvelteKit navigation to settle.
+		// Wait for the drawer close animation to finish AND the overlay to be removed
+		// from the DOM — otherwise the overlay intercepts subsequent clicks.
+		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeAttached();
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -69,6 +69,12 @@ export class BudgetPage extends BasePage {
 		await input.press('Enter');
 
 		await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
+		// The budget table reloads from a separate data fetch than the sidebar.
+		// Wait for the new category's Budget button to appear in the table row
+		// — this is what assignAmount needs to interact with next.
+		await expect(
+			this.page.getByRole('row').filter({ hasText: name }).getByRole('button', { name: 'Budget' })
+		).toBeVisible();
 	}
 
 	async goto(budgetName: string) {
@@ -77,14 +83,6 @@ export class BudgetPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
-		if (!this.isDesktop) {
-			// On tablet, clicking a link inside the drawer closes the drawer
-			// AND navigates. The drawer's close animation (fade-out) and the
-			// SvelteKit navigation both need time to settle. A fixed pause is
-			// crude but works reliably across CI browser versions — the overlay
-			// otherwise intercepts pointer events for subsequent clicks.
-			await this.page.waitForTimeout(1000);
-		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}
@@ -116,10 +114,11 @@ export class BudgetPage extends BasePage {
 		await this.page.getByRole('button', { name: 'Select category' }).click();
 		await this.page.getByRole('option', { name: 'Unassigned' }).click();
 
-		// NOTE: In Playwright (headless), the Combobox fails to close after selecting
-		// "Unassigned" — the balance badge then overlays the OK button. This does NOT
-		// reproduce in real browsers (Chrome, Safari, Firefox). Workaround:
-		// click the amount input to defocus the Combobox and dismiss the dropdown.
+		// Workaround: after selecting "Unassigned" in the Combobox, headless
+		// Chromium does not close the dropdown consistently. The balance badge
+		// (which appears in the popover after assigning to the source category)
+		// then overlays the OK button. Clicking the amount input steals focus,
+		// which dismisses the Combobox dropdown and reflows the layout.
 		await this.page.getByRole('textbox', { name: 'Amount' }).click();
 		await this.page.getByRole('button', { name: 'OK' }).click();
 

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -82,4 +82,40 @@ export class BudgetPage extends BasePage {
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}
+
+	async transferToCategory(sourceCategoryName: string, amount: string, targetCategoryName: string) {
+		const categoryRow = this.page.getByRole('row').filter({ hasText: sourceCategoryName });
+		const remainingCell = categoryRow.getByRole('cell').nth(3);
+		await remainingCell.getByRole('button').click();
+
+		await expect(this.page.getByText('Move')).toBeVisible();
+
+		await this.page.getByRole('textbox', { name: 'Amount' }).fill(amount);
+		await this.page.getByRole('button', { name: 'Select category' }).click();
+		await this.page.getByRole('option', { name: targetCategoryName }).click();
+
+		await this.page.getByRole('button', { name: 'OK' }).click();
+
+		await expect(this.page.getByText('Move')).not.toBeVisible();
+	}
+
+	async transferToUnassigned(categoryName: string, amount: string) {
+		const categoryRow = this.page.getByRole('row').filter({ hasText: categoryName });
+		const remainingCell = categoryRow.getByRole('cell').nth(3);
+		await remainingCell.getByRole('button').click();
+
+		await expect(this.page.getByText('Move')).toBeVisible();
+
+		await this.page.getByRole('textbox', { name: 'Amount' }).fill(amount);
+		await this.page.getByRole('button', { name: 'Select category' }).click();
+		await this.page.getByRole('option', { name: 'Unassigned' }).click();
+
+		// The combobox stays expanded after selecting Unassigned,
+		// and its balance badge intercepts the OK button.
+		// Click the amount input to re-focus and close the dropdown.
+		await this.page.getByRole('textbox', { name: 'Amount' }).click();
+		await this.page.getByRole('button', { name: 'OK' }).click();
+
+		await expect(this.page.getByText('Move')).not.toBeVisible();
+	}
 }

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -46,6 +46,10 @@ export class BudgetPage extends BasePage {
 			await this.openMobileNavigation();
 			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
 		}
+		// SvelteKit invalidateAll() after form submit triggers separate
+		// data fetches for sidebar and page content. networkidle ensures
+		// both settle before the next navigation or interaction.
+		await this.page.waitForLoadState('networkidle');
 	}
 
 	async createBudget(name: string) {
@@ -64,6 +68,10 @@ export class BudgetPage extends BasePage {
 			await this.openMobileNavigation();
 			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
 		}
+		// Creating a budget navigates to the budget page. networkidle
+		// ensures the SvelteKit navigation and any lazy data fetches
+		// have completed before the next step.
+		await this.page.waitForLoadState('networkidle');
 	}
 
 	async createCategory(name: string) {
@@ -73,13 +81,12 @@ export class BudgetPage extends BasePage {
 		await input.fill(name);
 		await input.press('Enter');
 
+		// The sidebar and the budget table reload from separate data
+		// fetches after SvelteKit invalidateAll(). networkidle ensures
+		// both have settled before the next createCategory/assignAmount
+		// interacts with the newly rendered rows.
 		await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
-		// The budget table reloads from a separate data fetch than the sidebar.
-		// Wait for the new category's Budget button to appear in the table row
-		// — this is what assignAmount needs to interact with next.
-		await expect(
-			this.page.getByRole('row').filter({ hasText: name }).getByRole('button', { name: 'Budget' })
-		).toBeVisible();
+		await this.page.waitForLoadState('networkidle');
 	}
 
 	async goto(budgetName: string) {

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -69,8 +69,13 @@ export class BudgetPage extends BasePage {
 		await input.fill(name);
 		await input.press('Enter');
 
-		// The new category renders as a row in the budget table.
-		await expect(this.categoryRow(name).getByRole('link', { exact: true, name })).toBeVisible();
+		const row = this.categoryRow(name);
+		// The link is rendered directly in the row (no async wait).
+		await expect(row.getByRole('link', { exact: true, name })).toBeVisible();
+		// CategoryAssignmentForm has its own `await getBudget()` — wait for the
+		// Budget button to confirm it has mounted before returning. All rows share
+		// the same getBudget cache, so this also unblocks other rows' buttons.
+		await expect(row.getByRole('button', { name: 'Budget' })).toBeVisible();
 	}
 
 	async goto(budgetName: string) {

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -78,7 +78,9 @@ export class BudgetPage extends BasePage {
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
 		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for SvelteKit navigation to settle before interacting with the new page.
+		// Wait for the drawer overlay to finish its fade-out animation — otherwise
+		// it intercepts pointer events for subsequent clicks (e.g. "Create Category").
+		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeVisible();
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -9,7 +9,12 @@ export class BudgetPage extends BasePage {
 
 	async assignAmount(categoryName: string, amount: string) {
 		const categoryRow = this.page.getByRole('row').filter({ hasText: categoryName });
-		await categoryRow.getByRole('button', { name: 'Budget' }).click();
+		const budgetButton = categoryRow.getByRole('button', { name: 'Budget' });
+		// Svelte can re-render the table after any category change (e.g. a
+		// second createCategory). toBeVisible retries if the element is
+		// detached during the check — more robust than a bare click().
+		await expect(budgetButton).toBeVisible();
+		await budgetButton.click();
 		await this.page.getByRole('textbox', { name: 'Budget' }).fill(amount);
 		await this.page.getByRole('textbox', { name: 'Budget' }).press('Enter');
 
@@ -83,6 +88,12 @@ export class BudgetPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
+		if (!this.isDesktop) {
+			// On tablet, clicking a link inside the drawer closes the drawer
+			// and navigates. The overlay can linger in the DOM briefly after
+			// close, intercepting pointer events for subsequent clicks.
+			await expect(this.page.locator('[data-vaul-overlay]')).not.toBeVisible();
+		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -1,55 +1,50 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
 export class BudgetPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async assignAmount(categoryName: string, amount: string) {
-		const categoryRow = this.page.getByRole('row').filter({ hasText: categoryName });
-		const budgetButton = categoryRow.getByRole('button', { name: 'Budget' });
-		// Svelte can re-render the table after any category change (e.g. a
-		// second createCategory). toBeVisible retries if the element is
-		// detached during the check — more robust than a bare click().
+		const budgetButton = this.categoryRow(categoryName).getByRole('button', { name: 'Budget' });
+		// The table can re-render after a category change (SvelteKit invalidateAll
+		// re-fetches the rows). A web-first assertion retries if the button is
+		// briefly detached, which a bare click() would not.
 		await expect(budgetButton).toBeVisible();
 		await budgetButton.click();
-		await this.page.getByRole('textbox', { name: 'Budget' }).fill(amount);
-		await this.page.getByRole('textbox', { name: 'Budget' }).press('Enter');
 
-		// Wait for form submission to complete and popover to close
-		await expect(this.page.getByRole('textbox', { name: 'Budget' })).not.toBeVisible();
-		await expect(categoryRow.getByRole('button', { name: 'Budget' })).toBeVisible();
+		const input = this.page.getByRole('textbox', { name: 'Budget' });
+		await input.fill(amount);
+		await input.press('Enter');
+
+		await expect(input).not.toBeVisible();
+		await expect(budgetButton).toBeVisible();
+	}
+
+	/** Locates a category's row in the budget table by its (unique) name. */
+	categoryRow(name: string): Locator {
+		return this.page.getByRole('row').filter({ hasText: name });
 	}
 
 	async createAccount(name: string, startingBalance = '0') {
 		await this.page.getByRole('button', { name: 'Show Accounts' }).click();
-		await expect(this.page.getByRole('menuitem', { name: 'Add Account' })).toBeVisible();
-
 		await this.page.getByRole('menuitem', { name: 'Add Account' }).click();
 		await expect(this.page.getByRole('heading', { name: 'Add New Account' })).toBeVisible();
 
-		await this.page.getByRole('textbox', { name: 'Account Name' }).clear();
 		await this.page.getByRole('textbox', { name: 'Account Name' }).fill(name);
-
-		await this.page.getByRole('textbox', { name: 'What is the current balance?' }).clear();
 		await this.page
 			.getByRole('textbox', { name: 'What is the current balance?' })
 			.fill(startingBalance);
 
 		await this.page.getByRole('button', { name: 'Create Account' }).click();
 
-		if (this.isDesktop) {
-			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
-		} else {
-			await this.openMobileNavigation();
-			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
+		// The server redirects to the new account page after creation.
+		// Wait for the heading to confirm the navigation completed, then capture the URL.
+		await expect(this.page.getByRole('heading', { name })).toBeVisible();
+		this.ctx.accounts.set(name, this.page.url());
+
+		// Return to the budget page so subsequent createCategory / assignAmount calls work.
+		if (this.ctx.budgetUrl) {
+			await this.page.goto(this.ctx.budgetUrl);
 		}
-		// SvelteKit invalidateAll() after form submit triggers separate
-		// data fetches for sidebar and page content. networkidle ensures
-		// both settle before the next navigation or interaction.
-		await this.page.waitForLoadState('networkidle');
 	}
 
 	async createBudget(name: string) {
@@ -59,19 +54,12 @@ export class BudgetPage extends BasePage {
 		).toBeVisible();
 
 		await this.page.getByRole('textbox', { name: 'Budget Name' }).fill(name);
-
 		await this.page.getByRole('button', { name: 'Create Budget' }).click();
 
-		if (this.isDesktop) {
-			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
-		} else {
-			await this.openMobileNavigation();
-			await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
-		}
-		// Creating a budget navigates to the budget page. networkidle
-		// ensures the SvelteKit navigation and any lazy data fetches
-		// have completed before the next step.
-		await this.page.waitForLoadState('networkidle');
+		// createBudget redirects to /{budgetId}, which redirects again to the
+		// current month page where the budget name is the heading.
+		await expect(this.page.getByRole('heading', { name })).toBeVisible();
+		this.ctx.budgetUrl = this.page.url();
 	}
 
 	async createCategory(name: string) {
@@ -81,65 +69,59 @@ export class BudgetPage extends BasePage {
 		await input.fill(name);
 		await input.press('Enter');
 
-		// The sidebar and the budget table reload from separate data
-		// fetches after SvelteKit invalidateAll(). networkidle ensures
-		// both have settled before the next createCategory/assignAmount
-		// interacts with the newly rendered rows.
-		await expect(this.page.getByRole('link', { exact: true, name })).toBeVisible();
-		await this.page.waitForLoadState('networkidle');
+		// The new category renders as a row in the budget table.
+		await expect(this.categoryRow(name).getByRole('link', { exact: true, name })).toBeVisible();
 	}
 
 	async goto(budgetName: string) {
-		if (!this.isDesktop) {
-			await this.openMobileNavigation();
+		if (!this.ctx.budgetUrl) {
+			throw new Error('createBudget must be called before goto');
 		}
-
-		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
-		if (!this.isDesktop) {
-			// On tablet, clicking a link inside the drawer closes the drawer
-			// and navigates. The overlay can linger in the DOM briefly after
-			// close, intercepting pointer events for subsequent clicks.
-			await expect(this.page.locator('[data-vaul-overlay]')).not.toBeVisible();
-		}
-		await this.page.waitForLoadState('networkidle');
+		await this.page.goto(this.ctx.budgetUrl);
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}
 
-	async transferToCategory(sourceCategoryName: string, amount: string, targetCategoryName: string) {
-		const categoryRow = this.page.getByRole('row').filter({ hasText: sourceCategoryName });
-		const remainingCell = categoryRow.getByRole('cell').nth(3);
-		await remainingCell.getByRole('button').click();
+	/** The transfer trigger for a category; its label shows the "remaining" amount. */
+	remainingTrigger(categoryName: string): Locator {
+		return this.categoryRow(categoryName).getByRole('button', {
+			name: `Adjust remaining for ${categoryName}`
+		});
+	}
 
-		await expect(this.page.getByText('Move')).toBeVisible();
+	async transferToCategory(sourceCategoryName: string, amount: string, targetCategoryName: string) {
+		await this.#openTransfer(sourceCategoryName);
 
 		await this.page.getByRole('textbox', { name: 'Amount' }).fill(amount);
-		await this.page.getByRole('button', { name: 'Select category' }).click();
-		await this.page.getByRole('option', { name: targetCategoryName }).click();
+		await this.#selectTransferTarget(targetCategoryName);
 
-		await this.page.getByRole('button', { name: 'OK' }).click();
-
-		await expect(this.page.getByText('Move')).not.toBeVisible();
+		await this.page.getByRole('button', { exact: true, name: 'OK' }).click();
+		await expect(this.page.getByRole('textbox', { name: 'Amount' })).not.toBeVisible();
 	}
 
 	async transferToUnassigned(categoryName: string, amount: string) {
-		const categoryRow = this.page.getByRole('row').filter({ hasText: categoryName });
-		const remainingCell = categoryRow.getByRole('cell').nth(3);
-		await remainingCell.getByRole('button').click();
-
-		await expect(this.page.getByText('Move')).toBeVisible();
-
+		// "Unassigned" is the default pre-selection in the combobox (targetCategoryId = '').
+		// Clicking it again doesn't change the value, so bits-ui keeps the dropdown open.
+		// Skip the combobox and submit directly — the server treats an empty target as Unassigned.
+		await this.#openTransfer(categoryName);
 		await this.page.getByRole('textbox', { name: 'Amount' }).fill(amount);
+		await this.page.getByRole('button', { exact: true, name: 'OK' }).click();
+		await expect(this.page.getByRole('textbox', { name: 'Amount' })).not.toBeVisible();
+	}
+
+	async #openTransfer(categoryName: string) {
+		const trigger = this.remainingTrigger(categoryName);
+		await expect(trigger).toBeVisible();
+		await trigger.click();
+		await expect(this.page.getByRole('textbox', { name: 'Amount' })).toBeVisible();
+	}
+
+	async #selectTransferTarget(targetCategoryName: string) {
 		await this.page.getByRole('button', { name: 'Select category' }).click();
-		await this.page.getByRole('option', { name: 'Unassigned' }).click();
-
-		// Workaround: after selecting "Unassigned" in the Combobox, headless
-		// Chromium does not close the dropdown consistently. The balance badge
-		// (which appears in the popover after assigning to the source category)
-		// then overlays the OK button. Clicking the amount input steals focus,
-		// which dismisses the Combobox dropdown and reflows the layout.
-		await this.page.getByRole('textbox', { name: 'Amount' }).click();
-		await this.page.getByRole('button', { name: 'OK' }).click();
-
-		await expect(this.page.getByText('Move')).not.toBeVisible();
+		// The option label also contains the balance badge, so match by substring.
+		const option = this.page.getByRole('option', { name: targetCategoryName });
+		await option.click();
+		// Selecting an item closes the combobox; wait for it so the OK button
+		// underneath is no longer covered by the option list.
+		await expect(option).not.toBeVisible();
 	}
 }

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -77,12 +77,14 @@ export class BudgetPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
-		// On tablet, clicking a link inside the drawer closes the drawer
-		// AND navigates. The drawer's close animation (fade-out) and the
-		// SvelteKit navigation both need time to settle. A fixed pause is
-		// crude but works reliably across CI browser versions — the overlay
-		// otherwise intercepts pointer events for subsequent clicks.
-		await this.page.waitForTimeout(1000);
+		if (!this.isDesktop) {
+			// On tablet, clicking a link inside the drawer closes the drawer
+			// AND navigates. The drawer's close animation (fade-out) and the
+			// SvelteKit navigation both need time to settle. A fixed pause is
+			// crude but works reliably across CI browser versions — the overlay
+			// otherwise intercepts pointer events for subsequent clicks.
+			await this.page.waitForTimeout(1000);
+		}
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -77,10 +77,12 @@ export class BudgetPage extends BasePage {
 		}
 
 		await this.page.getByRole('link', { exact: true, name: budgetName }).click();
-		// On tablet, clicking a link inside the drawer closes the drawer AND navigates.
-		// Wait for the drawer overlay to finish its fade-out animation — otherwise
-		// it intercepts pointer events for subsequent clicks (e.g. "Create Category").
-		await expect(this.page.locator('[data-slot="drawer-overlay"]')).not.toBeVisible();
+		// On tablet, clicking a link inside the drawer closes the drawer
+		// AND navigates. The drawer's close animation (fade-out) and the
+		// SvelteKit navigation both need time to settle. A fixed pause is
+		// crude but works reliably across CI browser versions — the overlay
+		// otherwise intercepts pointer events for subsequent clicks.
+		await this.page.waitForTimeout(1000);
 		await this.page.waitForLoadState('networkidle');
 		await expect(this.page.getByRole('heading', { name: budgetName })).toBeVisible();
 	}

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -35,18 +35,10 @@ export class CategoryPage extends BasePage {
 
 		await expect(dialog.getByText('Saved')).toBeVisible();
 
-		// The "Saved" toast uses a Svelte fly transition (200ms). Wait for
-		// all animations inside the dialog to finish so the close button is
-		// stable and not covered by a still-moving toast element.
-		await this.page.waitForFunction(
-			(dialogEl) => {
-				if (!dialogEl) return true;
-				return dialogEl
-					.getAnimations({ subtree: true })
-					.every((a: Animation) => a.playState !== 'running');
-			},
-			await dialog.elementHandle()
-		);
+		// The "Saved" toast uses a Svelte fly transition (200ms) that
+		// does not respect prefers-reduced-motion. Pause briefly so the
+		// toast settles before we try to click the close button.
+		await this.page.waitForTimeout(300);
 
 		await dialog.getByRole('button', { name: 'Close' }).first().click();
 		await expect(dialog).not.toBeVisible();

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -43,6 +43,8 @@ export class CategoryPage extends BasePage {
 		await dialog.getByRole('button', { name: 'Close' }).first().click();
 		await expect(dialog).not.toBeVisible();
 
-		await expect(this.page.getByRole('link', { exact: true, name: newName })).toBeVisible();
+		await expect(
+			this.page.getByRole('table').getByRole('link', { exact: true, name: newName })
+		).toBeVisible();
 	}
 }

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -35,11 +35,6 @@ export class CategoryPage extends BasePage {
 
 		await expect(dialog.getByText('Saved')).toBeVisible();
 
-		// The "Saved" toast uses a Svelte fly transition (200ms) that
-		// does not respect prefers-reduced-motion. Pause briefly so the
-		// toast settles before we try to click the close button.
-		await this.page.waitForTimeout(300);
-
 		await dialog.getByRole('button', { name: 'Close' }).first().click();
 		await expect(dialog).not.toBeVisible();
 

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -18,11 +18,11 @@ export class CategoryPage extends BasePage {
 	}
 
 	async editName(currentName: string, newName: string) {
-		// Budget nav links share names with categories; disambiguate by href.
-		await this.page
-			.getByRole('link', { exact: true, name: currentName })
-			.and(this.page.locator('[href*="/categories/"]'))
-			.click();
+		// Target the category link inside the budget table row, which is
+		// always visible in the page content (unlike the nav drawer link
+		// which shares the same accessible name on tablet).
+		const row = this.page.getByRole('row').filter({ hasText: currentName });
+		await row.getByRole('link', { exact: true, name: currentName }).click();
 
 		const dialog = this.page.getByRole('dialog');
 		await expect(dialog).toBeVisible();

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -1,12 +1,8 @@
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
 export class CategoryPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async create(name: string) {
 		await this.page.getByRole('button', { name: 'Create Category' }).click();
 

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -35,6 +35,19 @@ export class CategoryPage extends BasePage {
 
 		await expect(dialog.getByText('Saved')).toBeVisible();
 
+		// The "Saved" toast uses a Svelte fly transition (200ms). Wait for
+		// all animations inside the dialog to finish so the close button is
+		// stable and not covered by a still-moving toast element.
+		await this.page.waitForFunction(
+			(dialogEl) => {
+				if (!dialogEl) return true;
+				return dialogEl
+					.getAnimations({ subtree: true })
+					.every((a: Animation) => a.playState !== 'running');
+			},
+			await dialog.elementHandle()
+		);
+
 		await dialog.getByRole('button', { name: 'Close' }).first().click();
 		await expect(dialog).not.toBeVisible();
 

--- a/tests/playwright/pom/index.ts
+++ b/tests/playwright/pom/index.ts
@@ -13,7 +13,6 @@ export class Pages {
 	auth: AuthPage;
 	budget: BudgetPage;
 	category: CategoryPage;
-	page: Page;
 	settings: SettingsPage;
 
 	constructor(page: Page) {
@@ -22,7 +21,6 @@ export class Pages {
 		this.auth = new AuthPage(page);
 		this.budget = new BudgetPage(page);
 		this.category = new CategoryPage(page);
-		this.page = page;
 		this.settings = new SettingsPage(page);
 	}
 }

--- a/tests/playwright/pom/index.ts
+++ b/tests/playwright/pom/index.ts
@@ -13,6 +13,7 @@ export class Pages {
 	auth: AuthPage;
 	budget: BudgetPage;
 	category: CategoryPage;
+	page: Page;
 	settings: SettingsPage;
 
 	constructor(page: Page) {
@@ -21,6 +22,7 @@ export class Pages {
 		this.auth = new AuthPage(page);
 		this.budget = new BudgetPage(page);
 		this.category = new CategoryPage(page);
+		this.page = page;
 		this.settings = new SettingsPage(page);
 	}
 }

--- a/tests/playwright/pom/index.ts
+++ b/tests/playwright/pom/index.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import { AccountPage } from './account';
 import { AdminPage } from './admin';
 import { AuthPage } from './auth';
+import { type TestContext } from './base-page';
 import { BudgetPage } from './budget';
 import { CategoryPage } from './category';
 import { SettingsPage } from './settings';
@@ -16,11 +17,13 @@ export class Pages {
 	settings: SettingsPage;
 
 	constructor(page: Page) {
-		this.account = new AccountPage(page);
-		this.admin = new AdminPage(page);
-		this.auth = new AuthPage(page);
-		this.budget = new BudgetPage(page);
-		this.category = new CategoryPage(page);
-		this.settings = new SettingsPage(page);
+		const ctx: TestContext = { accounts: new Map() };
+
+		this.account = new AccountPage(page, ctx);
+		this.admin = new AdminPage(page, ctx);
+		this.auth = new AuthPage(page, ctx);
+		this.budget = new BudgetPage(page, ctx);
+		this.category = new CategoryPage(page, ctx);
+		this.settings = new SettingsPage(page, ctx);
 	}
 }

--- a/tests/playwright/pom/settings.ts
+++ b/tests/playwright/pom/settings.ts
@@ -1,12 +1,8 @@
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { BasePage } from './base-page';
 
 export class SettingsPage extends BasePage {
-	constructor(page: Page) {
-		super(page);
-	}
-
 	async changeDisplayName(name: string) {
 		const input = this.page.getByRole('textbox', { name: 'Display Name' });
 		await input.clear();

--- a/tests/playwright/pom/settings.ts
+++ b/tests/playwright/pom/settings.ts
@@ -17,6 +17,10 @@ export class SettingsPage extends BasePage {
 
 	async changeLanguage(locale: string) {
 		await this.page.getByRole('button', { name: 'Available Languages' }).click();
+		// The Select renders options in a floating portal. Wait for the
+		// listbox to appear before looking for the option — on chromium,
+		// floating-ui can take a frame or two to position the portal.
+		await expect(this.page.getByRole('listbox')).toBeVisible();
 		await this.page.getByRole('option', { name: locale }).click();
 		// Language change may navigate; the trigger's aria-label also changes languages.
 		// Match by regex that covers both English and German labels, check text is locale code.

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -7,11 +7,9 @@ test('Create Transaction', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);
@@ -31,11 +29,9 @@ test('Edit Transaction', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);
@@ -62,11 +58,9 @@ test('Delete Transaction', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);
@@ -86,11 +80,9 @@ test('Toggle Validated', async ({ pages }) => {
 
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
-	await pages.budget.goto(budgetName);
 
 	const accountName = faker.finance.accountName();
 	await pages.budget.createAccount(accountName);
-	await pages.budget.goto(budgetName);
 
 	const categoryName = faker.commerce.department();
 	await pages.budget.createCategory(categoryName);


### PR DESCRIPTION
## Summary

Budget Assignment Transfer — move assigned money between categories or return it to unassigned.

### Feature

- **Move**: transfer assigned amount from one category to another
- **Cover**: cover an overspent category by pulling from another category or unassigned
- **Return to unassigned**: move money back to the unassigned pool
- **UI**: click the remaining badge to open a popover — shows move form (positive remaining) or cover form (negative remaining)
- **Disabled trigger**: zero-remaining categories have no transfer action

### Implementation

- `transferAssignment` DB command with upsert pattern, atomic two-category transfer via transaction
- `TransferAssignmentSchema` (Valibot) — amount, sourceCategoryId, targetCategoryId
- `transferAssignment` remote function with `requested().refreshAll()` cache invalidation
- `TransferPopup` Svelte component with move/cover form split
- `SelectCategory` extended with `customItemRow` snippet for balance badges
- Renamed `NULL_SENTINEL` → `UNASSIGNED` throughout codebase

### Post-review fixes

- Schema: block `amount:0` via `v.notValue(0)`
- Command: validate categories belong to budget before transfer
- Deduplicate source-debit logic into `deductSource()` helper
- POM cleanup: remove `pages.page`, use Playwright page fixture
- Dead code: remove unused `cn()` import in category-budget-table

### Test Plan

- [x] `npm run lint` — 0 errors
- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npx vitest` — 164 tests (35 budget tests, 7 new for transfer + 3 validation)
- [x] 3 E2E tests (move between categories, move to unassigned, disabled trigger)