### PR TITLE
feat: add aria-invalid contract to SelectCategory and DatePicker (#27)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -7,6 +7,7 @@
 - Follow the existing export shape for primitives, including `index.ts` re-exports of `Root` and named parts where that pattern already exists.
 - Reuse existing Tailwind Variants patterns (`tv(...)`, `cn(...)`) for shared UI primitives.
 - Preserve accessibility wiring: roles, aria attributes, focus handling, keyboard affordances, sr-only labels.
+- Form controls accept `aria-invalid` and render the shared error border; composite controls forward it to their focusable element.
 - No hardcoded feature copy in shared UI primitives. Pass labels from callers, localize with Paraglide.
 - Match existing Svelte 5 runes and snippet-based composition patterns in touched components.
 - Prefer `<Name>Icon` imports in touched feature code.

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -10,6 +10,7 @@
 	import { Calendar } from '../calendar';
 
 	type DatePickerProps = {
+		ariaInvalid?: boolean;
 		class?: string;
 		disabled?: boolean;
 		formatDisplay?: (date: CalendarDate) => string;
@@ -25,6 +26,7 @@
 	};
 
 	let {
+		ariaInvalid,
 		class: className,
 		disabled = false,
 		formatDisplay,
@@ -79,6 +81,7 @@
 				)}
 				role="combobox"
 				aria-expanded={open}
+				aria-invalid={ariaInvalid}
 				aria-label={value ? displayFormatter(value) : label}
 			>
 				{displayValue}

--- a/src/lib/components/ui/date-picker/date-picker.svelte.test.ts
+++ b/src/lib/components/ui/date-picker/date-picker.svelte.test.ts
@@ -1,0 +1,53 @@
+import type { ComponentProps } from 'svelte';
+
+import { render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
+afterEach(() => {
+	vi.runAllTimers();
+	vi.useRealTimers();
+});
+
+import DatePicker from './date-picker.svelte';
+
+function renderDatePicker(props?: Partial<ComponentProps<typeof DatePicker>>) {
+	render(DatePicker, {
+		props: {
+			label: 'Pick a date',
+			...props
+		}
+	});
+
+	const button = screen.getByRole<HTMLButtonElement>('combobox', { name: /Pick a date/ });
+	return { button };
+}
+
+describe('DatePicker', () => {
+	it('renders a combobox button', () => {
+		const { button } = renderDatePicker();
+		expect(button).toBeInTheDocument();
+	});
+
+	it('shows the label text when no value is selected', () => {
+		const { button } = renderDatePicker();
+		expect(button).toHaveTextContent('Pick a date');
+	});
+});
+
+describe('DatePicker — aria-invalid contract', () => {
+	it('sets aria-invalid on the trigger button when ariaInvalid is true', () => {
+		const { button } = renderDatePicker({ ariaInvalid: true });
+		expect(button).toHaveAttribute('aria-invalid', 'true');
+	});
+
+	it('sets aria-invalid to false on the trigger button when ariaInvalid is false', () => {
+		const { button } = renderDatePicker({ ariaInvalid: false });
+		expect(button).toHaveAttribute('aria-invalid', 'false');
+	});
+
+	it('does not set aria-invalid on the trigger button when ariaInvalid is not passed', () => {
+		const { button } = renderDatePicker();
+		expect(button).not.toHaveAttribute('aria-invalid');
+	});
+});

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -12,6 +12,7 @@
 	type Category = { id: string; name: string };
 
 	let {
+		ariaInvalid,
 		ariaLabel,
 		ariaLabelTrigger,
 		categories,
@@ -27,6 +28,7 @@
 		textNotFound = m.select_category_not_found(),
 		value = $bindable('')
 	}: {
+		ariaInvalid?: boolean;
 		ariaLabel?: string;
 		ariaLabelTrigger?: string;
 		categories: Category[];
@@ -101,9 +103,14 @@
 	onOpenChange={handleOpenChange}
 	inputValue={displayValue}
 >
-	<div bind:this={containerRef} class={cn(inputVariants({ variant: 'container' }), className)}>
+	<div
+		bind:this={containerRef}
+		class={cn(inputVariants({ variant: 'container' }), className)}
+		aria-invalid={ariaInvalid}
+	>
 		<Combobox.Input
 			{...inputProps}
+			aria-invalid={ariaInvalid}
 			aria-label={ariaLabel}
 			class="h-full flex-1 border-0 bg-transparent px-2 py-1 outline-none placeholder:text-muted"
 			{placeholder}

--- a/src/lib/components/ui/select-category/select-category.svelte.test.ts
+++ b/src/lib/components/ui/select-category/select-category.svelte.test.ts
@@ -214,3 +214,23 @@ describe('SelectCategory — deselection', () => {
 		expect(formData.get('categoryId')).toBe('c2');
 	});
 });
+
+describe('SelectCategory — aria-invalid contract', () => {
+	it('sets aria-invalid on the combobox input when ariaInvalid is true', () => {
+		renderSelectCategory({ ariaInvalid: true });
+		const input = screen.getByRole<HTMLInputElement>('combobox', { name: 'Category' });
+		expect(input).toHaveAttribute('aria-invalid', 'true');
+	});
+
+	it('sets aria-invalid to false on the combobox input when ariaInvalid is false', () => {
+		renderSelectCategory({ ariaInvalid: false });
+		const input = screen.getByRole<HTMLInputElement>('combobox', { name: 'Category' });
+		expect(input).toHaveAttribute('aria-invalid', 'false');
+	});
+
+	it('does not set aria-invalid on the combobox input when ariaInvalid is not passed', () => {
+		renderSelectCategory();
+		const input = screen.getByRole<HTMLInputElement>('combobox', { name: 'Category' });
+		expect(input).not.toHaveAttribute('aria-invalid');
+	});
+});

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
@@ -68,6 +68,7 @@
 						(v) => scopedForm.fields.amount.set(v)
 					}
 					{currency}
+					aria-invalid={scopedForm.fields.amount.issues()?.length ? true : undefined}
 					class="h-full w-full rounded-none px-2 text-right font-currency ring-0 outline-none"
 					aria-label={m.budget_monthly_table_header_amount()}
 					selectOnFocus

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -105,6 +105,7 @@
 		}
 		categories={otherCategories}
 		nullable
+		ariaInvalid={form.fields.targetCategoryId.issues()?.length ? true : undefined}
 		textEmpty={m.transfer_assignment_unassigned()}
 		ariaLabel={m.transfer_assignment_category()}
 		ariaLabelTrigger={m.transfer_assignment_select_category()}

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-row-create.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-row-create.svelte
@@ -97,6 +97,7 @@
 					}
 					{categories}
 					nullable
+					ariaInvalid={createTransaction.fields.categoryId.issues()?.length ? true : undefined}
 					ariaLabel={m.transactions_table_header_category()}
 					ariaLabelTrigger={m.select_category_open()}
 				/>
@@ -116,6 +117,7 @@
 						},
 						(v) => createTransaction.fields.date.set(v.toString())
 					}
+					ariaInvalid={createTransaction.fields.date.issues()?.length ? true : undefined}
 					class="justify-end"
 					label={m.transaction_table_cell_date_select()}
 				/>

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-row-edit.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/table-row-edit.svelte
@@ -70,6 +70,7 @@
 			bind:value={() => form.fields.categoryId.value() ?? '', (v) => form.fields.categoryId.set(v)}
 			{categories}
 			nullable
+			ariaInvalid={form.fields.categoryId.issues()?.length ? true : undefined}
 			ariaLabel={m.transactions_table_header_category()}
 			ariaLabelTrigger={m.select_category_open()}
 		/>
@@ -90,6 +91,7 @@
 				() => parseDate(form.fields.date.value() ?? transaction.date),
 				(v) => form.fields.date.set(v.toString())
 			}
+			ariaInvalid={form.fields.date.issues()?.length ? true : undefined}
 			class="justify-end"
 			label={m.transaction_table_cell_date_select()}
 		/>

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/category-edit.svelte
@@ -81,6 +81,7 @@
 				(v) => editCategory.fields.targetBalance.set(v)
 			}
 			{currency}
+			aria-invalid={editCategory.fields.targetBalance.issues()?.length ? true : undefined}
 			class="h-12 text-center text-xl font-semibold placeholder:text-base placeholder:font-normal"
 			placeholder={formatMoney({ currency, money: asMoney(0) })}
 			aria-label={m.category_label_targetbalance()}


### PR DESCRIPTION
Closes #27

## Problem

SelectCategory and DatePicker had no `aria-invalid` support — validation errors showed no visual or screen-reader feedback on those controls. Call sites had no way to signal invalidity even though the field state was available.

## Solution

- **SelectCategory** — new `ariaInvalid` prop forwarded to `Combobox.Input` (screen readers) and container `div` (error border via shared `inputVariants`)
- **DatePicker** — new `ariaInvalid` prop forwarded to trigger `Button` (error border via Button's existing `aria-invalid:border-error` variant)
- **5 call sites** wired with `field.issues()?.length` signal
- **Component tests** pin the attribute placement on the focusable element
- **Docs** — one convention line in `docs/components.md`

## Verification

- `npm run test:unit` — 266 tests pass
- `npm run lint` — clean
- Typechecking — no new errors