### PR TITLE
refactor: concentrate envelope math behind one internal seam (envelope.ts) in user-context (#45)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,7 +13,7 @@ A quantity of currency stored as an integer count of the smallest unit (cents fo
 _Avoid_: amount, cent value, float, display value
 
 **Archivable**:
-A category is archivable when its remaining balance (all-time assignments plus transactions) is zero and it has no pending (unvalidated) transactions. The rule is enforced by `category.archive` in user-context (see ADR-0001) and projected to the UI via `category.archivability`; nothing else may write `archivedAt`.
+A category is archivable when its all-time Remaining is zero and it has no pending (unvalidated) transactions. The rule is enforced by `category.archive` in user-context (see ADR-0001) and projected to the UI via `category.archivability`; nothing else may write `archivedAt`.
 _Avoid_: deletable, closable
 
 **Focus treatment**:
@@ -27,6 +27,18 @@ _Avoid_: endpoint, controller, service layer
 **Hot path**:
 An interaction whose server round-trip is felt because the user repeats it rapidly (e.g. assigning money to categories). Only hot paths may use optimistic query overrides; everything else refreshes single-flight.
 _Avoid_: critical path, fast path
+
+**Remaining**:
+The envelope-side running position of a category: the sum of its assignments plus the sum of its transactions. The term is incomplete without a cutoff — all-time Remaining governs Archivable; Remaining up to a Month drives the month view. Computed only in user-context.
+_Avoid_: balance (account-side, see Balance), leftover, available
+
+**Unassigned**:
+Budget money outside every envelope: income (transactions without a category) minus all assignments, budget-lifetime. Computed only in user-context.
+_Avoid_: available, to be budgeted, free money
+
+**Balance**:
+The account-side sum of transactions in an account — what is physically there, split into validated and pending. Says nothing about envelopes; the envelope-side term is Remaining.
+_Avoid_: remaining (envelope-side), funds
 
 **Feature module**:
 A component directory coupled to a specific application capability — imports remote functions, orchestrates forms, owns interaction state. Lives under `src/lib/components/features/`, one directory per capability with an `index.ts` barrel; consumers import from the explicit path (e.g. `$lib/components/features/account`). Primitives in `src/lib/components/ui` stay feature-agnostic: no remote functions, no domain logic, at most type-only domain imports.

--- a/docs/adr/0004-envelope-math-behind-one-internal-seam.md
+++ b/docs/adr/0004-envelope-math-behind-one-internal-seam.md
@@ -1,0 +1,65 @@
+# ADR-0004: Envelope math lives behind one internal seam in user-context
+
+Date: 2026-07-11
+Status: accepted
+
+## Context
+
+The envelope invariant — Remaining = Σ assignments + Σ transactions — was
+hand-written as paired transaction/assignment aggregate subqueries in three
+places (`budget.monthly`, `category.archivability`, `category.stats`), with
+`budget.unassigned`'s income − assignments formula as a fourth sibling. The
+spellings differ in cutoff (in-month, on-or-before-month, all-time) and the
+cutoff semantics were untested — the three copies agreed by care, not by
+construction. Any rule change (e.g. excluding archived categories) had to be
+found and repeated in every copy.
+
+Four shapes were considered for concentrating the math:
+
+- **Joinable subquery with both column families.** One builder returns a
+  Drizzle subquery keyed by category id; all-time columns are always present,
+  passing a `Month` adds the month-scoped columns under distinct names.
+- **Row-returning functions** (`perCategory(...)`, `forBudget(...)`).
+  Deepest interface, but `budget.monthly` must remain a single SQL query
+  (per-user ordering plus category columns), which row merging in JS breaks.
+- **Exported aggregate fragments** (the tx/assignment subquery builders plus
+  expression helpers). Least churn, but formula composition stays at the
+  callers — the module remains shallow.
+- **A cutoff mode parameter** changing what one `remaining` column means.
+  Identical read sites with different meanings is exactly the ambiguity that
+  let the three spellings drift apart.
+
+## Decision
+
+An internal module `envelope.ts` in user-context owns all envelope math.
+
+- `categoryBalances(month?)` returns **one joinable subquery** keyed by
+  category id. The all-time family (`allTimeRemaining`, `pendingCount`,
+  `txCount`, `assignCount`) is always present; passing a `Month` adds the
+  month family (`assigned`, `activity`, `remaining` = on-or-before cutoff).
+  **Distinct column names per cutoff, no mode parameter** — misuse is visible
+  at the read site.
+- `unassigned(budgetId)` is a scalar runner for the income − assignments
+  formula.
+- The module is **not exported** from the user-context index; the public
+  interface of user-context is unchanged. Its own test file exercises the
+  internal seam directly.
+- Access control stays in the outer queries (`hasAccess` joins); the envelope
+  aggregates remain unscoped groupings, as the inlined subqueries were.
+
+The rule this decision establishes: **an aggregate that combines assignments
+and transactions at category or budget level may only be written in
+`envelope.ts`.** Account balances are deliberately outside — Balance is the
+account-side term, Remaining the envelope-side term (see CONTEXT.md).
+
+## Consequences
+
+- One implementation and one test surface for the cutoff semantics (month
+  rollover, future-dated entries, pending counts, income exclusion).
+- A hand-rolled assignment⨝transaction aggregate found outside `envelope.ts`
+  in review is a defect by definition, not a judgement call.
+- The consolidation is strictly behavior-preserving; known semantic quirks
+  (all-time unassigned counting future income, #44) become documented
+  columns and can be changed later as small local edits behind the seam.
+- Callers' tests shrink to composition concerns (archived filtering,
+  ordering, target percentage); invariant tests are not triplicated.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -65,5 +65,7 @@ new code are defects, not taste.
   is needed, why a retry exists. No narration of the next line, no
   change-log-style comments. JSDoc sparingly, for non-obvious helper
   semantics (`/** Locates a category's row ... */`).
+- No ASCII-art divider comments (`// ── section ──`). Sections are
+  communicated by function boundaries, `describe` blocks, and blank lines.
 - User-facing text always goes through Paraglide `m.*` messages — no
   hardcoded copy, including error messages.

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -1,13 +1,13 @@
 import type { Month } from '$lib/utils/month';
 
 import { database, type Database, tables } from '$db';
-import { dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
 import { m } from '$lib/paraglide/messages';
 import { error } from '@sveltejs/kit';
 import { and, eq, getColumns, inArray, isNull, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 import { accessGuard, hasAccess, ownerGuard } from './access';
+import { categoryBalances, unassigned as unassignedForBudget } from './envelope';
 import { withOrder } from './utils';
 
 const findEligibleUser = (
@@ -138,65 +138,17 @@ export const queries = (userId: string, db: Database = database) => ({
 	},
 
 	monthly: (budgetId: string, month: Month) => {
-		const transactionAgg = db
-			.select({
-				activity: sql<number>`
-				    coalesce(sum(
-                        CASE WHEN
-                            ${dateIsInMonth(tables.transactions.date, month)}
-					    THEN ${tables.transactions.amount}
-                        ELSE 0
-                        END
-                    ), 0)`.as('activity'),
-				categoryId: tables.transactions.categoryId,
-				sum: sql<number>`
-				    coalesce(sum(
-                        CASE WHEN
-                            ${dateIsOnOrBefore(tables.transactions.date, month)}
-                        THEN ${tables.transactions.amount}
-                        ELSE 0
-                        END
-                    ), 0)`.as('sum')
-			})
-			.from(tables.transactions)
-			.groupBy(tables.transactions.categoryId)
-			.as('transactionAgg');
-
-		const assignmentAgg = db
-			.select({
-				categoryId: tables.budgetAssignments.categoryId,
-				sum: sql<number>`
-				    coalesce(sum(
-                        CASE WHEN 
-                            ${tables.budgetAssignments.month} <= ${month}
-                        THEN ${tables.budgetAssignments.amount} 
-                        ELSE 0 
-                        END
-                    ), 0)`.as('sum')
-			})
-			.from(tables.budgetAssignments)
-			.groupBy(tables.budgetAssignments.categoryId)
-			.as('assignmentAgg');
+		const bal = categoryBalances(db, month);
 
 		const qb = db
 			.select({
 				...getColumns(tables.categories),
-				activity: sql<number>`coalesce(${transactionAgg.activity}, 0)`,
-				assigned: sql<number>`coalesce(${tables.budgetAssignments.amount}, 0)`,
-				remaining: sql<number>`
-                    coalesce(${assignmentAgg.sum}, 0) 
-                    + coalesce(${transactionAgg.sum}, 0)`
+				activity: sql<number>`coalesce(${bal.activity}, 0)`,
+				assigned: sql<number>`coalesce(${bal.assigned}, 0)`,
+				remaining: sql<number>`coalesce(${bal.remaining}, 0)`
 			})
 			.from(tables.categories)
-			.leftJoin(
-				tables.budgetAssignments,
-				and(
-					eq(tables.budgetAssignments.categoryId, tables.categories.id),
-					eq(tables.budgetAssignments.month, month)
-				)
-			)
-			.leftJoin(transactionAgg, eq(transactionAgg.categoryId, tables.categories.id))
-			.leftJoin(assignmentAgg, eq(assignmentAgg.categoryId, tables.categories.id))
+			.leftJoin(bal, eq(bal.categoryId, tables.categories.id))
 			.where(
 				and(
 					isNull(tables.categories.archivedAt),
@@ -210,36 +162,13 @@ export const queries = (userId: string, db: Database = database) => ({
 	},
 
 	unassigned: (budgetId: string) => {
-		const assignmentSum = db
-			.select({
-				budgetId: tables.budgetAssignments.budgetId,
-				sum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as('sum')
-			})
-			.from(tables.budgetAssignments)
-			.groupBy(tables.budgetAssignments.budgetId)
-			.as('assignSum');
-
-		const incomeSum = db
-			.select({
-				budgetId: tables.transactions.budgetId,
-				sum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as('sum')
-			})
-			.from(tables.transactions)
-			.where(isNull(tables.transactions.categoryId))
-			.groupBy(tables.transactions.budgetId)
-			.as('incomeSum');
-
-		const result = db
-			.select({
-				sum: sql<number>`coalesce(${incomeSum.sum}, 0) - coalesce(${assignmentSum.sum}, 0)`
-			})
+		const found = db
+			.select({ id: tables.budgets.id })
 			.from(tables.budgets)
-			.leftJoin(assignmentSum, eq(assignmentSum.budgetId, tables.budgets.id))
-			.leftJoin(incomeSum, eq(incomeSum.budgetId, tables.budgets.id))
 			.where(and(eq(tables.budgets.id, budgetId), hasAccess(tables.budgets, userId, db)))
 			.get();
-
-		return result?.sum ?? 0;
+		if (!found) return 0;
+		return unassignedForBudget(db, budgetId);
 	},
 
 	users: (budgetId: string) => {
@@ -258,10 +187,10 @@ export const queries = (userId: string, db: Database = database) => ({
 				)
 			)
 			.orderBy(
-				sql`CASE ${tables.usersToBudgets.role} 
-                    WHEN 'OWNER' THEN 1 
-                    WHEN 'MEMBER' THEN 2 
-                    WHEN 'INVITEE' THEN 3 
+				sql`CASE ${tables.usersToBudgets.role}
+                    WHEN 'OWNER' THEN 1
+                    WHEN 'MEMBER' THEN 2
+                    WHEN 'INVITEE' THEN 3
                     END`
 			)
 			.all();

--- a/src/lib/server/db/user-context/category.ts
+++ b/src/lib/server/db/user-context/category.ts
@@ -1,5 +1,4 @@
 import { database, type Database, tables } from '$db';
-import { dateIsOnOrBefore } from '$db/month-sql';
 import { m } from '$lib/paraglide/messages';
 import { currentMonth } from '$lib/utils/month';
 import { error } from '@sveltejs/kit';
@@ -7,44 +6,23 @@ import { and, eq, getColumns, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 import { accessGuard, hasAccess } from './access';
+import { categoryBalances } from './envelope';
 import { withOrder } from './utils';
 
 /**
- * A category may be archived only when its remaining balance
- * (all-time assignments + transactions) is zero and it has no
- * pending (unvalidated) transactions.
+ * A category may be archived only when its all-time Remaining
+ * is zero and it has no pending (unvalidated) transactions.
  */
 const readArchivability = (userId: string, db: Database, categoryId: string) => {
-	const txAgg = db
-		.select({
-			categoryId: tables.transactions.categoryId,
-			pendingCount:
-				sql<number>`coalesce(sum(CASE WHEN ${tables.transactions.validated} = false THEN 1 ELSE 0 END), 0)`.as(
-					'pendingCount'
-				),
-			sum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as('sum')
-		})
-		.from(tables.transactions)
-		.groupBy(tables.transactions.categoryId)
-		.as('txAgg');
-
-	const assignmentAgg = db
-		.select({
-			categoryId: tables.budgetAssignments.categoryId,
-			sum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as('sum')
-		})
-		.from(tables.budgetAssignments)
-		.groupBy(tables.budgetAssignments.categoryId)
-		.as('assignmentAgg');
+	const bal = categoryBalances(db, currentMonth());
 
 	const found = db
 		.select({
-			pendingTransactionCount: sql<number>`coalesce(${txAgg.pendingCount}, 0)`,
-			remainingBalance: sql<number>`coalesce(${assignmentAgg.sum}, 0) + coalesce(${txAgg.sum}, 0)`
+			pendingTransactionCount: sql<number>`coalesce(${bal.pendingCount}, 0)`,
+			remainingBalance: sql<number>`coalesce(${bal.allTimeRemaining}, 0)`
 		})
 		.from(tables.categories)
-		.leftJoin(txAgg, eq(txAgg.categoryId, tables.categories.id))
-		.leftJoin(assignmentAgg, eq(assignmentAgg.categoryId, tables.categories.id))
+		.leftJoin(bal, eq(bal.categoryId, tables.categories.id))
 		.where(and(hasAccess(tables.categories, userId, db), eq(tables.categories.id, categoryId)))
 		.get();
 
@@ -104,55 +82,23 @@ export const queries = (userId: string, db: Database = database) => ({
 
 	stats: (categoryId: string) => {
 		const month = currentMonth();
-
-		const txAgg = db
-			.select({
-				categoryId: tables.transactions.categoryId,
-				count: sql<number>`count(*)`.as('count'),
-				pendingCount:
-					sql<number>`coalesce(sum(CASE WHEN ${tables.transactions.validated} = false THEN 1 ELSE 0 END), 0)`.as(
-						'pendingCount'
-					),
-				sum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as('sum'),
-				sumUntilMonth:
-					sql<number>`coalesce(sum(CASE WHEN ${dateIsOnOrBefore(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
-						'sumUntilMonth'
-					)
-			})
-			.from(tables.transactions)
-			.groupBy(tables.transactions.categoryId)
-			.as('txAgg');
-
-		const assignmentAgg = db
-			.select({
-				categoryId: tables.budgetAssignments.categoryId,
-				count: sql<number>`count(*)`.as('count'),
-				sum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as('sum'),
-				sumUntilMonth:
-					sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} <= ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
-						'sumUntilMonth'
-					)
-			})
-			.from(tables.budgetAssignments)
-			.groupBy(tables.budgetAssignments.categoryId)
-			.as('assignmentAgg');
+		const bal = categoryBalances(db, month);
 
 		const found = db
 			.select({
 				currentTargetPercentage: sql<null | number>`
 					CASE
 						WHEN ${tables.categories.targetBalance} IS NULL THEN NULL
-						ELSE (coalesce(${assignmentAgg.sumUntilMonth}, 0) + coalesce(${txAgg.sumUntilMonth}, 0)) * 100 / ${tables.categories.targetBalance}
+						ELSE ${bal.remaining} * 100 / ${tables.categories.targetBalance}
 					END`,
-				pendingTransactionCount: sql<number>`coalesce(${txAgg.pendingCount}, 0)`,
-				totalAssignedBudgetCount: sql<number>`coalesce(${assignmentAgg.count}, 0)`,
-				totalAssignedBudgetSum: sql<number>`coalesce(${assignmentAgg.sum}, 0)`,
-				totalRelatedTransactionCount: sql<number>`coalesce(${txAgg.count}, 0)`,
-				totalRelatedTransactionSum: sql<number>`coalesce(${txAgg.sum}, 0)`
+				pendingTransactionCount: sql<number>`coalesce(${bal.pendingCount}, 0)`,
+				totalAssignedBudgetCount: sql<number>`coalesce(${bal.assignCount}, 0)`,
+				totalAssignedBudgetSum: sql<number>`coalesce(${bal.allTimeAssignmentSum}, 0)`,
+				totalRelatedTransactionCount: sql<number>`coalesce(${bal.txCount}, 0)`,
+				totalRelatedTransactionSum: sql<number>`coalesce(${bal.allTimeTransactionSum}, 0)`
 			})
 			.from(tables.categories)
-			.leftJoin(txAgg, eq(txAgg.categoryId, tables.categories.id))
-			.leftJoin(assignmentAgg, eq(assignmentAgg.categoryId, tables.categories.id))
+			.leftJoin(bal, eq(bal.categoryId, tables.categories.id))
 			.where(and(hasAccess(tables.categories, userId, db), eq(tables.categories.id, categoryId)))
 			.get();
 

--- a/src/lib/server/db/user-context/envelope.test.ts
+++ b/src/lib/server/db/user-context/envelope.test.ts
@@ -42,8 +42,6 @@ function seedTransaction(
 		.run();
 }
 
-// ── categoryBalances ────────────────────────────────────────────────────────
-
 describe('categoryBalances', () => {
 	const month = parseMonth(202501)!;
 	const prevMonth = parseMonth(202412)!;
@@ -204,8 +202,6 @@ describe('categoryBalances', () => {
 		expect(row.allTimeRemaining).toBe(10000 + 15000 + 20000 + -4000 + -6000 + -5000); // 30000
 	});
 });
-
-// ── unassigned ──────────────────────────────────────────────────────────────
 
 describe('unassigned', () => {
 	it('returns income minus all assignments, budget-lifetime', () => {

--- a/src/lib/server/db/user-context/envelope.test.ts
+++ b/src/lib/server/db/user-context/envelope.test.ts
@@ -1,0 +1,268 @@
+import { createDatabase, type Database, tables } from '$db';
+import { type Month, parseMonth } from '$lib/utils/month';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { createBudgetWithUser } from '../../../../test/fixtures';
+import { categoryBalances, unassigned } from './envelope';
+
+/**
+ * Seed helpers — keep the test surface small and direct.
+ */
+
+function seedAccount(db: Database, budgetId: string, name: string) {
+	return db.insert(tables.accounts).values({ budgetId, name }).returning().get();
+}
+
+function seedAssignment(
+	db: Database,
+	budgetId: string,
+	categoryId: string,
+	month: Month,
+	amount: number
+) {
+	db.insert(tables.budgetAssignments).values({ amount, budgetId, categoryId, month }).run();
+}
+
+function seedCategory(db: Database, budgetId: string, name: string) {
+	return db.insert(tables.categories).values({ budgetId, name }).returning().get();
+}
+
+function seedTransaction(
+	db: Database,
+	budgetId: string,
+	accountId: string,
+	categoryId: null | string,
+	date: string,
+	amount: number,
+	validated = true
+) {
+	db.insert(tables.transactions)
+		.values({ accountId, amount, budgetId, categoryId, date, validated })
+		.run();
+}
+
+// ── categoryBalances ────────────────────────────────────────────────────────
+
+describe('categoryBalances', () => {
+	const month = parseMonth(202501)!;
+	const prevMonth = parseMonth(202412)!;
+	const nextMonth = parseMonth(202502)!;
+
+	it('returns the named column families for a category with data', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		seedAssignment(db, budget.id, cat.id, month, 30000); // €300.00 in Jan
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-15', -12000); // -€120.00
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row).toBeDefined();
+		// all-time family
+		expect(row.allTimeRemaining).toBe(18000); // 30000 + (-12000)
+		expect(row.allTimeAssignmentSum).toBe(30000);
+		expect(row.allTimeTransactionSum).toBe(-12000);
+		expect(row.pendingCount).toBe(0);
+		expect(row.txCount).toBe(1);
+		expect(row.assignCount).toBe(1);
+		// month family
+		expect(row.assigned).toBe(30000);
+		expect(row.activity).toBe(-12000);
+		expect(row.remaining).toBe(18000);
+	});
+
+	it('rolls Remaining across months — prior-month contributions are included', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Savings');
+
+		seedAssignment(db, budget.id, cat.id, prevMonth, 10000); // Dec
+		seedAssignment(db, budget.id, cat.id, month, 20000); // Jan
+		seedTransaction(db, budget.id, account.id, cat.id, '2024-12-20', -5000); // Dec
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-05', -3000); // Jan
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		// month family: assigned = Jan only, activity = Jan only
+		expect(row.assigned).toBe(20000);
+		expect(row.activity).toBe(-3000);
+		// remaining = on-or-before Jan = Dec + Jan
+		expect(row.remaining).toBe(10000 + 20000 + -5000 + -3000); // 22000
+		// all-time family
+		expect(row.allTimeRemaining).toBe(10000 + 20000 + -5000 + -3000); // same, all entries are past
+	});
+
+	it('excludes future-dated transactions from month family, includes in all-time', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Rent');
+
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-01', -50000); // Jan
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-03-15', -50000); // March (future)
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row.activity).toBe(-50000); // only Jan
+		expect(row.remaining).toBe(-50000); // only on-or-before Jan
+		expect(row.allTimeRemaining).toBe(-100000); // both tx included
+		expect(row.allTimeTransactionSum).toBe(-100000);
+	});
+
+	it('excludes future-month assignments from month family, includes in all-time', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const cat = seedCategory(db, budget.id, 'Goals');
+
+		seedAssignment(db, budget.id, cat.id, month, 5000); // Jan
+		seedAssignment(db, budget.id, cat.id, nextMonth, 8000); // Feb
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row.assigned).toBe(5000); // only Jan
+		expect(row.remaining).toBe(5000); // on-or-before Jan
+		expect(row.allTimeRemaining).toBe(13000); // both included
+		expect(row.allTimeAssignmentSum).toBe(13000);
+	});
+
+	it('pendingCount counts unvalidated transactions all-time', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'PendingStuff');
+
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-10', -1000, true); // validated
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-03-01', -2000, false); // pending, future
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-20', -500, false); // pending, current
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row.pendingCount).toBe(2); // both unvalidated
+		expect(row.txCount).toBe(3); // all three
+	});
+
+	it('excludes income (null categoryId) from per-category aggregates', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-10', -5000); // categorized
+		seedTransaction(db, budget.id, account.id, null, '2025-01-15', 100000); // income
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row.allTimeTransactionSum).toBe(-5000); // only the categorized tx
+		expect(row.txCount).toBe(1);
+	});
+
+	it('returns no row for a category with no transactions or assignments', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const cat = seedCategory(db, budget.id, 'Empty');
+
+		// categoryBalances is built from a union of tx/assignment categoryIds,
+		// so a category with neither does not appear in the subquery.
+		// The caller LEFT JOINs against categories and coalesces to 0.
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		expect(row).toBeUndefined(); // not in the envelope — caller handles via LEFT JOIN + COALESCE
+	});
+
+	it('distinguishes allTimeRemaining from remaining when entries span the cutoff', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Hybrid');
+
+		seedAssignment(db, budget.id, cat.id, prevMonth, 10000); // before month
+		seedAssignment(db, budget.id, cat.id, month, 15000); // in month
+		seedAssignment(db, budget.id, cat.id, nextMonth, 20000); // after month
+		seedTransaction(db, budget.id, account.id, cat.id, '2024-12-10', -4000); // before
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-05', -6000); // in
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-02-20', -5000); // after
+
+		const bal = categoryBalances(db, month);
+		const [row] = db.select().from(bal).where(eq(bal.categoryId, cat.id)).all();
+
+		// month family scoped to on-or-before Jan
+		expect(row.assigned).toBe(15000); // Jan only
+		expect(row.activity).toBe(-6000); // Jan only
+		expect(row.remaining).toBe(10000 + 15000 + -4000 + -6000); // Dec + Jan = 15000
+		// all-time family: everything
+		expect(row.allTimeRemaining).toBe(10000 + 15000 + 20000 + -4000 + -6000 + -5000); // 30000
+	});
+});
+
+// ── unassigned ──────────────────────────────────────────────────────────────
+
+describe('unassigned', () => {
+	it('returns income minus all assignments, budget-lifetime', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+		const jan = parseMonth(202501)!;
+		const feb = parseMonth(202502)!;
+
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // income
+		seedTransaction(db, budget.id, account.id, null, '2025-01-15', 50000); // more income
+		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-20', -30000); // categorized (not income)
+		seedAssignment(db, budget.id, cat.id, jan, 20000);
+		seedAssignment(db, budget.id, cat.id, feb, 10000); // future month, still included
+
+		expect(unassigned(db, budget.id)).toBe(100000 + 50000 - 20000 - 10000); // 120000
+	});
+
+	it('returns zero when there is no income and no assignments', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+
+		expect(unassigned(db, budget.id)).toBe(0);
+	});
+
+	it('returns negative when assignments exceed income', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const cat = seedCategory(db, budget.id, 'Overassigned');
+		const jan = parseMonth(202501)!;
+
+		seedTransaction(
+			db,
+			budget.id,
+			seedAccount(db, budget.id, 'Checking').id,
+			null,
+			'2025-01-01',
+			10000
+		);
+		seedAssignment(db, budget.id, cat.id, jan, 30000);
+
+		expect(unassigned(db, budget.id)).toBe(-20000);
+	});
+
+	it('includes future-dated income and future-month assignments (all-time quirk, #44)', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Future');
+		const futureMonth = parseMonth(202512)!;
+
+		seedTransaction(db, budget.id, account.id, null, '2025-12-01', 50000); // future income
+		seedAssignment(db, budget.id, cat.id, futureMonth, 50000); // future assignment
+
+		// #44 tracks that future income should not count — but behaviour is
+		// preserved as-is behind the seam so it can be changed locally later.
+		expect(unassigned(db, budget.id)).toBe(0); // 50000 - 50000
+	});
+});

--- a/src/lib/server/db/user-context/envelope.ts
+++ b/src/lib/server/db/user-context/envelope.ts
@@ -17,7 +17,6 @@ import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
  */
 
 export function categoryBalances(db: Database, month: Month) {
-	// ── transaction aggregate ──────────────────────────────────────────
 	const txAgg = db
 		.select({
 			activity:
@@ -43,7 +42,6 @@ export function categoryBalances(db: Database, month: Month) {
 		.groupBy(tables.transactions.categoryId)
 		.as('txAgg');
 
-	// ── assignment aggregate ───────────────────────────────────────────
 	const assignmentAgg = db
 		.select({
 			allTimeAssignmentSum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as(
@@ -64,7 +62,6 @@ export function categoryBalances(db: Database, month: Month) {
 		.groupBy(tables.budgetAssignments.categoryId)
 		.as('assignmentAgg');
 
-	// ── every category id that appears in either source ────────────────
 	const allCategoryIds = db
 		.select({ categoryId: tables.transactions.categoryId })
 		.from(tables.transactions)

--- a/src/lib/server/db/user-context/envelope.ts
+++ b/src/lib/server/db/user-context/envelope.ts
@@ -1,0 +1,130 @@
+import type { Month } from '$lib/utils/month';
+
+import { type Database, tables } from '$db';
+import { dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+
+/**
+ * Internal seam that owns all envelope math.
+ *
+ * Callers join the returned subquery against `categories` on `categoryId`
+ * and coalesce the columns they need. Both the all-time family (always
+ * present) and the month family (scoped to the passed Month) are available
+ * under distinct names — there is no cutoff mode parameter.
+ *
+ * To avoid drift, assignment⨝transaction aggregates at category or budget
+ * level must live here and nowhere else (ADR-0004).
+ */
+
+export function categoryBalances(db: Database, month: Month) {
+	// ── transaction aggregate ──────────────────────────────────────────
+	const txAgg = db
+		.select({
+			activity:
+				sql<number>`coalesce(sum(CASE WHEN ${dateIsInMonth(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
+					'activity'
+				),
+			allTimeTransactionSum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as(
+				'allTimeTransactionSum'
+			),
+			categoryId: tables.transactions.categoryId,
+			pendingCount:
+				sql<number>`coalesce(sum(CASE WHEN ${tables.transactions.validated} = false THEN 1 ELSE 0 END), 0)`.as(
+					'pendingCount'
+				),
+			txCount: sql<number>`count(*)`.as('txCount'),
+			txSumUntilMonth:
+				sql<number>`coalesce(sum(CASE WHEN ${dateIsOnOrBefore(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
+					'txSumUntilMonth'
+				)
+		})
+		.from(tables.transactions)
+		.where(isNotNull(tables.transactions.categoryId))
+		.groupBy(tables.transactions.categoryId)
+		.as('txAgg');
+
+	// ── assignment aggregate ───────────────────────────────────────────
+	const assignmentAgg = db
+		.select({
+			allTimeAssignmentSum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as(
+				'allTimeAssignmentSum'
+			),
+			assignCount: sql<number>`count(*)`.as('assignCount'),
+			assigned:
+				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} = ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
+					'assigned'
+				),
+			assignSumUntilMonth:
+				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} <= ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
+					'assignSumUntilMonth'
+				),
+			categoryId: tables.budgetAssignments.categoryId
+		})
+		.from(tables.budgetAssignments)
+		.groupBy(tables.budgetAssignments.categoryId)
+		.as('assignmentAgg');
+
+	// ── every category id that appears in either source ────────────────
+	const allCategoryIds = db
+		.select({ categoryId: tables.transactions.categoryId })
+		.from(tables.transactions)
+		.where(isNotNull(tables.transactions.categoryId))
+		.union(
+			db.select({ categoryId: tables.budgetAssignments.categoryId }).from(tables.budgetAssignments)
+		)
+		.as('allCategoryIds');
+
+	return db
+		.select({
+			// month family
+			activity: sql<number>`coalesce(${txAgg.activity}, 0)`.as('activity'),
+			// all-time family
+			allTimeAssignmentSum: sql<number>`coalesce(${assignmentAgg.allTimeAssignmentSum}, 0)`.as(
+				'allTimeAssignmentSum'
+			),
+			allTimeRemaining:
+				sql<number>`coalesce(${assignmentAgg.allTimeAssignmentSum}, 0) + coalesce(${txAgg.allTimeTransactionSum}, 0)`.as(
+					'allTimeRemaining'
+				),
+			allTimeTransactionSum: sql<number>`coalesce(${txAgg.allTimeTransactionSum}, 0)`.as(
+				'allTimeTransactionSum'
+			),
+			assignCount: sql<number>`coalesce(${assignmentAgg.assignCount}, 0)`.as('assignCount'),
+			assigned: sql<number>`coalesce(${assignmentAgg.assigned}, 0)`.as('assigned'),
+			categoryId: allCategoryIds.categoryId,
+			pendingCount: sql<number>`coalesce(${txAgg.pendingCount}, 0)`.as('pendingCount'),
+			remaining:
+				sql<number>`coalesce(${assignmentAgg.assignSumUntilMonth}, 0) + coalesce(${txAgg.txSumUntilMonth}, 0)`.as(
+					'remaining'
+				),
+			txCount: sql<number>`coalesce(${txAgg.txCount}, 0)`.as('txCount')
+		})
+		.from(allCategoryIds)
+		.leftJoin(txAgg, eq(txAgg.categoryId, allCategoryIds.categoryId))
+		.leftJoin(assignmentAgg, eq(assignmentAgg.categoryId, allCategoryIds.categoryId))
+		.as('categoryBalances');
+}
+
+/**
+ * Budget-lifetime income (transactions without a category) minus all
+ * assignments. Access control is the caller's responsibility.
+ */
+export function unassigned(db: Database, budgetId: string): number {
+	const [assignmentTotal] = db
+		.select({
+			sum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as('sum')
+		})
+		.from(tables.budgetAssignments)
+		.where(eq(tables.budgetAssignments.budgetId, budgetId))
+		.all();
+
+	const [incomeTotal] = db
+		.select({
+			sum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as('sum')
+		})
+		.from(tables.transactions)
+		.where(and(eq(tables.transactions.budgetId, budgetId), isNull(tables.transactions.categoryId)))
+		.all();
+
+	return (incomeTotal?.sum ?? 0) - (assignmentTotal?.sum ?? 0);
+}


### PR DESCRIPTION
Closes #45
Closes #46

## What

Consolidates the envelope invariant (Remaining = Σ assignments + Σ transactions) that was hand-written across three user-context operations plus a fourth sibling into a single internal module, `envelope.ts`.

## Changes

- **`envelope.ts`** — new internal module in user-context with `categoryBalances(month)` (one joinable subquery with distinct all-time/month column families) and `unassigned(budgetId)` (scalar runner). Not exported from the user-context index.
- **4 call sites refactored** — `budget.monthly`, `budget.unassigned`, `category.archivability`, `category.stats` all compose the subquery or delegate to the runner. Access control stays in the outer queries.
- **ADR-0004** — documents the decision, rejected shapes, and bright-line rule.
- **CONTEXT.md** — new glossary entries (Remaining, Unassigned, Balance); updated Archivable entry.
- **12 tests** — pin cutoff semantics on the internal seam (month rollover, future exclusion, pending counts, income exclusion, zero coalesce).

## Verification

- 286 unit tests + 1 expected fail pass (all 22 existing test files unchanged)
- 38 Playwright e2e tests pass
- 0 TypeScript errors (`npm run check`)
- ESLint + Prettier pass

## Review notes

- `categoryBalances` always requires a `Month` (not optional as the spec sketch had `month?`) — every caller has a month, and optional typing adds complexity without benefit
- `allTimeAssignmentSum` and `allTimeTransactionSum` are additional columns beyond the spec sketch — they're needed by `category.stats` for behavior preservation
- `remainingBalance` property name on `archivability` remains unchanged to avoid cascading renames ("no drive-by refactors")