### PR TITLE
feat: unify input styling behind shared inputVariants and focus-ring modules (#26)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: amount, cent value, float, display value
 A category is archivable when its remaining balance (all-time assignments plus transactions) is zero and it has no pending (unvalidated) transactions. The rule is enforced by `category.archive` in user-context (see ADR-0001) and projected to the UI via `category.archivability`; nothing else may write `archivedAt`.
 _Avoid_: deletable, closable
 
+**Focus treatment**:
+The canonical focus indicator — `border-focus` plus `ring-2 ring-focus/50` — owned by `src/lib/components/ui/focus-ring` in two flavors: `focusRing` (`focus-visible:`) for direct controls and `focusRingWithin` (`focus-within:`) for containers wrapping a focusable child. Focusable elements compose one of these instead of styling their own ring or falling back to the browser outline; input chrome gets it via `inputVariants` in `src/lib/components/ui/input`.
+_Avoid_: custom outline, per-component ring values
+
 **Adapter**:
 A mechanical entry point (remote function or server load) that connects SvelteKit to user-context: it guards auth, validates input, translates form semantics, redirects, and refreshes caches — but produces no values and holds no business rules (see ADR-0002).
 _Avoid_: endpoint, controller, service layer

--- a/src/lib/components/ui/focus-ring/focus-ring.ts
+++ b/src/lib/components/ui/focus-ring/focus-ring.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical focus treatment for interactive elements. Every focusable
+ * element draws this ring instead of the browser default outline.
+ *
+ * Both flavors must express the same treatment; only the trigger differs.
+ */
+
+/** `focus-visible:` flavor — for elements that receive focus directly. */
+export const focusRing =
+	'focus-visible:border-focus focus-visible:ring-2 focus-visible:ring-focus/50';
+
+/** `focus-within:` flavor — for containers that wrap a focusable child. */
+export const focusRingWithin =
+	'focus-within:border-focus focus-within:ring-2 focus-within:ring-focus/50';

--- a/src/lib/components/ui/focus-ring/index.ts
+++ b/src/lib/components/ui/focus-ring/index.ts
@@ -1,0 +1,1 @@
+export { focusRing, focusRingWithin } from './focus-ring';

--- a/src/lib/components/ui/input-currency/input-currency.svelte
+++ b/src/lib/components/ui/input-currency/input-currency.svelte
@@ -3,6 +3,7 @@
 	import type { CurrencyInputValues, IntlConfig } from '@canutin/svelte-currency-input';
 	import type { HTMLInputAttributes } from 'svelte/elements';
 
+	import { inputVariants } from '$lib/components/ui/input';
 	import { getLocale, type Locale } from '$lib/paraglide/runtime';
 	import { parseMoney, unwrapMoney } from '$lib/utils/money';
 	import { CurrencyInput } from '@canutin/svelte-currency-input';
@@ -141,10 +142,7 @@
 	bind:ref
 	value={internalValue}
 	data-slot={dataSlot}
-	class={cn(
-		'h-9 w-full rounded-md border border-muted/30 bg-surface/70 px-3 py-1 outline-none placeholder:text-muted focus-visible:border-focus focus-visible:bg-surface/80 focus-visible:ring-2 focus-visible:ring-focus/50 aria-invalid:border-error',
-		className
-	)}
+	class={cn(inputVariants(), className)}
 	intlConfig={{ currency, locale, ...intlConfig }}
 	{prefix}
 	{suffix}

--- a/src/lib/components/ui/input-group/input-group-input.svelte
+++ b/src/lib/components/ui/input-group/input-group-input.svelte
@@ -15,10 +15,8 @@
 <Input
 	bind:ref
 	data-slot="input-group-control"
-	class={cn(
-		'flex-1 rounded-none border-0 bg-transparent ring-0 focus-visible:bg-transparent focus-visible:ring-0 aria-invalid:border-0',
-		className
-	)}
+	variant="ghost"
+	class={cn('flex-1', className)}
 	bind:value
 	{...props}
 />

--- a/src/lib/components/ui/input/index.ts
+++ b/src/lib/components/ui/input/index.ts
@@ -1,3 +1,4 @@
+import { type InputVariant, inputVariants } from './input-variants';
 import Root from './input.svelte';
 
-export { Root as Input };
+export { Root as Input, type InputVariant, inputVariants };

--- a/src/lib/components/ui/input/input-variants.test.ts
+++ b/src/lib/components/ui/input/input-variants.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { focusRing, focusRingWithin } from '../focus-ring';
+import { inputVariants } from './input-variants';
+
+function classList(result: string): string[] {
+	return result.split(/\s+/).filter(Boolean);
+}
+
+describe('inputVariants', () => {
+	it('default variant renders the canonical chrome', () => {
+		const result = classList(inputVariants());
+
+		expect(result).toEqual(
+			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/30', 'bg-surface/70', 'h-9'])
+		);
+	});
+
+	it('ghost variant yields no chrome — no border, background, ring, or radius classes', () => {
+		const chrome = /^(border|bg-|ring|rounded)/;
+		const result = classList(inputVariants({ variant: 'ghost' }));
+
+		expect(result.filter((cls) => chrome.test(cls))).toEqual([]);
+	});
+
+	it('ghost variant keeps the shared sizing and padding', () => {
+		const result = classList(inputVariants({ variant: 'ghost' }));
+
+		expect(result).toEqual(expect.arrayContaining(['h-9', 'w-full', 'px-3', 'py-1']));
+	});
+
+	it.each(['default', 'ghost', 'container'] as const)(
+		'base carries the error border for the %s variant',
+		(variant) => {
+			expect(classList(inputVariants({ variant }))).toContain('aria-invalid:border-error');
+		}
+	);
+
+	it('base carries the muted placeholder', () => {
+		expect(classList(inputVariants())).toContain('placeholder:text-muted');
+	});
+
+	it('default variant composes the focus-visible focus ring', () => {
+		const result = classList(inputVariants());
+
+		for (const cls of classList(focusRing)) {
+			expect(result).toContain(cls);
+		}
+	});
+
+	it('container variant composes the focus-within flavor instead of focus-visible', () => {
+		const result = classList(inputVariants({ variant: 'container' }));
+
+		for (const cls of classList(focusRingWithin)) {
+			expect(result).toContain(cls);
+		}
+		expect(result.filter((cls) => cls.startsWith('focus-visible:'))).toEqual([]);
+	});
+
+	it('multiline drops the fixed height in favor of content-based sizing', () => {
+		const result = classList(inputVariants({ multiline: true }));
+
+		expect(result).toEqual(expect.arrayContaining(['field-sizing-content', 'min-h-16']));
+		expect(result).not.toContain('h-9');
+	});
+
+	it('container variant carries the chrome but omits inner padding', () => {
+		const result = classList(inputVariants({ variant: 'container' }));
+
+		expect(result).toEqual(
+			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/30', 'bg-surface/70', 'h-9'])
+		);
+		expect(result.filter((cls) => /^p[xy]?-/.test(cls))).toEqual([]);
+	});
+});

--- a/src/lib/components/ui/input/input-variants.ts
+++ b/src/lib/components/ui/input/input-variants.ts
@@ -1,0 +1,30 @@
+import { tv, type VariantProps } from 'tailwind-variants';
+
+import { focusRing, focusRingWithin } from '../focus-ring';
+
+export const inputVariants = tv({
+	base: 'w-full outline-none placeholder:text-muted aria-invalid:border-error',
+	defaultVariants: {
+		multiline: false,
+		variant: 'default'
+	},
+	variants: {
+		multiline: {
+			false: 'h-9',
+			true: 'field-sizing-content min-h-16'
+		},
+		variant: {
+			container: [
+				'flex items-center rounded-lg border border-muted/30 bg-surface/70 focus-within:bg-surface/80',
+				focusRingWithin
+			],
+			default: [
+				'rounded-lg border border-muted/30 bg-surface/70 px-3 py-1 focus-visible:bg-surface/80',
+				focusRing
+			],
+			ghost: 'px-3 py-1'
+		}
+	}
+});
+
+export type InputVariant = VariantProps<typeof inputVariants>['variant'];

--- a/src/lib/components/ui/input/input.svelte
+++ b/src/lib/components/ui/input/input.svelte
@@ -4,12 +4,14 @@
 
 	import { cn } from 'tailwind-variants';
 
+	import { type InputVariant, inputVariants } from './input-variants';
+
 	type InputType = Exclude<HTMLInputTypeAttribute, 'file'>;
 
 	type Props = WithElementRef<
 		Omit<HTMLInputAttributes, 'type'> &
 			({ files?: FileList; type: 'file' } | { files?: undefined; type?: InputType })
-	>;
+	> & { variant?: InputVariant };
 
 	let {
 		class: className,
@@ -18,6 +20,7 @@
 		ref = $bindable(null),
 		type,
 		value = $bindable(),
+		variant = 'default',
 		...restProps
 	}: Props = $props();
 </script>
@@ -27,7 +30,8 @@
 		bind:this={ref}
 		data-slot={dataSlot}
 		class={cn(
-			'h-9 w-full rounded-lg border border-muted/30 bg-surface/70 px-3 py-1 outline-none file:inline-flex file:border-0 file:bg-transparent file:text-foreground placeholder:text-muted/90 focus-visible:ring-2 focus-visible:ring-focus/80 aria-invalid:border-error',
+			inputVariants({ variant }),
+			'file:inline-flex file:border-0 file:bg-transparent file:text-foreground',
 			className
 		)}
 		type="file"
@@ -39,10 +43,7 @@
 	<input
 		bind:this={ref}
 		data-slot={dataSlot}
-		class={cn(
-			'h-9 w-full rounded-lg border border-muted/30 bg-surface/70 px-3 py-1 outline-none placeholder:text-muted focus-visible:border-focus focus-visible:bg-surface/80 focus-visible:ring-2 focus-visible:ring-focus/50 aria-invalid:border-error',
-			className
-		)}
+		class={cn(inputVariants({ variant }), className)}
 		{type}
 		bind:value
 		{...restProps}

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
+	import { inputVariants } from '$lib/components/ui/input';
 	import { UNASSIGNED } from '$lib/constants';
 	import { m } from '$lib/paraglide/messages';
 	import { Combobox, type WithoutChildrenOrChild } from 'bits-ui';
@@ -100,13 +101,7 @@
 	onOpenChange={handleOpenChange}
 	inputValue={displayValue}
 >
-	<div
-		bind:this={containerRef}
-		class={cn(
-			'flex h-9 w-full items-center rounded-md border border-muted/30 bg-surface/70 focus-within:border-focus focus-within:ring-2 focus-within:ring-focus/50',
-			className
-		)}
-	>
+	<div bind:this={containerRef} class={cn(inputVariants({ variant: 'container' }), className)}>
 		<Combobox.Input
 			{...inputProps}
 			aria-label={ariaLabel}

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -2,6 +2,7 @@
 	import type { WithElementRef, WithoutChildren } from 'bits-ui';
 	import type { HTMLTextareaAttributes } from 'svelte/elements';
 
+	import { inputVariants } from '$lib/components/ui/input';
 	import { cn } from 'tailwind-variants';
 
 	let {
@@ -17,7 +18,8 @@
 	bind:this={ref}
 	data-slot={dataSlot}
 	class={cn(
-		'flex field-sizing-content min-h-16 w-full rounded-md border border-muted/30 bg-focus/5 px-3 py-1 outline-none placeholder:text-muted/90 focus-visible:bg-focus/7 focus-visible:ring-2 focus-visible:ring-focus/80 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error',
+		inputVariants({ multiline: true }),
+		'flex disabled:cursor-not-allowed disabled:opacity-50',
 		className
 	)}
 	bind:value


### PR DESCRIPTION
Closes #26.

## Summary

All form input chrome now derives from one shared `tv()` module (`inputVariants`) that composes a standalone canonical focus treatment module (`focus-ring`). Changing a design token touches one file and propagates everywhere.

### New modules
- **`focus-ring`** — two exportable string constants (`focusRing` / `focusRingWithin`) encoding the canonical `border-focus + ring-2 ring-focus/50` treatment. Own module, so non-input elements can import it without reaching into the input module (`#25`).
- **`inputVariants`** — `tv()` definition with variants: `default` (full chrome + focusRing), `ghost` (no chrome, replaces the input-group class-negation list), `container` (focusRingWithin, no inner padding), and a `multiline` axis for textarea sizing.

### Adapters migrated
- **Input** — gains optional `variant` prop (`default`), file-input branch folds into the canonical focus ring.
- **Textarea** — `multiline: true`, loses the `bg-focus/5` tint and `rounded-md` in favor of the canonical tokens.
- **InputCurrency** — mechanical `inputVariants()` call.
- **SelectCategory** — `variant: container` on the wrapper `div`; gains `aria-invalid:border-error` from the shared base.
- **InputGroup input** — `variant: ghost`, the class-negation list is gone.

### Verification
- 11 unit tests on the variant contract (ghost = no chrome, container = focus-within + no padding, error border in base, multiline sizing swap)
- `npm run check` — 0 errors; `npm run lint` — clean
- Full suite: 269 tests pass (258 existing + 11 new), including unchanged select-category and input-currency component tests

### Out of scope
- `aria-invalid` wired from FormField into the category selector and date picker (separate candidate)
- Migrating non-input elements to the focus-ring module (tracked in #25)