### PR TITLE
feat: extract DialogForm module for the save-and-close flow (#5)

### DIFF
--- a/src/lib/components/account/account-set-name.svelte
+++ b/src/lib/components/account/account-set-name.svelte
@@ -1,56 +1,36 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import { DialogForm } from '$lib/components/ui/dialog-form';
 	import { m } from '$lib/paraglide/messages';
 	import { editAccount, getAccount } from '$lib/remote-functions/account.remote';
 	import PencilIcon from '~icons/ph/pencil';
 
-	import { FormBody } from '../ui/form-body';
 	import { FormField } from '../ui/form-field';
 	import { Input } from '../ui/input';
 
 	let { accountId }: { accountId: string } = $props();
 
 	const account = $derived(await getAccount(accountId));
-
-	let open = $state(false);
-
-	const formId = $props.id();
 </script>
 
-<Dialog.Root
-	bind:open
-	onOpenChangeComplete={(isOpen) => {
-		if (!isOpen) {
-			editAccount.fields.accountName.set(account.name);
-		}
-	}}
->
-	<Dialog.Trigger>
-		{#snippet child({ props })}
-			<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
-				<PencilIcon class="size-5" />
-				<span class="sr-only">{m.account_settings_title()}</span>
-			</Button>
-		{/snippet}
-	</Dialog.Trigger>
+<DialogForm enhance={editAccount.enhance}>
+	{#snippet trigger(props)}
+		<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
+			<PencilIcon class="size-5" />
+			<span class="sr-only">{m.account_settings_title()}</span>
+		</Button>
+	{/snippet}
 
-	<Dialog.Content class="max-w-lg gap-6">
-		<Dialog.Header>
-			<Dialog.Title>{m.account_set_name_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
-				<p>{m.account_set_name_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+	{#snippet header()}
+		<Dialog.Title>{m.account_set_name_title()}</Dialog.Title>
+		<Dialog.Description class="grid gap-4">
+			<p>{m.account_set_name_description()}</p>
+		</Dialog.Description>
+	{/snippet}
 
-		<FormBody
-			{...editAccount.enhance(async (f) => {
-				if (await f.submit()) {
-					open = false;
-				}
-			})}
-			id={formId}
-		>
+	{#snippet fields()}
+		<div class="grid space-y-3 rounded-xl bg-muted/5 p-3">
 			<input {...editAccount.fields.accountId.as('hidden', accountId)} />
 
 			<FormField field={editAccount.fields.accountName} label={m.account_label_name()}>
@@ -58,11 +38,11 @@
 					<Input {...field.as('text', account.name)} class="text-base" />
 				{/snippet}
 			</FormField>
-		</FormBody>
+		</div>
+	{/snippet}
 
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-			<Button type="submit" form={formId}>{m.account_save()}</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+	{#snippet footer({ formId })}
+		<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
+		<Button type="submit" form={formId}>{m.account_save()}</Button>
+	{/snippet}
+</DialogForm>

--- a/src/lib/components/budget-settings/budget-settings.svelte
+++ b/src/lib/components/budget-settings/budget-settings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import { DialogForm } from '$lib/components/ui/dialog-form';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import * as Select from '$lib/components/ui/select';
 	import { m } from '$lib/paraglide/messages';
@@ -15,44 +16,26 @@
 
 	const budget = $derived(await getBudget(budgetId()));
 
-	let open = $state(false);
-
-	const formId = $props.id();
-
 	const form = $derived(editBudget.for(budgetId()));
 </script>
 
-<Dialog.Root bind:open>
-	<Dialog.Trigger>
-		{#snippet child({ props })}
-			<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
-				<PencilIcon class="size-5" />
-				<span class="sr-only">{m.budget_settings_title()}</span>
-			</Button>
-		{/snippet}
-	</Dialog.Trigger>
+<DialogForm enhance={form.enhance} contentClass="gap-0" interactOutsideBehavior="ignore">
+	{#snippet trigger(props)}
+		<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
+			<PencilIcon class="size-5" />
+			<span class="sr-only">{m.budget_settings_title()}</span>
+		</Button>
+	{/snippet}
 
-	<Dialog.Content class="max-w-lg gap-0" interactOutsideBehavior="ignore">
-		<Dialog.Header>
-			<Dialog.Title>{m.budget_settings_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
-				<p>{m.budget_settings_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+	{#snippet header()}
+		<Dialog.Title>{m.budget_settings_title()}</Dialog.Title>
+		<Dialog.Description class="grid gap-4">
+			<p>{m.budget_settings_description()}</p>
+		</Dialog.Description>
+	{/snippet}
 
-		<form
-			{...form.enhance(async (f) => {
-				try {
-					if (await f.submit()) {
-						open = false;
-					}
-				} catch (error) {
-					console.error(error);
-				}
-			})}
-			id={formId}
-			class="mt-6 grid gap-2 rounded-lg bg-muted/5 p-3"
-		>
+	{#snippet fields()}
+		<div class="mt-6 grid gap-2 rounded-lg bg-muted/5 p-3">
 			<input {...editBudget.fields.budgetId.as('hidden', budgetId())} />
 
 			<div class="grid gap-2">
@@ -91,11 +74,11 @@
 					</Select.Content>
 				</Select.Root>
 			</div>
-		</form>
+		</div>
+	{/snippet}
 
-		<Dialog.Footer class="mt-6">
-			<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-			<Button type="submit" form={formId}>{m.save()}</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+	{#snippet footer({ formId })}
+		<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
+		<Button type="submit" form={formId}>{m.save()}</Button>
+	{/snippet}
+</DialogForm>

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { cn } from 'tailwind-variants';
+
+	let {
+		contentClass = '',
+		enhance,
+		errors,
+		fields,
+		footer,
+		header,
+		interactOutsideBehavior = undefined,
+		open = $bindable(false),
+		resetOnClose = true,
+		trigger,
+		...restProps
+	}: {
+		contentClass?: string;
+		enhance: (
+			onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>
+		) => Record<string, unknown>;
+		errors?: Snippet<[unknown]>;
+		fields: Snippet;
+		footer: Snippet<[{ formId: string }]>;
+		header: Snippet;
+		interactOutsideBehavior?: 'ignore' | undefined;
+		open?: boolean;
+		resetOnClose?: boolean;
+		trigger: Snippet<[Record<string, unknown>]>;
+	} = $props();
+
+	const formId = $props.id();
+
+	let _error = $state<unknown>(null);
+
+	function resetError() {
+		_error = null;
+	}
+</script>
+
+<Dialog.Root bind:open {...restProps}>
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			{@render trigger(props)}
+		{/snippet}
+	</Dialog.Trigger>
+
+	<Dialog.Content class={cn('max-w-lg gap-6', contentClass)} {interactOutsideBehavior}>
+		<Dialog.Header>
+			{@render header()}
+		</Dialog.Header>
+
+		<form
+			id={formId}
+			{...enhance(async (f) => {
+				resetError();
+				try {
+					if (await f.submit()) {
+						open = false;
+					}
+				} catch (e) {
+					_error = e;
+				}
+			})}
+		>
+			{#if resetOnClose}
+				{#key open}
+					{@render fields()}
+				{/key}
+			{:else}
+				{@render fields()}
+			{/if}
+		</form>
+
+		{#if _error && errors}
+			{@render errors(_error)}
+		{/if}
+
+		<Dialog.Footer>
+			{@render footer({ formId })}
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/ui/dialog-form/index.ts
+++ b/src/lib/components/ui/dialog-form/index.ts
@@ -1,0 +1,1 @@
+export { default as DialogForm } from './dialog-form.svelte';


### PR DESCRIPTION
Consolidate the trigger → dialog → form → enhance → close-on-success pattern into one deep DialogForm component.

## What

One `DialogForm` module at `src/lib/components/ui/dialog-form/` that owns open/close state, enhance wiring, reset-on-close, and error catching. Call sites shrink to their fields — everything else is snippets.

## Why

The three original implementations (account-set-name, budget-settings, category-edit) had diverged on toast vs. silent success, blur auto-submit, FormBody vs. raw form — accidents of copy-paste. DialogForm makes the divergent UX explicit.

## Scope

- Refactors the two dialog sites: `account-set-name.svelte` and `budget-settings.svelte`
- Category-edit (standalone form, no dialog) deferred to #16
- Error handling wiring deferred to #17

## Checks

- Typecheck: 0 errors
- Unit tests: 194 passed
- E2E tests: 32 passed