### PR TITLE
docs: resolve ADR-0002 transaction date/validated defaults note (#47)

### DIFF
--- a/docs/adr/0002-remote-functions-are-mechanical-adapters.md
+++ b/docs/adr/0002-remote-functions-are-mechanical-adapters.md
@@ -44,7 +44,12 @@ path. Tests target user-context.
 - Loads that use `createUserCtx()` directly must check `locals.session`
   themselves — the guard helpers do not cover them.
 - Existing violations in `budget.remote.ts` (`findEligibleUser`, `inviteUser`)
-  and `transaction.remote.ts` (date/validated defaults) are tracked as
-  follow-up issues rather than fixed alongside this decision. The double list
-  query in `transaction.remote.ts` was resolved by consolidating transaction
-  listing into one `page()` user-context operation (#50).
+  are tracked as follow-up issues rather than fixed alongside this decision.
+- The `transaction.remote.ts` "date/validated defaults" were **not** adapter
+  violations: both are business rules that already live in user-context
+  (`transaction.create` dates an undated transaction today; `transaction.edit`
+  resets validation via `validated ?? false`). The schema defaults
+  (`v.optional(v.boolean(), false)`) are UI convenience; the user-context lines
+  are the canonical enforcement, covered by direct-`ctx` tests (#47).
+- The double list query in `transaction.remote.ts` was resolved by consolidating
+  transaction listing into one `page()` user-context operation (#50).

--- a/src/lib/server/db/user-context/transaction.test.ts
+++ b/src/lib/server/db/user-context/transaction.test.ts
@@ -1,6 +1,7 @@
 import { createDatabase, type Database, tables } from '$db';
 import { UNASSIGNED } from '$lib/constants';
 import { NotFoundError } from '$server/utils/not-found-error';
+import { getLocalTimeZone, today } from '@internationalized/date';
 import { describe, expect, it } from 'vitest';
 
 import { createAccount, createBudgetWithUser, createUser } from '../../../../test/fixtures';
@@ -313,16 +314,17 @@ describe('commands.create', () => {
 		expect(tx.id).toBeDefined();
 	});
 
-	it('defaults date to today when omitted', () => {
+	it('defaults date to today in local timezone when omitted', () => {
 		const db = createDatabase(':memory:');
 		const { budget, user } = createBudgetWithUser(db);
 		const a = createAccount(db, budget.id, 'A');
 		const { create } = commands(user.id, db);
 
+		// Direct ctx call bypasses the schema/adapter layer, so the business rule
+		// "a transaction without a date is dated today" is enforced here.
 		const tx = create({ accountId: a.id, amount: -42, budgetId: budget.id });
 
-		expect(tx.date).toBeDefined();
-		expect(tx.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(tx.date).toBe(today(getLocalTimeZone()).toString());
 	});
 
 	it('throws NotFoundError without budget access', () => {
@@ -380,13 +382,16 @@ describe('commands.edit', () => {
 		expect(updated).toMatchObject({ amount: 200, id: tx.id, notes: 'new' });
 	});
 
-	it('defaults validated to false when omitted', () => {
+	it('resets validated to false when omitted', () => {
 		const db = createDatabase(':memory:');
 		const { budget, user } = createBudgetWithUser(db);
 		const a = createAccount(db, budget.id, 'A');
 		const tx = createTransaction(db, budget.id, a.id, { validated: true });
 		const { edit } = commands(user.id, db);
 
+		// Direct ctx call bypasses the schema default, so this asserts the
+		// business rule "editing a transaction resets its validation" — the
+		// `?? false` in edit() is the canonical enforcing line, not dead code.
 		const updated = edit(tx.id, { amount: 300 });
 
 		expect(updated.validated).toBe(false);


### PR DESCRIPTION
Closes #47.

## What

The "date/validated defaults" flagged in ADR-0002 for `transaction.remote.ts` were never adapter violations — both are business rules that already live in user-context:

- `transaction.create` dates an undated transaction today (local timezone).
- `transaction.edit` resets validation via `validated ?? false`.

The schema defaults (`v.optional(v.boolean(), false)`) are UI convenience only; the user-context lines are the canonical enforcement. No code change was needed — the enforcing lines were already correct. This PR closes the documentation and test gap.

## Changes

- **`docs/adr/0002-...md`** — update the consequence note: the date/validated entries are resolved (business rules, not adapter violations); only the `budget.remote.ts` entries (`findEligibleUser`, `inviteUser`) remain open.
- **`transaction.test.ts`** — strengthen the create test to assert the exact `today(getLocalTimeZone())` value instead of a loose regex, and clarify both tests bypass the schema default via direct `ctx` calls (documenting that `?? false` is the enforcing line, not dead code).

## Verification

- `npm run check` — 0 errors
- `npm run lint` — clean
- Full unit suite — 374 passed, 1 expected-fail
- `transaction.test.ts` — 29 passed