### PR TITLE
feat: cents-native InputMoney, retire @canutin/svelte-currency-input (#60)

### DIFF
--- a/docs/adr/0005-cents-native-input-money.md
+++ b/docs/adr/0005-cents-native-input-money.md
@@ -1,0 +1,59 @@
+# ADR-0005: InputMoney is cents-native and owns its editing model
+
+Date: 2026-07-12
+Status: accepted
+
+## Context
+
+Amount entry ran through `@canutin/svelte-currency-input`, wrapped by our
+`InputCurrency` (renamed `InputMoney` in #59). The library treats a formatted
+_string_ as the source of truth, which forced the wrapper into a
+cents↔float↔string triple conversion, an `$effect` reconciling two shadow
+states, and a ~25-prop pass-through surface consumers barely used. The
+string-first model also produces a null/number ambiguity for the bound value:
+every consumer form invented its own fallback, and a cleared field could snap
+back to its previous value instead of meaning zero — the #52 bug class, whose
+fix (#57) still left a cleared field displaying empty until the value
+round-tripped.
+
+## Decision
+
+The dependency is removed and replaced by an own, cents-native `InputMoney`
+(#58, #60).
+
+- **Integer cents are the single source of truth.** The bound `value` is a
+  non-nullable plain number of cents (the form-field currency; not the
+  branded `Money` type — user-context keeps owning null semantics such as "no
+  target balance"). The hidden form input always submits a valid integer
+  string; empty text and a bare minus parse to 0.
+- **Format on blur, plain text while focused.** Keystrokes are filtered via
+  `beforeinput` (digits, one leading minus, one decimal separator — first of
+  `,` or `.` typed wins — max 2 decimals); no live reformatting or caret
+  management. Blur re-renders through the domain `formatMoney` in the runtime
+  locale. The displayed text _derives_ from focus state and cents, so
+  external value writes reset the text only while unfocused — no `$effect`,
+  no shadow state.
+- **Pastes are parsed tolerantly** (strip symbols/spaces; with both `.` and
+  `,` the last one is decimal; a lone separator is decimal before 1–2 digits,
+  grouping before 3); unparseable pastes are ignored.
+- **The text rules are pure functions** in `money-text.ts` colocated with the
+  component, table-driven-tested, and deliberately outside
+  `$lib/utils/money`, which stays the domain seam for the branded `Money`.
+- **The API is hard-pruned** to `currency`, bindable `value`, bindable `ref`,
+  `selectOnFocus`, plus standard input attributes; the value callbacks and
+  the `locale` prop are gone (`bind:value` is the contract; the component
+  reads the runtime locale itself).
+
+## Consequences
+
+- Null/0 ambiguity is structurally impossible: consumers bind cents directly
+  without fallbacks, and a cleared field submits 0 and shows formatted zero
+  after blur.
+- Amount-entry behavior is fully owned and cheap to verify: separator and
+  paste rules change as pure-function edits with table tests, not upstream
+  library surprises.
+- The formatted display is produced by the same `formatMoney` used everywhere
+  else, so input display and read-only amounts cannot drift apart.
+- Editing behavior (e.g. group separators while typing) is deliberately
+  minimal; any future richening happens in our own component under the same
+  cents contract.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
 				"pino": "^10.3.1"
 			},
 			"devDependencies": {
-				"@canutin/svelte-currency-input": "^1.1.1",
 				"@eslint/compat": "^2.0.3",
 				"@eslint/js": "^10.0.1",
 				"@faker-js/faker": "^10.4.0",
@@ -516,19 +515,6 @@
 			},
 			"bin": {
 				"specificity": "bin/cli.js"
-			}
-		},
-		"node_modules/@canutin/svelte-currency-input": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@canutin/svelte-currency-input/-/svelte-currency-input-1.1.1.tgz",
-			"integrity": "sha512-7huhZ2QFjP9JhfSATmdpNtqA7XZrTUv2xjUBLBPU1edFf5ZucJzPbIe1oY/ofDVgpq8WyXbQCrFntjRKMW0fSw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=22"
-			},
-			"peerDependencies": {
-				"svelte": "^5.0.0"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 		"pino": "^10.3.1"
 	},
 	"devDependencies": {
-		"@canutin/svelte-currency-input": "^1.1.1",
 		"@eslint/compat": "^2.0.3",
 		"@eslint/js": "^10.0.1",
 		"@faker-js/faker": "^10.4.0",

--- a/src/lib/components/features/category/category-edit.svelte
+++ b/src/lib/components/features/category/category-edit.svelte
@@ -7,7 +7,6 @@
 	import { m } from '$lib/paraglide/messages';
 	import { editCategory, getCategoryById } from '$lib/remote-functions/category.remote';
 	import { type CURRENCIES } from '$lib/utils/currencies';
-	import { asMoney, formatMoney } from '$lib/utils/money';
 	import { createSingletonToast } from '$lib/utils/singleton-toast.svelte';
 	import { fly } from 'svelte/transition';
 	import FloppyDiskDuotoneIcon from '~icons/ph/floppy-disk-duotone';
@@ -71,8 +70,7 @@
 			}
 			{currency}
 			aria-invalid={editCategory.fields.targetBalance.issues()?.length ? true : undefined}
-			class="h-12 text-center text-xl font-semibold placeholder:text-base placeholder:font-normal"
-			placeholder={formatMoney({ currency, money: asMoney(0) })}
+			class="h-12 text-center text-xl font-semibold"
 			aria-label={m.category_label_targetbalance()}
 		/>
 

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
@@ -108,6 +108,13 @@ async function renderRow(props: Partial<typeof baseProps> & { open?: boolean } =
 	const merged = { ...baseProps, open: true, ...props };
 	const utils = render(TableRowCreate, { props: merged });
 	const form = merged.open ? await screen.findByRole('row') : null;
+	if (form) {
+		// The Popover moves focus into its content once opening completes. Wait
+		// for that one-shot autofocus to land before a test drives the keyboard,
+		// so it can't steal focus from the field mid-interaction and drop the
+		// keystroke that submits the form.
+		await waitFor(() => expect(document.activeElement).not.toBe(document.body));
+	}
 	return { ...utils, form };
 }
 

--- a/src/lib/components/ui/input-money/input-money.svelte
+++ b/src/lib/components/ui/input-money/input-money.svelte
@@ -1,163 +1,143 @@
 <script lang="ts">
 	import type { CURRENCIES } from '$lib/utils/currencies';
-	import type { CurrencyInputValues, IntlConfig } from '@canutin/svelte-currency-input';
 	import type { HTMLInputAttributes } from 'svelte/elements';
 
 	import { inputVariants } from '$lib/components/ui/input';
-	import { getLocale, type Locale } from '$lib/paraglide/runtime';
-	import { CurrencyInput } from '@canutin/svelte-currency-input';
+	import { getLocale } from '$lib/paraglide/runtime';
+	import { asMoney, formatMoney } from '$lib/utils/money';
+	import { tick } from 'svelte';
 	import { cn } from 'tailwind-variants';
+
+	import {
+		centsToEditText,
+		decimalSeparatorFor,
+		editTextToCents,
+		isValidEditText,
+		parsePastedAmount
+	} from './money-text';
 
 	type Props = Omit<
 		HTMLInputAttributes,
-		'defaultValue' | 'onchangevalue' | 'oninputvalue' | 'type' | 'value'
+		'onbeforeinput' | 'oninput' | 'onpaste' | 'type' | 'value'
 	> & {
-		allowDecimals?: boolean;
-		allowNegativeValue?: boolean;
 		currency: (typeof CURRENCIES)[number];
-		decimalScale?: number;
-		decimalSeparator?: string;
-		decimalsLimit?: number;
-		disableAbbreviations?: boolean;
-		disableGroupSeparators?: boolean;
-		fixedDecimalLength?: number;
-		formatValueOnBlur?: boolean;
-		groupSeparator?: string;
-		intlConfig?: IntlConfig;
-		locale?: Locale;
-		max?: number;
-		maxLength?: number;
-		min?: number;
-		onchangevalue?: (values: CurrencyInputValues) => void;
-		oninputvalue?: (values: CurrencyInputValues) => void;
-		prefix?: string;
 		ref?: HTMLInputElement | null;
 		selectOnFocus?: boolean;
-		step?: number;
-		suffix?: string;
-		transformRawValue?: (value: string) => string;
-		value?: null | number;
+		value?: number;
 	};
 
 	let {
-		allowDecimals,
-		allowNegativeValue,
 		class: className,
 		currency,
 		'data-slot': dataSlot = 'input',
-		decimalScale,
-		decimalSeparator,
-		decimalsLimit,
-		disableAbbreviations,
-		disableGroupSeparators,
-		fixedDecimalLength,
-		formatValueOnBlur,
-		groupSeparator,
-		intlConfig,
-		locale = getLocale(),
-		max,
-		maxLength,
-		min,
 		name,
-		onchangevalue,
+		onblur,
 		onfocus,
-		oninputvalue,
-		prefix,
 		ref = $bindable(null),
 		selectOnFocus = false,
-		step,
-		suffix,
-		transformRawValue,
 		value = $bindable(),
 		...restProps
 	}: Props = $props();
 
-	function normalizeCents(cents: null | number | undefined): null | number {
-		return cents === null || cents === undefined || Number.isNaN(cents) ? null : cents;
+	// No $bindable fallback: remote-function form fields read as undefined
+	// before their first write, and Svelte forbids binding undefined to a
+	// prop with a fallback. Unset simply means 0 cents.
+	const cents = $derived(value ?? 0);
+
+	// While focused the text is owned by the user's editing; while unfocused it
+	// derives from the bound cents, so external writes reset it automatically.
+	let focused = $state(false);
+	let editText = $state('');
+
+	const displayText = $derived(
+		focused ? editText : formatMoney({ currency, money: asMoney(cents) })
+	);
+
+	function proposedText(input: HTMLInputElement, inserted: string): string {
+		const start = input.selectionStart ?? input.value.length;
+		const end = input.selectionEnd ?? input.value.length;
+		return input.value.slice(0, start) + inserted + input.value.slice(end);
 	}
 
-	function centsToInputValue(cents: null | number | undefined): string {
-		const normalized = normalizeCents(cents);
-		return normalized === null ? '' : (normalized / 100).toFixed(2);
-	}
-
-	function floatToCents(floatValue: null | number): number {
-		if (floatValue === null || floatValue === undefined || Number.isNaN(floatValue)) {
-			return 0;
+	function handleBeforeInput(event: InputEvent & { currentTarget: HTMLInputElement }) {
+		// Deletions (data is null) can never make valid edit text invalid.
+		if (event.data === null) {
+			return;
 		}
-		return Math.round(floatValue * 100);
+		if (!isValidEditText(proposedText(event.currentTarget, event.data))) {
+			event.preventDefault();
+		}
 	}
 
-	// Internal string value for CurrencyInput (library expects string)
-	let internalValue = $state(centsToInputValue(value));
-	let internalCentValue = $state<null | number>(normalizeCents(value));
+	function handleInput(event: Event & { currentTarget: HTMLInputElement }) {
+		editText = event.currentTarget.value;
+		value = editTextToCents(editText);
+	}
 
-	// Keep internal value synchronized from canonical external cent state.
-	$effect(() => {
-		const resolved = normalizeCents(value);
-		if (resolved === internalCentValue) {
+	function handlePaste(event: ClipboardEvent & { currentTarget: HTMLInputElement }) {
+		event.preventDefault();
+		const pasted = event.clipboardData?.getData('text') ?? '';
+
+		const inserted = proposedText(event.currentTarget, pasted);
+		if (isValidEditText(inserted)) {
+			editText = inserted;
+			value = editTextToCents(inserted);
 			return;
 		}
 
-		const expectedInternalValue = centsToInputValue(value);
-
-		if (internalValue !== expectedInternalValue) {
-			internalValue = expectedInternalValue;
+		const cents = parsePastedAmount(pasted);
+		if (cents === null) {
+			return;
 		}
-
-		internalCentValue = resolved;
-	});
-
-	function handleInputValue(values: CurrencyInputValues) {
-		internalValue = values.value;
-		const nextCentValue = floatToCents(values.float);
-		internalCentValue = nextCentValue;
-		value = nextCentValue;
-		oninputvalue?.(values);
+		editText = centsToEditText(cents, decimalSeparatorFor(getLocale()));
+		value = cents;
 	}
 
-	function handleChangeValue(values: CurrencyInputValues) {
-		internalValue = values.value;
-		const nextCentValue = floatToCents(values.float);
-		internalCentValue = nextCentValue;
-		value = nextCentValue;
-		onchangevalue?.(values);
+	function handleFocus(event: FocusEvent & { currentTarget: HTMLInputElement }) {
+		const input = event.currentTarget;
+		// A selection made before focusing (tab focus, Playwright's fill) is
+		// applied by the browser only after the focus dispatch finishes — in
+		// this handler it still reads as collapsed, and any value write before
+		// then (ours or Svelte's flush) would destroy it. So the swap to edit
+		// text, including the state writes driving it, is deferred to a
+		// microtask: late enough to see and carry over a full selection, early
+		// enough to land before the next keystroke.
+		queueMicrotask(() => {
+			const hadFullSelection =
+				input.selectionStart === 0 && input.selectionEnd === input.value.length;
+			editText = cents === 0 ? '' : centsToEditText(cents, decimalSeparatorFor(getLocale()));
+			focused = true;
+			input.value = editText;
+			if (hadFullSelection) {
+				input.select();
+			}
+		});
+		if (selectOnFocus) {
+			// Deferred past the swap microtask; a synchronous select would also
+			// be collapsed by the caret the focusing click places afterwards.
+			tick().then(() => ref?.select());
+		}
+		onfocus?.(event);
+	}
+
+	function handleBlur(event: FocusEvent & { currentTarget: HTMLInputElement }) {
+		focused = false;
+		onblur?.(event);
 	}
 </script>
 
-<CurrencyInput
-	bind:ref
-	value={internalValue}
+<input
+	bind:this={ref}
 	data-slot={dataSlot}
 	class={cn(inputVariants(), className)}
-	intlConfig={{ currency, locale, ...intlConfig }}
-	{prefix}
-	{suffix}
-	{decimalSeparator}
-	{groupSeparator}
-	{disableGroupSeparators}
-	{allowDecimals}
-	{decimalsLimit}
-	{decimalScale}
-	{fixedDecimalLength}
-	{allowNegativeValue}
-	{min}
-	{max}
-	{maxLength}
-	{step}
-	{disableAbbreviations}
-	{formatValueOnBlur}
-	{transformRawValue}
-	oninputvalue={handleInputValue}
-	onchangevalue={handleChangeValue}
-	onfocus={(ev) => {
-		if (selectOnFocus) {
-			ref?.select();
-		}
-		if (onfocus) {
-			onfocus(ev);
-		}
-	}}
+	type="text"
+	inputmode="decimal"
+	value={displayText}
+	onbeforeinput={handleBeforeInput}
+	oninput={handleInput}
+	onpaste={handlePaste}
+	onfocus={handleFocus}
+	onblur={handleBlur}
 	{...restProps}
 />
 
@@ -165,7 +145,7 @@
 	<input
 		type="hidden"
 		{name}
-		value={normalizeCents(value) === null ? '' : String(value)}
+		value={String(cents)}
 		disabled={restProps.disabled}
 		form={restProps.form}
 	/>

--- a/src/lib/components/ui/input-money/input-money.svelte.test.ts
+++ b/src/lib/components/ui/input-money/input-money.svelte.test.ts
@@ -1,23 +1,27 @@
 import type { ComponentProps } from 'svelte';
 
+import { asMoney, formatMoney } from '$lib/utils/money';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { flushSync } from 'svelte';
+import { flushSync, tick } from 'svelte';
 import { describe, expect, it } from 'vitest';
 
 import InputMoney from './input-money.svelte';
+
+function formatted(cents: number): string {
+	return formatMoney({ currency: 'EUR', money: asMoney(cents) });
+}
 
 function renderNamedMoneyInput(props?: Partial<ComponentProps<typeof InputMoney>>) {
 	render(InputMoney, {
 		props: {
 			currency: 'EUR',
-			intlConfig: { locale: 'de-DE' },
 			name: 'targetBalance',
 			...props
 		}
 	});
 
-	const input = screen.getByRole('textbox');
+	const input = screen.getByRole<HTMLInputElement>('textbox');
 	const hidden = document.querySelector<HTMLInputElement>(
 		'input[type="hidden"][name="targetBalance"]'
 	);
@@ -30,7 +34,7 @@ function renderNamedMoneyInput(props?: Partial<ComponentProps<typeof InputMoney>
 }
 
 describe('InputMoney cent binding', () => {
-	it('keeps cent precision for comma-decimal locales', async () => {
+	it('keeps cent precision for comma-decimal entry', async () => {
 		const user = userEvent.setup();
 		const { hidden, input } = renderNamedMoneyInput();
 
@@ -41,12 +45,9 @@ describe('InputMoney cent binding', () => {
 		expect(hidden.value).toBe('1234');
 	});
 
-	it('keeps full cent precision when entering decimal amounts', async () => {
+	it('keeps cent precision for dot-decimal entry', async () => {
 		const user = userEvent.setup();
-		const { hidden, input } = renderNamedMoneyInput({
-			currency: 'USD',
-			intlConfig: { locale: 'en-US' }
-		});
+		const { hidden, input } = renderNamedMoneyInput({ currency: 'USD' });
 
 		await user.clear(input);
 		await user.type(input, '12.34');
@@ -76,30 +77,35 @@ describe('InputMoney cent binding', () => {
 		expect(hidden.value).toBe('0');
 	});
 
-	it('renders a cent value as a decimal amount for display', () => {
-		render(InputMoney, {
-			props: {
-				currency: 'EUR',
-				intlConfig: { locale: 'de-DE' },
-				value: 1234
-			}
-		});
+	it('updates the hidden input on every keystroke', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
 
-		const input = screen.getByRole<HTMLInputElement>('textbox');
-		expect(input.value).toContain('12,34');
+		await user.click(input);
+		await user.keyboard('4');
+		flushSync();
+		expect(hidden.value).toBe('400');
+
+		await user.keyboard('2');
+		flushSync();
+		expect(hidden.value).toBe('4200');
 	});
 
-	it('renders 0 cents as formatted "0,00"', () => {
-		render(InputMoney, {
-			props: {
-				currency: 'EUR',
-				intlConfig: { locale: 'de-DE' },
-				value: 0
-			}
-		});
+	it('submits 0 as a valid integer string before any interaction', () => {
+		const { hidden } = renderNamedMoneyInput();
 
-		const input = screen.getByRole<HTMLInputElement>('textbox');
-		expect(input.value).toContain('0');
+		expect(hidden.value).toBe('0');
+	});
+
+	it('accepts a leading minus for negative amounts', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.type(input, '-12,34');
+		flushSync();
+
+		expect(hidden.value).toBe('-1234');
 	});
 
 	it('submits cent integer value in form data', async () => {
@@ -110,7 +116,6 @@ describe('InputMoney cent binding', () => {
 		render(InputMoney, {
 			props: {
 				currency: 'EUR',
-				intlConfig: { locale: 'de-DE' },
 				name: 'targetBalance'
 			},
 			target: form
@@ -125,22 +130,137 @@ describe('InputMoney cent binding', () => {
 		const formData = new FormData(form);
 		expect(formData.get('targetBalance')).toBe('99955');
 	});
+});
 
-	it('submits empty string when value is NaN', () => {
-		const form = document.createElement('form');
-		document.body.append(form);
+describe('InputMoney keystroke filter', () => {
+	it('rejects a third decimal digit', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
 
-		render(InputMoney, {
-			props: {
-				currency: 'EUR',
-				intlConfig: { locale: 'de-DE' },
-				name: 'amount',
-				value: NaN
-			},
-			target: form
-		});
+		await user.clear(input);
+		await user.type(input, '12,345');
+		flushSync();
 
-		const formData = new FormData(form);
-		expect(formData.get('amount')).toBe('');
+		expect(input.value).toBe('12,34');
+		expect(hidden.value).toBe('1234');
+	});
+
+	it('rejects a second decimal separator', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.type(input, '1,2.3');
+		flushSync();
+
+		expect(input.value).toBe('1,23');
+		expect(hidden.value).toBe('123');
+	});
+
+	it('rejects letters and a non-leading minus', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.type(input, '1a2-3');
+		flushSync();
+
+		expect(input.value).toBe('123');
+		expect(hidden.value).toBe('12300');
+	});
+});
+
+describe('InputMoney display', () => {
+	it('renders the bound cents formatted with currency symbol while unfocused', () => {
+		renderNamedMoneyInput({ value: 1234 });
+
+		const input = screen.getByRole<HTMLInputElement>('textbox');
+		expect(input.value).toBe(formatted(1234));
+	});
+
+	it('shows plain edit text while focused and reformats on blur', async () => {
+		const user = userEvent.setup();
+		const { input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.type(input, '200');
+		flushSync();
+		expect(input.value).toBe('200');
+
+		await user.tab();
+		flushSync();
+		expect(input.value).toBe(formatted(20000));
+	});
+
+	it('shows formatted zero after clearing and blurring', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput({ value: 40000 });
+
+		await user.clear(input);
+		await user.tab();
+		flushSync();
+
+		expect(input.value).toBe(formatted(0));
+		expect(hidden.value).toBe('0');
+	});
+
+	it('selects the current text on focus when selectOnFocus is set', async () => {
+		const user = userEvent.setup();
+		const { input } = renderNamedMoneyInput({ selectOnFocus: true, value: 1234 });
+
+		await user.click(input);
+		await tick();
+
+		expect(input.selectionStart).toBe(0);
+		expect(input.selectionEnd).toBe(input.value.length);
+	});
+});
+
+describe('InputMoney paste', () => {
+	it('understands pasted currency strings with symbols and group separators', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.paste('1.234,56 €');
+		flushSync();
+
+		expect(hidden.value).toBe('123456');
+	});
+
+	it('treats a pasted single separator followed by three digits as grouping', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.paste('1.234');
+		flushSync();
+
+		expect(hidden.value).toBe('123400');
+	});
+
+	it('inserts plain decimal pastes at the caret', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.paste('12,34');
+		flushSync();
+
+		expect(input.value).toBe('12,34');
+		expect(hidden.value).toBe('1234');
+	});
+
+	it('ignores unparseable pastes', async () => {
+		const user = userEvent.setup();
+		const { hidden, input } = renderNamedMoneyInput();
+
+		await user.clear(input);
+		await user.type(input, '42');
+		await user.paste('not a number');
+		flushSync();
+
+		expect(input.value).toBe('42');
+		expect(hidden.value).toBe('4200');
 	});
 });

--- a/src/lib/components/ui/input-money/money-text.test.ts
+++ b/src/lib/components/ui/input-money/money-text.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	centsToEditText,
+	decimalSeparatorFor,
+	editTextToCents,
+	isValidEditText,
+	parsePastedAmount
+} from './money-text';
+
+describe('isValidEditText', () => {
+	it.each([
+		['', true],
+		['-', true],
+		['0', true],
+		['1234', true],
+		['12,3', true],
+		['12,34', true],
+		['12.34', true],
+		[',5', true],
+		['-12,34', true],
+		['12,345', false],
+		['12.345', false],
+		['1.234,56', false],
+		['12,3,4', false],
+		['12,3.4', false],
+		['1-2', false],
+		['12-', false],
+		['--12', false],
+		['abc', false],
+		['12 34', false],
+		['12,34 €', false]
+	])('%j → %s', (text, valid) => {
+		expect(isValidEditText(text)).toBe(valid);
+	});
+});
+
+describe('editTextToCents', () => {
+	it.each([
+		['', 0],
+		['-', 0],
+		['0', 0],
+		['200', 20000],
+		['12,34', 1234],
+		['12.34', 1234],
+		['12,3', 1230],
+		['12,', 1200],
+		[',5', 50],
+		[',05', 5],
+		['-12,34', -1234],
+		['-0', 0],
+		['-,', 0]
+	])('%j → %d', (text, cents) => {
+		expect(editTextToCents(text)).toBe(cents);
+	});
+});
+
+describe('centsToEditText', () => {
+	it.each([
+		[0, ',', '0'],
+		[20000, ',', '200'],
+		[1234, ',', '12,34'],
+		[1234, '.', '12.34'],
+		[1230, ',', '12,30'],
+		[5, ',', '0,05'],
+		[-1234, ',', '-12,34'],
+		[-20000, ',', '-200']
+	])('%d with %j → %j', (cents, separator, text) => {
+		expect(centsToEditText(cents, separator)).toBe(text);
+	});
+});
+
+describe('decimalSeparatorFor', () => {
+	it.each([
+		['de', ','],
+		['en', '.']
+	] as const)('%s → %j', (locale, separator) => {
+		expect(decimalSeparatorFor(locale)).toBe(separator);
+	});
+});
+
+describe('parsePastedAmount', () => {
+	it.each([
+		// single separator: decimal when followed by 1–2 digits
+		['1.23', 123],
+		['1,23', 123],
+		['12.5', 1250],
+		// single separator followed by 3 digits is a group separator
+		['1.234', 123400],
+		['1,234', 123400],
+		// repeated single-kind separators group thousands
+		['1.234.567', 123456700],
+		// both separators: the last one is the decimal separator
+		['1.234,56', 123456],
+		['1,234.56', 123456],
+		['1.234.567,89', 123456789],
+		// symbols, spaces, and sign are tolerated
+		['1.234,56 €', 123456],
+		['€1,234.56', 123456],
+		['EUR 1 234,56', 123456],
+		['-12,34', -1234],
+		['- 12,34 €', -1234],
+		['42', 4200],
+		['12.', 1200],
+		// unparseable
+		['', null],
+		['abc', null],
+		['.', null],
+		['-', null],
+		['1,234.567', null]
+	])('%j → %o', (text, cents) => {
+		expect(parsePastedAmount(text)).toBe(cents);
+	});
+});

--- a/src/lib/components/ui/input-money/money-text.ts
+++ b/src/lib/components/ui/input-money/money-text.ts
@@ -1,0 +1,103 @@
+/**
+ * Text rules for the InputMoney editing model: what may appear in the
+ * focused input, how edit text maps to integer cents, and how pasted
+ * currency strings are understood. Widget concern — deliberately separate
+ * from the domain money utils (`$lib/utils/money`), which own the branded
+ * `Money` type.
+ */
+
+const EDIT_TEXT_PATTERN = /^(-?)(\d*)(?:[.,](\d{0,2}))?$/;
+
+/** Minimal edit representation: no grouping, decimals only when non-zero. */
+export function centsToEditText(cents: number, decimalSeparator: string): string {
+	const sign = cents < 0 ? '-' : '';
+	const absolute = Math.abs(cents);
+	const whole = Math.trunc(absolute / 100);
+	const fraction = absolute % 100;
+	if (fraction === 0) {
+		return `${sign}${whole}`;
+	}
+	return `${sign}${whole}${decimalSeparator}${String(fraction).padStart(2, '0')}`;
+}
+
+export function decimalSeparatorFor(locale: string): string {
+	const parts = new Intl.NumberFormat(locale).formatToParts(1.1);
+	return parts.find((part) => part.type === 'decimal')?.value ?? '.';
+}
+
+/** Empty text and a bare minus parse to 0; a trailing separator counts as ",00". */
+export function editTextToCents(text: string): number {
+	const match = EDIT_TEXT_PATTERN.exec(text);
+	if (!match) {
+		return 0;
+	}
+	const [, sign, whole = '', fraction = ''] = match;
+	const cents = Number(whole || '0') * 100 + Number(fraction.padEnd(2, '0'));
+	return sign === '-' && cents !== 0 ? -cents : cents;
+}
+
+/** Digits, one leading minus, one decimal separator (`,` or `.`), max 2 decimals. */
+export function isValidEditText(text: string): boolean {
+	return EDIT_TEXT_PATTERN.test(text);
+}
+
+/**
+ * Tolerant parser for pasted currency strings (`1.234,56 €`). Strips symbols
+ * and spaces; when both `.` and `,` appear the last one is the decimal
+ * separator; a lone separator is decimal when followed by 1–2 digits and a
+ * group separator when followed by 3. Returns null for unparseable input.
+ */
+export function parsePastedAmount(text: string): null | number {
+	const cleaned = text.replace(/[^\d.,-]/g, '');
+	const unsigned = cleaned.replace(/-/g, '');
+	if (!/^[\d.,]+$/.test(unsigned) || !/\d/.test(unsigned)) {
+		return null;
+	}
+
+	const decimalIndex = resolveDecimalSeparator(unsigned);
+	if (decimalIndex === 'unparseable') {
+		return null;
+	}
+
+	const [whole, fraction] =
+		decimalIndex === null
+			? [unsigned, '']
+			: [unsigned.slice(0, decimalIndex), unsigned.slice(decimalIndex + 1)];
+	if (fraction.length > 2) {
+		return null;
+	}
+
+	const cents = Number(whole.replace(/[.,]/g, '') || '0') * 100 + Number(fraction.padEnd(2, '0'));
+	if (!Number.isSafeInteger(cents)) {
+		return null;
+	}
+	return cleaned.includes('-') && cents !== 0 ? -cents : cents;
+}
+
+/** Index of the decimal separator, null when every separator groups thousands. */
+function resolveDecimalSeparator(unsigned: string): 'unparseable' | null | number {
+	const lastDot = unsigned.lastIndexOf('.');
+	const lastComma = unsigned.lastIndexOf(',');
+	if (lastDot === -1 && lastComma === -1) {
+		return null;
+	}
+	if (lastDot !== -1 && lastComma !== -1) {
+		return Math.max(lastDot, lastComma);
+	}
+
+	const kind = lastDot !== -1 ? '.' : ',';
+	const index = Math.max(lastDot, lastComma);
+	// the same separator repeated can only group thousands ("1.234.567")
+	if (unsigned.indexOf(kind) !== index) {
+		return null;
+	}
+	const digitsAfter = unsigned.length - index - 1;
+	if (digitsAfter === 3) {
+		return null;
+	}
+	// a trailing separator ("12.") carries no decimals
+	if (digitsAfter === 0) {
+		return null;
+	}
+	return digitsAfter <= 2 ? index : 'unparseable';
+}


### PR DESCRIPTION
Closes #60. Closes #58.

InputMoney is now cents-native and owns its entire editing model, replacing `@canutin/svelte-currency-input`.

## What changed

- **Bound value is non-nullable integer cents.** The hidden form input always submits a valid integer string; no consumer needs a null/undefined fallback.
- **Focused text is plain and editable** — digits, one leading minus, one decimal separator (first of `,` or `.` typed wins), at most 2 decimals; a third decimal keystroke doesn't land. No live reformatting.
- **Blur renders the domain money formatter** with the currency symbol in the runtime locale. Clearing the field means zero (submits `0`, shows formatted zero after blur).
- **Tolerant paste heuristic** understands currency strings with symbols, spaces, and group separators (`1.234,56 €`); unparseable pastes are ignored.
- **Pure text rules** (keystroke filter, edit-text ↔ cents, paste heuristic) live in a colocated `money-text.ts`, deliberately outside the domain money utils, with table-driven unit tests.
- **API hard-pruned** to `currency`, bindable `value`, bindable `ref`, `selectOnFocus` + rest props; visible input is `type="text" inputmode="decimal"`. Library pass-through props, value callbacks, and the `locale` prop are gone.
- `@canutin/svelte-currency-input` removed from the manifest and lockfile; the dead `placeholder` on the category-edit target-balance field deleted.
- **ADR 0005** records the dependency reversal (formatted-string source of truth forced shadow state; null/0 ambiguity caused the #52 bug class) and the replacement's contract.

## Focus/selection handling

`fill` and tab-focus select the field's text before the focus event fires, but the browser applies that selection only after the focus dispatch completes. The edit-text swap (and the state writes driving it) is deferred to a microtask so it can see and carry over a full selection, and lands before the next keystroke — otherwise type-over appends instead of replacing.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- Full unit suite — 374 passed + 1 expected fail (83 new input-money tests)
- Full Playwright suite — 38/38 passed
- The #57 regression test passes, changed only by the rename