### PR TITLE
refactor: move business rules from remote functions into user-context (#11, #12)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+	"mcpServers": {
+		"svelte": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@sveltejs/mcp"]
+		},
+		"context7": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp@latest"]
+		}
+	}
+}

--- a/src/lib/components/budget-user-manager/user-invitation.svelte
+++ b/src/lib/components/budget-user-manager/user-invitation.svelte
@@ -61,11 +61,7 @@
 						/>
 
 						<InputGroup.Addon align="block-end" class="text-xs font-normal">
-							{#if findUserResult?.current?.error}
-								<div class="flex items-center gap-1 text-error">
-									{findUserResult.current.error}
-								</div>
-							{:else if findUserResult?.current?.userId}
+							{#if findUserResult?.current?.userId}
 								<div class="flex items-center gap-1 text-success">
 									{m.budget_users_invite_success()}
 								</div>
@@ -78,7 +74,7 @@
 							<Button
 								type="submit"
 								class="ms-auto"
-								aria-disabled={!findUserResult?.current?.eligible}
+								aria-disabled={!findUserResult?.current?.userId}
 							>
 								{m.budget_users_invite_button()}
 							</Button>

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -1,7 +1,6 @@
 import { resolve } from '$app/paths';
 import { requested } from '$app/server';
 import { UNASSIGNED } from '$lib/constants';
-import { m } from '$lib/paraglide/messages';
 import {
 	AssignmentSchema,
 	BudgetAndUserIdSchema,
@@ -13,7 +12,7 @@ import {
 } from '$lib/schemas/budget';
 import { OrderedIdsSchema } from '$lib/schemas/utils';
 import { guardedCommand, guardedForm, guardedQuery } from '$server/utils/remote-guard';
-import { error, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import * as v from 'valibot';
 
 export const getBudgets = guardedQuery(async ({ ctx }) => ctx.budget.all());
@@ -43,39 +42,14 @@ export const removeUser = guardedForm(
 
 export const findEligibleUser = guardedQuery(
 	FindBudgetUserSchema,
-	async ({ budgetId, inviteeName }, { ctx, user }) => {
-		if (user.username === inviteeName) {
-			return { error: m.budget_users_error_its_you() };
-		}
-
-		const budgetUsers = ctx.budget.users(budgetId);
-		const existingMember = budgetUsers.find((u) => u.name === inviteeName);
-
-		if (existingMember) {
-			return {
-				error:
-					existingMember.role === 'INVITEE'
-						? m.budget_users_error_already_invited({ value: inviteeName })
-						: m.budget_users_error_already_access({ value: inviteeName })
-			};
-		}
-
-		const eligibleUser = ctx.budget.eligibleUsers(budgetId).find((u) => u.name === inviteeName);
-
-		if (!eligibleUser) {
-			return { error: m.budget_users_error_not_found({ value: inviteeName }) };
-		}
-
-		return { eligible: true, userId: eligibleUser.id };
-	}
+	async ({ budgetId, inviteeName }, { ctx }) => ctx.budget.findEligibleUser(budgetId, inviteeName)
 );
 
 export const inviteUser = guardedForm(
 	FindBudgetUserSchema,
 	async ({ budgetId, inviteeName }, { ctx }) => {
-		const eligibleUser = ctx.budget.eligibleUsers(budgetId).find((f) => f.name === inviteeName);
-		if (!eligibleUser) error(400);
-		ctx.budget.invite(budgetId, eligibleUser.id);
+		ctx.budget.invite(budgetId, inviteeName);
+		void getBudgetUsers(budgetId).refresh();
 	}
 );
 

--- a/src/lib/remote-functions/transaction.remote.ts
+++ b/src/lib/remote-functions/transaction.remote.ts
@@ -44,13 +44,12 @@ export const listTransactions = guardedQuery(
 			...(sortValidated ? { validated: sortValidated } : {})
 		};
 
-		const transactions = ctx.transaction.list(filter, sort, { page: page - 1, pageSize });
-		const allTransactions = ctx.transaction.list(filter, sort);
+		const [transactions, totalTransactionCount] = await Promise.all([
+			ctx.transaction.list(filter, sort, { page: page - 1, pageSize }),
+			ctx.transaction.count(filter)
+		]);
 
-		return {
-			pagination: { page, pageSize, totalTransactionCount: allTransactions.length },
-			transactions
-		};
+		return { pagination: { page, pageSize, totalTransactionCount }, transactions };
 	}
 );
 
@@ -63,7 +62,7 @@ export const createTransaction = guardedForm(
 			budgetId: data.budgetId,
 			categoryId: data.categoryId || null,
 			createdBy: user.id,
-			date: data.date ?? new Date().toISOString().split('T')[0],
+			date: data.date,
 			notes: data.notes || null,
 			validated: data.validated
 		});
@@ -78,7 +77,7 @@ export const editTransaction = guardedForm(
 			...rest,
 			categoryId: categoryId === '' ? null : categoryId,
 			notes: notes === undefined ? undefined : notes || null,
-			validated: rest.validated ?? false
+			validated: rest.validated
 		};
 		ctx.transaction.edit(transactionId, update);
 		await requested(listTransactions, 1).refreshAll();

--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -79,6 +79,59 @@ describe('queries.eligibleUsers', () => {
 	});
 });
 
+describe('queries.findEligibleUser', () => {
+	it('returns userId for eligible user', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const other = createUser(db, 'other');
+		const { findEligibleUser } = queries(user.id, db);
+
+		const result = findEligibleUser(budget.id, 'other');
+
+		expect(result).toEqual({ userId: other.id });
+	});
+
+	it('throws for self-invite', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const { findEligibleUser } = queries(user.id, db);
+
+		expect(() => findEligibleUser(budget.id, 'owner')).toThrow();
+	});
+
+	it('throws for already invited user', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const invitee = createUser(db, 'invitee');
+		db.insert(tables.usersToBudgets)
+			.values({ budgetId: budget.id, role: 'INVITEE', userId: invitee.id })
+			.run();
+		const { findEligibleUser } = queries(user.id, db);
+
+		expect(() => findEligibleUser(budget.id, 'invitee')).toThrow();
+	});
+
+	it('throws for already a member', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const member = createUser(db, 'member');
+		db.insert(tables.usersToBudgets)
+			.values({ budgetId: budget.id, role: 'MEMBER', userId: member.id })
+			.run();
+		const { findEligibleUser } = queries(user.id, db);
+
+		expect(() => findEligibleUser(budget.id, 'member')).toThrow();
+	});
+
+	it('throws for non-existent user', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db, 'OWNER', 'owner');
+		const { findEligibleUser } = queries(user.id, db);
+
+		expect(() => findEligibleUser(budget.id, 'nonexistent')).toThrow();
+	});
+});
+
 describe('queries.invitations', () => {
 	it('returns pending invites with budget and inviter name', () => {
 		const db = createDatabase(':memory:');
@@ -328,7 +381,7 @@ describe('commands.invite', () => {
 		const invitee = createUser(db, 'invitee');
 		const { invite } = commands(owner.id, db);
 
-		invite(budget.id, invitee.id);
+		invite(budget.id, invitee.username);
 
 		const membership = db
 			.select()
@@ -344,7 +397,7 @@ describe('commands.invite', () => {
 		const outsider = createUser(db, 'outsider');
 		const { invite } = commands(user.id, db);
 
-		expect(() => invite(budget.id, outsider.id)).toThrow(NotFoundError);
+		expect(() => invite(budget.id, outsider.username)).toThrow(NotFoundError);
 	});
 });
 

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -2,12 +2,71 @@ import type { Month } from '$lib/utils/month';
 
 import { database, type Database, tables } from '$db';
 import { dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
+import { m } from '$lib/paraglide/messages';
 import { error } from '@sveltejs/kit';
 import { and, eq, getColumns, inArray, isNull, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 import { accessGuard, hasAccess, ownerGuard } from './access';
 import { withOrder } from './utils';
+
+const findEligibleUser = (
+	userId: string,
+	db: Database,
+	budgetId: string,
+	inviteeName: string
+): { userId: string } => {
+	const currentUser = db
+		.select({ username: tables.users.username })
+		.from(tables.users)
+		.where(eq(tables.users.id, userId))
+		.get();
+
+	if (currentUser?.username === inviteeName) {
+		error(400, m.budget_users_error_its_you());
+	}
+
+	const existing = db
+		.select({ role: tables.usersToBudgets.role })
+		.from(tables.usersToBudgets)
+		.innerJoin(tables.users, eq(tables.users.id, tables.usersToBudgets.userId))
+		.where(
+			and(
+				eq(tables.usersToBudgets.budgetId, budgetId),
+				eq(tables.users.username, inviteeName),
+				hasAccess(tables.usersToBudgets, userId, db)
+			)
+		)
+		.get();
+
+	if (existing) {
+		error(
+			400,
+			existing.role === 'INVITEE'
+				? m.budget_users_error_already_invited({ value: inviteeName })
+				: m.budget_users_error_already_access({ value: inviteeName })
+		);
+	}
+
+	const eligible = db
+		.select({ id: tables.users.id })
+		.from(tables.users)
+		.leftJoin(
+			tables.usersToBudgets,
+			and(
+				eq(tables.usersToBudgets.userId, tables.users.id),
+				eq(tables.usersToBudgets.budgetId, budgetId)
+			)
+		)
+		.where(and(eq(tables.users.username, inviteeName), isNull(tables.usersToBudgets.userId)))
+		.get();
+
+	if (!eligible) {
+		error(400, m.budget_users_error_not_found({ value: inviteeName }));
+	}
+
+	return { userId: eligible.id };
+};
 
 export type BudgetUser = {
 	id: string;
@@ -52,6 +111,9 @@ export const queries = (userId: string, db: Database = database) => ({
 			.where(isNull(tables.usersToBudgets.userId))
 			.all();
 	},
+
+	findEligibleUser: (budgetId: string, inviteeName: string) =>
+		findEligibleUser(userId, db, budgetId, inviteeName),
 
 	invitations: () => {
 		const inviterAlias = alias(tables.usersToBudgets, 'inviter_utb');
@@ -256,8 +318,9 @@ export const commands = (userId: string, db: Database = database) => ({
 		return updated;
 	},
 
-	invite: (budgetId: string, inviteeId: string) => {
+	invite: (budgetId: string, inviteeName: string) => {
 		ownerGuard(budgetId, userId, db);
+		const { userId: inviteeId } = findEligibleUser(userId, db, budgetId, inviteeName);
 		db.insert(tables.usersToBudgets).values({ budgetId, role: 'INVITEE', userId: inviteeId }).run();
 	},
 

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -31,11 +31,7 @@ const findEligibleUser = (
 		.from(tables.usersToBudgets)
 		.innerJoin(tables.users, eq(tables.users.id, tables.usersToBudgets.userId))
 		.where(
-			and(
-				eq(tables.usersToBudgets.budgetId, budgetId),
-				eq(tables.users.username, inviteeName),
-				hasAccess(tables.usersToBudgets, userId, db)
-			)
+			and(eq(tables.usersToBudgets.budgetId, budgetId), eq(tables.users.username, inviteeName))
 		)
 		.get();
 

--- a/src/lib/server/db/user-context/transaction.test.ts
+++ b/src/lib/server/db/user-context/transaction.test.ts
@@ -166,6 +166,39 @@ describe('queries.list', () => {
 	});
 });
 
+describe('queries.count', () => {
+	it('returns total transaction count', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const a = createAccount(db, budget.id, 'A');
+		createTransaction(db, budget.id, a.id);
+		createTransaction(db, budget.id, a.id);
+		const { count } = queries(user.id, db);
+
+		expect(count()).toBe(2);
+	});
+
+	it('returns 0 when no transactions', () => {
+		const db = createDatabase(':memory:');
+		const { user } = createBudgetWithUser(db);
+		const { count } = queries(user.id, db);
+
+		expect(count()).toBe(0);
+	});
+
+	it('respects filters', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const a = createAccount(db, budget.id, 'A');
+		createTransaction(db, budget.id, a.id, { validated: true });
+		createTransaction(db, budget.id, a.id, { validated: false });
+		const { count } = queries(user.id, db);
+
+		expect(count({ validated: true })).toBe(1);
+		expect(count({ validated: false })).toBe(1);
+	});
+});
+
 describe('commands.create', () => {
 	it('creates transaction', () => {
 		const db = createDatabase(':memory:');
@@ -177,6 +210,18 @@ describe('commands.create', () => {
 
 		expect(tx).toMatchObject({ accountId: a.id, amount: -42, date: '2025-03-15' });
 		expect(tx.id).toBeDefined();
+	});
+
+	it('defaults date to today when omitted', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const a = createAccount(db, budget.id, 'A');
+		const { create } = commands(user.id, db);
+
+		const tx = create({ accountId: a.id, amount: -42, budgetId: budget.id });
+
+		expect(tx.date).toBeDefined();
+		expect(tx.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 	});
 
 	it('throws NotFoundError without budget access', () => {
@@ -232,6 +277,18 @@ describe('commands.edit', () => {
 		const updated = edit(tx.id, { amount: 200, notes: 'new' });
 
 		expect(updated).toMatchObject({ amount: 200, id: tx.id, notes: 'new' });
+	});
+
+	it('defaults validated to false when omitted', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const a = createAccount(db, budget.id, 'A');
+		const tx = createTransaction(db, budget.id, a.id, { validated: true });
+		const { edit } = commands(user.id, db);
+
+		const updated = edit(tx.id, { amount: 300 });
+
+		expect(updated.validated).toBe(false);
 	});
 
 	it('throws for non-existent transaction', () => {

--- a/src/lib/server/db/user-context/transaction.ts
+++ b/src/lib/server/db/user-context/transaction.ts
@@ -1,6 +1,7 @@
 import { database, type Database, tables } from '$db';
+import { getLocalTimeZone, today } from '@internationalized/date';
 import { error } from '@sveltejs/kit';
-import { and, eq, getColumns, inArray } from 'drizzle-orm';
+import { and, count, eq, getColumns, inArray } from 'drizzle-orm';
 
 import { accessGuard, hasAccess } from './access';
 import {
@@ -21,6 +22,20 @@ export const queries = (userId: string, db: Database = database) => ({
 
 		if (!found) error(404);
 		return found;
+	},
+
+	count: (filter: TransactionFilterParam = {}) => {
+		let dq = db
+			.select({ total: count() })
+			.from(tables.transactions)
+			.leftJoin(tables.categories, eq(tables.transactions.categoryId, tables.categories.id))
+			.leftJoin(tables.users, eq(tables.transactions.createdBy, tables.users.id))
+			.where(hasAccess(tables.transactions, userId, db))
+			.$dynamic();
+
+		dq = withFilter({ dq, filter });
+
+		return dq.get()?.total ?? 0;
 	},
 
 	list: (
@@ -54,11 +69,15 @@ export const queries = (userId: string, db: Database = database) => ({
 export type ListTransaction = Awaited<ReturnType<ReturnType<typeof queries>['list']>>[number];
 
 export const commands = (userId: string, db: Database = database) => ({
-	create: (data: typeof tables.transactions.$inferInsert) => {
+	create: (data: Omit<typeof tables.transactions.$inferInsert, 'date'> & { date?: string }) => {
 		accessGuard(data.budgetId, userId, db);
 
 		return db.transaction((tx) => {
-			return tx.insert(tables.transactions).values(data).returning().get();
+			return tx
+				.insert(tables.transactions)
+				.values({ ...data, date: data.date ?? today(getLocalTimeZone()).toString() })
+				.returning()
+				.get();
 		});
 	},
 
@@ -71,9 +90,10 @@ export const commands = (userId: string, db: Database = database) => ({
 	},
 
 	edit: (id: string, update: Partial<typeof tables.transactions.$inferInsert>) => {
+		const data = { ...update, validated: update.validated ?? false };
 		const updated = db
 			.update(tables.transactions)
-			.set(update)
+			.set(data)
 			.where(and(hasAccess(tables.transactions, userId, db), eq(tables.transactions.id, id)))
 			.returning()
 			.get();


### PR DESCRIPTION
## Summary

Resolves #11 and #12 — follow-ups from ADR-0002 (remote functions are mechanical adapters).

### Issue #11 — Budget user invite logic

- Extract `findEligibleUser` as a module-level helper in budget user-context that validates self-invite, already-member, already-invited, not-found and throws `error(400, m.<message>())` per ADR-0001
- Add `queries.findEligibleUser` and update `commands.invite` to accept `inviteeName` instead of `inviteeId`, internally calling the shared helper
- Shrink `budget.remote.ts` adapters to pure passthrough; remove unused `m` and `error` imports

### Issue #12 — Transaction defaults and count query

- Add `queries.count(filter)` using `SELECT count(*)` to replace the double list-query pattern that loaded all rows per page view
- Move date default (today) into `commands.create`, validated default (false) into `commands.edit`, both following `account.ts` conventions
- Update `transaction.remote.ts` to use `Promise.all` for list + count and remove value-producing defaults from the adapter layer

### Tests

10 new unit tests covering all new user-context functions. 239 tests pass, lint clean.

Litmus test from ADR-0002: if a remote function produces a value instead of passing one through or translating it, that value belongs in user-context. All violations identified in ADR-0002 are now resolved.