### PR TITLE
fix: category sort in budget monthly query uses wrong entityType

### DIFF
--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -206,6 +206,37 @@ describe('queries.monthly', () => {
 
 		expect(monthly(budget.id, month202501)).toHaveLength(0);
 	});
+
+	it('orders categories by custom position from userEntityOrder', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const catA = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'A' })
+			.returning()
+			.get();
+		const catB = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'B' })
+			.returning()
+			.get();
+		const catC = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'C' })
+			.returning()
+			.get();
+		db.insert(tables.userEntityOrder)
+			.values([
+				{ entityId: catA.id, entityType: 'category', position: 2, userId: user.id },
+				{ entityId: catB.id, entityType: 'category', position: 0, userId: user.id },
+				{ entityId: catC.id, entityType: 'category', position: 1, userId: user.id }
+			])
+			.run();
+		const { monthly } = queries(user.id, db);
+
+		const result = monthly(budget.id, month202501);
+		expect(result.map((c) => c.name)).toEqual(['B', 'C', 'A']);
+	});
 });
 
 describe('queries.unassigned', () => {

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -158,7 +158,7 @@ export const queries = (userId: string, db: Database = database) => ({
 			)
 			.$dynamic();
 
-		return withOrder(qb, tables.categories, 'budget', userId).all();
+		return withOrder(qb, tables.categories, 'category', userId).all();
 	},
 
 	unassigned: (budgetId: string) => {


### PR DESCRIPTION
## Problem

Categories appeared in a different order in transaction create/edit select boxes than in the budget table. The custom drag-and-drop order set in the budget table did not carry through.

## Root cause

The `monthly()` category query in `user-context/budget.ts` joined `userEntityOrder` with `entityType = 'budget'` instead of `'category'`. The reorder writes positions under `entityType = 'category'`, so the budget table never matched any order rows and silently fell back to `createdAt` ordering — while the transaction select's `all()` query correctly read `'category'`, creating the mismatch.

## Fix

Change the `entityType` argument in the monthly category query from `'budget'` to `'category'` so both reads use the same order rows. Single-line change, no schema/API/module changes.

## Tests

Added a `queries.monthly` test seeding categories A/B/C with custom positions (A=2, B=0, C=1) and asserting `monthly()` returns `['B', 'C', 'A']`.

- `npm run check` — clean
- Full unit suite — 375 passed, 1 expected-fail
- `npm run lint` — clean

Closes #63