### PR TITLE
fix: propagate 0 cents when InputCurrency is cleared

### DIFF
--- a/src/lib/components/features/account/account-create.svelte
+++ b/src/lib/components/features/account/account-create.svelte
@@ -29,7 +29,7 @@
 		{#snippet input(field)}
 			<InputCurrency
 				name={field.as('number').name}
-				bind:value={() => field.value() ?? 0, (v) => field.set(v)}
+				bind:value={() => field.value(), (v) => field.set(v)}
 				currency={budget.currency}
 				aria-invalid={field.issues()?.length ? true : undefined}
 			/>

--- a/src/lib/components/features/category/category-edit.svelte
+++ b/src/lib/components/features/category/category-edit.svelte
@@ -23,6 +23,10 @@
 
 	let savedIndicator = createSingletonToast();
 
+	$effect(() => {
+		editCategory.fields.targetBalance.set(category.targetBalance ?? 0);
+	});
+
 	const flyDuration = browser
 		? window.matchMedia('(prefers-reduced-motion: reduce)').matches
 			? 0
@@ -62,7 +66,7 @@
 		<InputGroup.InputCurrency
 			name={editCategory.fields.targetBalance.as('number').name}
 			bind:value={
-				() => editCategory.fields.targetBalance.value() ?? category.targetBalance ?? 0,
+				() => editCategory.fields.targetBalance.value(),
 				(v) => editCategory.fields.targetBalance.set(v)
 			}
 			{currency}

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -131,7 +131,7 @@
 					name={createTransaction.fields.amount.as('number').name}
 					aria-label="Amount"
 					bind:value={
-						() => createTransaction.fields.amount.value() ?? 0,
+						() => createTransaction.fields.amount.value(),
 						(v) => createTransaction.fields.amount.set(v)
 					}
 					currency={budget.currency}

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -43,6 +43,7 @@
 
 	onMount(() => {
 		form.fields.categoryId.set(transaction.categoryId ?? undefined);
+		form.fields.amount.set(transaction.amount);
 	});
 </script>
 
@@ -105,9 +106,7 @@
 		<InputCurrency
 			name={form.fields.amount.as('number').name}
 			aria-label={m.transactions_table_header_amount()}
-			bind:value={
-				() => form.fields.amount.value() ?? transaction.amount, (v) => form.fields.amount.set(v)
-			}
+			bind:value={() => form.fields.amount.value(), (v) => form.fields.amount.set(v)}
 			{currency}
 			class="px-2 text-right font-currency font-normal"
 		/>

--- a/src/lib/components/ui/input-currency/input-currency.svelte
+++ b/src/lib/components/ui/input-currency/input-currency.svelte
@@ -68,7 +68,7 @@
 		step,
 		suffix,
 		transformRawValue,
-		value = $bindable(null),
+		value = $bindable(),
 		...restProps
 	}: Props = $props();
 
@@ -81,9 +81,9 @@
 		return normalized === null ? '' : (normalized / 100).toFixed(2);
 	}
 
-	function floatToCents(floatValue: null | number): null | number {
+	function floatToCents(floatValue: null | number): number {
 		if (floatValue === null || floatValue === undefined || Number.isNaN(floatValue)) {
-			return null;
+			return 0;
 		}
 		return Math.round(floatValue * 100);
 	}

--- a/src/lib/components/ui/input-currency/input-currency.svelte.test.ts
+++ b/src/lib/components/ui/input-currency/input-currency.svelte.test.ts
@@ -66,6 +66,16 @@ describe('InputCurrency cent binding', () => {
 		expect(hidden.value).toBe('5678');
 	});
 
+	it('propagates 0 cents when the input is cleared', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedCurrencyInput({ value: 40000 });
+
+		await user.clear(input);
+		flushSync();
+
+		expect(hidden.value).toBe('0');
+	});
+
 	it('renders a cent value as a decimal amount for display', () => {
 		render(InputCurrency, {
 			props: {

--- a/src/lib/components/ui/input-group/input-group-input-currency.svelte
+++ b/src/lib/components/ui/input-group/input-group-input-currency.svelte
@@ -8,7 +8,7 @@
 	let {
 		class: className,
 		ref = $bindable(null),
-		value = $bindable(null),
+		value = $bindable(),
 		...props
 	}: ComponentProps<typeof InputCurrency> = $props();
 </script>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
@@ -64,8 +64,7 @@
 				<InputCurrency
 					name={scopedForm.fields.amount.as('number').name}
 					bind:value={
-						() => scopedForm.fields.amount.value() ?? category.assigned,
-						(v) => scopedForm.fields.amount.set(v)
+						() => scopedForm.fields.amount.value(), (v) => scopedForm.fields.amount.set(v)
 					}
 					{currency}
 					aria-invalid={scopedForm.fields.amount.issues()?.length ? true : undefined}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -130,7 +130,7 @@
 		<InputCurrency
 			name={form.fields.amount.as('number').name}
 			aria-label={m.transfer_assignment_amount()}
-			bind:value={() => form.fields.amount.value() ?? 0, (v) => form.fields.amount.set(v)}
+			bind:value={() => form.fields.amount.value(), (v) => form.fields.amount.set(v)}
 			currency={budget.currency}
 			class="px-2 text-right font-currency font-medium"
 			selectOnFocus


### PR DESCRIPTION
Closes #52

## Problem

Clearing an `InputCurrency` field (Backspace on the last character or select-all + Backspace) snapped the field back to its initial value instead of submitting `0`. Two interacting causes: `floatToCents(null)` returned `null`, and all six consumer forms swallowed that `null` with a `?? fallback` in their `bind:value` getter.

## Fix

- `floatToCents` now maps `null`/`undefined`/`NaN` to `0`, so clearing propagates `0` cents through the binding and to the server.
- All six `??` fallbacks in consumer `bind:value` getters are removed, as specified in the issue.

## Deviations from the issue

Removing the fallbacks alone was not enough — two consequences surfaced during implementation:

- Svelte 5 throws `props_invalid_value` when a `bind:value` getter returns `undefined` while the bindable prop declares a fallback. `InputCurrency` and `InputGroup.InputCurrency` now use `value = $bindable()` without a default (matching the other input-group controls). The row-create component tests and the category e2e tests caught this.
- In the two edit forms the fallback was also what displayed the existing value (remote-form `field.value()` is `undefined` until set), and an untouched field would have submitted empty. `transaction-table-row-edit` now seeds the amount in its existing `onMount` next to `categoryId`; `category-edit` seeds `targetBalance` via an `$effect` keyed on the category — the same pattern `category-assignment-form` already uses. The `$effect` conflicts with the (stale) "zero $effect calls" line in `docs/code-style.md`; `$derived` can't express user-editable form state and `onMount` wouldn't re-seed when navigating between categories.

Note on display: after clearing, the field shows empty until submit (the library keeps `''`); `0` is what reaches the server, and formatted `0,00` reappears once the value round-trips.

## Verification

- New unit test: clearing the input propagates `0` cents to the hidden form input (red before the fix).
- `npm run check` 0 errors, lint clean, 299 unit tests and all 38 Playwright tests pass.