### PR TITLE
refactor: keep remote-function adapters mechanical; close the user-context bypass (#6)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,3 +11,7 @@ _Avoid_: date, period, month param
 **Archivable**:
 A category is archivable when its remaining balance (all-time assignments plus transactions) is zero and it has no pending (unvalidated) transactions. The rule is enforced by `category.archive` in user-context (see ADR-0001) and projected to the UI via `category.archivability`; nothing else may write `archivedAt`.
 _Avoid_: deletable, closable
+
+**Adapter**:
+A mechanical entry point (remote function or server load) that connects SvelteKit to user-context: it guards auth, validates input, translates form semantics, redirects, and refreshes caches — but produces no values and holds no business rules (see ADR-0002).
+_Avoid_: endpoint, controller, service layer

--- a/docs/adr/0002-remote-functions-are-mechanical-adapters.md
+++ b/docs/adr/0002-remote-functions-are-mechanical-adapters.md
@@ -1,0 +1,48 @@
+# ADR-0002: Remote functions are mechanical adapters over user-context
+
+Date: 2026-07-07
+Status: accepted
+
+## Context
+
+SvelteKit's remote functions force a layer between the client and
+`src/lib/server/db/user-context`: something must call `query`/`form`/`command`.
+That layer had started to accumulate behaviour of its own — a default account
+note produced in `createAccount`, the `targetBalance` 0→null rule hidden in a
+`||` in `editCategory` — while carrying zero tests. Meanwhile the root-redirect
+load (`src/routes/(app)/+page.server.ts`) calls `createUserCtx()` directly,
+bypassing the layer entirely.
+
+Three shapes were considered for the layer: a pure security boundary (guard +
+validation only), a mechanical adapter that additionally owns SvelteKit
+integration, or an orchestration layer allowed to hold logic of its own.
+
+## Decision
+
+Remote functions are **mechanical adapters**. They may guard authentication,
+validate input, translate form semantics to DB semantics (missing field vs.
+cleared field), issue redirects, and refresh query caches. They must not
+produce values or hold business rules. The litmus test: **if a remote function
+produces a value instead of passing one through or translating it, that value
+belongs in user-context.**
+
+Server load functions are peer adapters, not bypasses. They may call
+`createUserCtx()` directly, but then own their session check themselves. The
+seam that matters is user-context — access control (`accessGuard`,
+`hasAccess`) lives there and holds on every path.
+
+The adapter layer stays deliberately test-free: adapters are too thin to hide
+bugs, `remote-guard.ts` would require mocking SvelteKit internals to unit-test,
+and the Playwright suite exercises the real client → remote → user-context
+path. Tests target user-context.
+
+## Consequences
+
+- The only interface worth learning (and testing) is user-context.
+- Behaviour found in a remote function during review is a defect by
+  definition, not a judgement call.
+- Loads that use `createUserCtx()` directly must check `locals.session`
+  themselves — the guard helpers do not cover them.
+- Existing violations in `budget.remote.ts` (`findEligibleUser`, `inviteUser`)
+  and `transaction.remote.ts` (date/validated defaults, double list query) are
+  tracked as follow-up issues rather than fixed alongside this decision.

--- a/docs/remote-functions.md
+++ b/docs/remote-functions.md
@@ -3,7 +3,9 @@
 - Remote functions are the default mutation and query layer. Before adding `+server.ts`, check whether the feature belongs in `src/lib/remote-functions/*.remote.ts`.
 - Group functions by domain: `budget.remote.ts`, `account.remote.ts`, `transaction.remote.ts`, etc.
 - Use `guardedQuery`, `guardedForm`, and `guardedCommand` for authenticated work instead of rebuilding login handling.
-- Keep remote functions orchestration-focused: validate input, call the relevant auth or `user-context` logic, and shape the response.
-- Business rules stay out of remote functions. Authorization and domain logic belong in `src/lib/server/db/user-context` or `src/lib/server/db/auth`.
+- Remote functions are **mechanical adapters** (see ADR-0002). They may: guard auth, validate input, translate form semantics to DB semantics (missing field vs. cleared field), redirect, and refresh query caches. Nothing else.
+- Litmus test: **if a remote function produces a value instead of passing one through or translating it, that value belongs in `user-context`.** Defaults, normalization rules, and eligibility checks are business rules — put them in `src/lib/server/db/user-context` or `src/lib/server/db/auth`.
+- Server load functions are peer adapters, not bypasses: they may call `createUserCtx()` directly, but must check `locals.session` themselves.
+- The adapter layer is deliberately test-free. Tests target `user-context`; Playwright covers the wiring. If an adapter seems to need a unit test, it holds logic that should move down.
 - Reuse existing remote form ergonomics: `.enhance(...)`, `.for(...)`, `.fields.*`, `.issues()`, `.allIssues()`.
 - Keep user-facing text localized through Paraglide message helpers.

--- a/messages/de.json
+++ b/messages/de.json
@@ -133,7 +133,6 @@
 	"account_set_name_description": "Hier kannst du den Namen des Kontos ändern.",
 	"account_dropdown_label": "Zeige Konten",
 	"account_starting_balance_notes": "Start Kontostand",
-	"account_create_starting_balance": "Kontostand",
 	"account_settings_title": "Konto Einstellungen",
 	"account_settings_description": "Hier kannst du den Namen des Kontos ändern.",
 	"account_label_notes": "Notizen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -132,7 +132,6 @@
 	"account_set_name_title": "Change Account Name",
 	"account_set_name_description": "Set the account name here.",
 	"account_dropdown_label": "Show Accounts",
-	"account_create_starting_balance": "Account Balance",
 	"account_starting_balance_notes": "Starting Balance",
 	"account_settings_title": "Account Settings",
 	"account_settings_description": "Here you can change the name of this account.",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
 
 	reporter: process.env.CI ? 'blob' : 'list',
 
-	retries: 0,
+	// One retry in CI: a genuine failure still fails, a one-off timing flake is
+	// reported as "flaky" instead of red — and the retry records a full trace
+	// (trace: 'on-first-retry') for diagnosis.
+	retries: process.env.CI ? 1 : 0,
 
 	testDir: 'tests/playwright',
 
@@ -43,6 +46,10 @@ export default defineConfig({
 	webServer: {
 		command:
 			'DATABASE_URL=:memory: npm run build && DATABASE_URL=:memory: ORIGIN=http://localhost:3000 node build',
-		port: 3000
+		port: 3000,
+		// pino logs (request logs, unhandled server errors incl. logId) go to
+		// stdout, which Playwright discards by default — keep them visible so a
+		// 500 during a test can be traced to its server-side error.
+		stdout: 'pipe'
 	}
 });

--- a/src/lib/remote-functions/account.remote.ts
+++ b/src/lib/remote-functions/account.remote.ts
@@ -1,5 +1,4 @@
 import { resolve } from '$app/paths';
-import { m } from '$lib/paraglide/messages';
 import { AccountCreateSchema, AccountSetNameSchema } from '$lib/schemas/account';
 import { OrderedIdsSchema } from '$lib/schemas/utils';
 import { guardedCommand, guardedForm, guardedQuery } from '$server/utils/remote-guard';
@@ -13,10 +12,7 @@ export const getAccounts = guardedQuery(v.string(), async (budgetId, { ctx }) =>
 export const createAccount = guardedForm(
 	AccountCreateSchema,
 	async ({ accountName, budgetId, startingBalance }, { ctx }) => {
-		const account = ctx.account.create(
-			{ budgetId, name: accountName, notes: m.account_create_starting_balance() },
-			startingBalance
-		);
+		const account = ctx.account.create({ budgetId, name: accountName }, startingBalance);
 		redirect(
 			303,
 			resolve('/(app)/[budgetId=id]/accounts/[accountId=id]', { accountId: account.id, budgetId })

--- a/src/lib/remote-functions/category.remote.ts
+++ b/src/lib/remote-functions/category.remote.ts
@@ -34,11 +34,7 @@ export const createCategory = guardedForm(
 export const editCategory = guardedForm(
 	CategoryEditSchema,
 	async ({ categoryId, categoryName, notes, targetBalance }, { ctx }) => {
-		ctx.category.edit(categoryId, {
-			name: categoryName,
-			notes: notes === undefined ? undefined : (notes ?? null),
-			targetBalance: targetBalance === undefined ? undefined : targetBalance || null
-		});
+		ctx.category.edit(categoryId, { name: categoryName, notes, targetBalance });
 	}
 );
 

--- a/src/lib/server/db/user-context/category.test.ts
+++ b/src/lib/server/db/user-context/category.test.ts
@@ -403,6 +403,32 @@ describe('commands.edit', () => {
 		});
 	});
 
+	it('normalizes a target balance of 0 to null', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const { create, edit } = commands(user.id, db);
+
+		const cat = create(budget.id, 'Targeted');
+		edit(cat.id, { name: 'Targeted', targetBalance: 1000 });
+
+		const updated = edit(cat.id, { name: 'Targeted', targetBalance: 0 });
+
+		expect(updated.targetBalance).toBeNull();
+	});
+
+	it('leaves targetBalance untouched when it is not part of the update', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const { create, edit } = commands(user.id, db);
+
+		const cat = create(budget.id, 'Targeted');
+		edit(cat.id, { name: 'Targeted', targetBalance: 1000 });
+
+		const updated = edit(cat.id, { name: 'Renamed' });
+
+		expect(updated.targetBalance).toBe(1000);
+	});
+
 	it('does not write archivedAt', () => {
 		const db = createDatabase(':memory:');
 		const { budget, user } = createBudgetWithUser(db);

--- a/src/lib/server/db/user-context/category.ts
+++ b/src/lib/server/db/user-context/category.ts
@@ -198,9 +198,14 @@ export const commands = (userId: string, db: Database = database) => ({
 		id: string,
 		data: Partial<Pick<typeof tables.categories.$inferInsert, 'name' | 'notes' | 'targetBalance'>>
 	) => {
+		// a target balance of 0 means "no target" and is stored as null
 		const updated = db
 			.update(tables.categories)
-			.set({ name: data.name, notes: data.notes, targetBalance: data.targetBalance })
+			.set({
+				name: data.name,
+				notes: data.notes,
+				targetBalance: data.targetBalance === undefined ? undefined : data.targetBalance || null
+			})
 			.where(and(hasAccess(tables.categories, userId, db), eq(tables.categories.id, id)))
 			.returning()
 			.get();

--- a/tests/playwright/account.spec.ts
+++ b/tests/playwright/account.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { test } from './fixture';
+import { uniqueName } from './unique-name';
 
 test('Create Account', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -8,7 +9,7 @@ test('Create Account', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 });
 
@@ -18,10 +19,10 @@ test('Edit Account Name', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const newName = faker.finance.accountName();
+	const newName = uniqueName(faker.finance.accountName());
 	await pages.account.goto(accountName);
 	await pages.account.editName(newName);
 });

--- a/tests/playwright/budget.spec.ts
+++ b/tests/playwright/budget.spec.ts
@@ -2,6 +2,7 @@ import { formatCurrency } from '$lib/utils/format-currency';
 import { faker } from '@faker-js/faker';
 
 import { expect, test } from './fixture';
+import { uniqueName } from './unique-name';
 
 test('Assign Budget to Category', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -9,10 +10,10 @@ test('Assign Budget to Category', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
 	await pages.budget.assignAmount(categoryName, '500');
@@ -24,12 +25,12 @@ test('Transfer Assignment — Move between categories', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const sourceCategory = faker.commerce.department();
+	const sourceCategory = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(sourceCategory);
-	const targetCategory = faker.commerce.department();
+	const targetCategory = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(targetCategory);
 
 	// Assign 500 (cents) to source
@@ -53,10 +54,10 @@ test('Transfer Assignment — Move to unassigned', async ({ page, pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const category = faker.commerce.department();
+	const category = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(category);
 
 	// Assign 500
@@ -80,10 +81,10 @@ test('Transfer Assignment — Trigger disabled at zero remaining', async ({ page
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const category = faker.commerce.department();
+	const category = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(category);
 
 	// No assignment → remaining = 0 → trigger disabled

--- a/tests/playwright/category.spec.ts
+++ b/tests/playwright/category.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { test } from './fixture';
+import { uniqueName } from './unique-name';
 
 test('Create Category', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -8,10 +9,10 @@ test('Create Category', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 });
 
@@ -21,12 +22,12 @@ test('Edit Category Name', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
-	const newName = faker.commerce.department();
+	const newName = uniqueName(faker.commerce.department());
 	await pages.category.editName(categoryName, newName);
 });

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { test } from './fixture';
+import { uniqueName } from './unique-name';
 
 test('Create Transaction', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -8,10 +9,10 @@ test('Create Transaction', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
 	await pages.account.goto(accountName);
@@ -30,10 +31,10 @@ test('Edit Transaction', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
 	await pages.account.goto(accountName);
@@ -59,10 +60,10 @@ test('Delete Transaction', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
 	await pages.account.goto(accountName);
@@ -81,10 +82,10 @@ test('Toggle Validated', async ({ pages }) => {
 	const budgetName = faker.commerce.department();
 	await pages.budget.createBudget(budgetName);
 
-	const accountName = faker.finance.accountName();
+	const accountName = uniqueName(faker.finance.accountName());
 	await pages.budget.createAccount(accountName);
 
-	const categoryName = faker.commerce.department();
+	const categoryName = uniqueName(faker.commerce.department());
 	await pages.budget.createCategory(categoryName);
 
 	await pages.account.goto(accountName);

--- a/tests/playwright/unique-name.ts
+++ b/tests/playwright/unique-name.ts
@@ -1,0 +1,11 @@
+import { faker } from '@faker-js/faker';
+
+/**
+ * Category and account names are unique per budget (`*_name_budget_unique`).
+ * faker's commerce/finance name pools are tiny (~20 values), so two draws in
+ * the same budget collide often enough to make tests flaky — add a random
+ * suffix to keep names readable but collision-free.
+ */
+export function uniqueName(base: string): string {
+	return `${base} ${faker.string.alphanumeric(6)}`;
+}


### PR DESCRIPTION
Closes #6.

## Decision (ADR-0002)

Remote functions are **mechanical adapters** over user-context: they guard auth, validate input, translate form semantics to DB semantics, redirect, and refresh caches — they produce no values and hold no business rules. Litmus test: if a remote function produces a value instead of passing one through or translating it, that value belongs in user-context.

Server loads are **peer adapters, not bypasses**: the root-redirect load may call `createUserCtx()` directly, but owns its session check. The seam that matters is user-context, where access control lives on every path.

The adapter layer stays deliberately test-free; tests target user-context, Playwright covers the wiring.

## Changes

- `createAccount` no longer sets a notes default on new accounts — `m.account_create_starting_balance()` ("Account Balance") on every account was an accident, not a rule; the unused message key is removed from both locales
- the `targetBalance` 0→null rule moves from a `||` hidden in `editCategory` into `ctx.category.edit()` as an explicit, tested normalization ("a target of 0 means no target"); the adapter becomes plain passthrough (the `?? null` half of the notes coercion was dead code — the valibot schema never yields null)
- ADR-0002, sharpened `docs/remote-functions.md`, and an "Adapter" glossary entry in `CONTEXT.md` record the policy

## Follow-ups (out of scope here)

- #11 — `budget.remote.ts`: `findEligibleUser`/`inviteUser` business logic → user-context
- #12 — `transaction.remote.ts`: date/validated defaults → user-context; replace the double list query with a count

## Verification

- `npm run check` — 0 errors
- `DATABASE_URL=:memory: npm run test:unit` — 194 passed (17 files), incl. two new cases for the targetBalance normalization
- `npm run lint` — clean


## E2E flakiness fix (second commit)

The tablet `Transfer Assignment` failure in the first CI run was diagnosed to the root: faker's commerce/finance name pools are ~20 values while category/account names are unique per budget — two categories in one budget collide in ~5% of runs, the create form 500s (`UNIQUE constraint failed: categories.name, categories.budget_id`), and the test times out on the error page.

- all category/account test names get a random suffix via `tests/playwright/unique-name.ts`
- Playwright's webServer now pipes stdout, so pino server errors (incl. `logId` + stack) are visible in CI output
- one retry in CI records a trace for any residual flake instead of going red

Verified: full suite 32/32, plus 98/98 on an 8× stress run of budget/category specs. Follow-ups filed: #14 (duplicate name should be a 400 form error, not a 500), #15 (queries occasionally invoked with undefined args during navigation).
