### PR TITLE
docs: define lifecycle for route-local module extraction (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,6 @@ Persistent agent and workflow rules for this repository.
 
 ## Ground Rules
 
-- No automatic staging, committing, or pushing. Commits only on explicit instruction.
 - Match existing code conventions. No drive-by refactors, renames, or reformatting.
 - Verify with real tool output — never fabricate file contents, API responses, or test results.
 - Keep codebase files in English.

--- a/docs/components.md
+++ b/docs/components.md
@@ -13,3 +13,18 @@
 - No hardcoded feature copy in shared UI primitives. Pass labels from callers, localize with Paraglide.
 - Match existing Svelte 5 runes and snippet-based composition patterns in touched components.
 - Prefer `<Name>Icon` imports in touched feature code.
+
+## Route-local module extraction
+
+Route-local Svelte modules (components living under `src/routes/**`) follow an explicit lifecycle:
+
+- A route-local module graduates to `features/<domain>/` when at least one of these holds:
+  - it carries complex state logic (keyboard handling, form orchestration, multi-field sync),
+  - it is testable in isolation through its props/callbacks interface,
+  - it is reused across routes.
+- A module stays in the route when it is tightly coupled to page data, has a single call-site, and carries no independent state logic. Trivial state like a single `let open = $state(false)` toggle does not trigger extraction.
+- Extraction is reactive: apply the rule when you next touch a route-local module for other work. There is no one-time audit of existing route-local modules.
+- Promoted modules keep their filename and land in `features/<domain>/<name>.svelte`, where `<domain>` reflects the feature domain, not the route they came from (e.g. `table-row-create.svelte` from the accounts route lives in `features/transaction/`).
+- Companion files (local `utils.ts`, sibling components) move with the promoted module only when they are used exclusively by it; otherwise they stay in the route or are extracted separately.
+- Tests follow the extracted module: `features/<domain>/<name>.test.ts`, exercising state logic through the public interface (props in, events/callbacks out) — no implementation details, no DOM mocking.
+- This rule is a documented convention, not a gate: there is no ESLint or build enforcement.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -4,7 +4,7 @@
 - Prefer redirects over duplicated routing logic. The app root already redirects logged-in users into the correct budget and month route.
 - Respect matcher-based params such as `[budgetId=id]` and `[month=month]` when adding routes, links, or helpers.
 - Keep page-specific UI near the route. Large table rows, filters, navigators, and detail widgets used only by one route stay under that route folder.
-- Move a component into `src/lib/components` only when reuse is real across multiple features.
+- When touching a route-local module, apply the extraction rule in `docs/components.md` ("Route-local module extraction") to decide whether it graduates to `src/lib/components/features/<domain>/` or stays in the route.
 - Keep server-only logic out of `.svelte` files. Database writes, auth checks, and permission checks go through remote functions or server modules.
 - Match existing Svelte 5 runes patterns: `$props()`, `$derived(...)`, `$state(...)`, `$effect(...)`.
 - Prefer async-derived remote data in components: `const foo = $derived(await getFoo(...))`.


### PR DESCRIPTION
Closes #30.

## What

Documents the extraction lifecycle for route-local Svelte modules:

- New "Route-local module extraction" section in `docs/components.md`: graduation criteria (complex state logic, isolation-testable, cross-route reuse), stay criteria, reactive timing, naming (`features/<domain>/<name>.svelte` keyed by feature domain, not source route), companion-file handling, test placement, and the convention-not-gate stance.
- `docs/routes.md` now points to that rule, replacing the outdated "only when reuse is real" guidance.
- Drops the no-automatic-commit ground rule from `CLAUDE.md` (separate commit, requested alongside).

## Why

The structural prerequisites from #30 already landed: #34 introduced the `features/`/`ui/` tier split and #41 extracted `table-row-create.svelte` into `features/transaction/` with component tests. This PR completes the issue with the documented rule so future extraction decisions can point to it instead of being re-litigated per PR.

## Verification

Docs-only change; `npm run lint` (prettier + eslint) passes. /code-review ran clean on both the Standards and Spec axes.