### PR TITLE
test(e2e): duplicate-name field errors for categories and accounts

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -9,3 +9,4 @@
 - Reuse and extend the page-object model under `tests/playwright/pom`.
 - Respect the serial bootstrap flow in `tests/playwright/global.setup.ts`, including first-user and admin setup behavior.
 - Prefer user-visible assertions around navigation, forms, dialogs, and data changes over implementation-detail assertions.
+- The Playwright dev server defaults to port 3000. Set `E2E_PORT` to run against an isolated server/database — required when several worktrees run `npm run test:e2e` at once, otherwise they collide on the same port. Example: `E2E_PORT=3247 npm run test:e2e`.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig, devices } from '@playwright/test';
 
 const DEFAULT_VIEWPORT = { height: 900, width: 1440 } as const;
 
+// The dev server port is configurable so parallel worktrees can run the e2e
+// suite against isolated servers/databases instead of colliding on one port.
+const PORT = Number(process.env.E2E_PORT ?? 3000);
+const ORIGIN = `http://localhost:${PORT}`;
+
 export default defineConfig({
 	expect: {
 		timeout: 10000
@@ -38,15 +43,15 @@ export default defineConfig({
 	testDir: 'tests/playwright',
 
 	use: {
+		baseURL: ORIGIN,
 		contextOptions: { reducedMotion: 'reduce' },
 		trace: 'on-first-retry',
 		viewport: DEFAULT_VIEWPORT
 	},
 
 	webServer: {
-		command:
-			'DATABASE_URL=:memory: npm run build && DATABASE_URL=:memory: ORIGIN=http://localhost:3000 node build',
-		port: 3000,
+		command: `DATABASE_URL=:memory: npm run build && DATABASE_URL=:memory: ORIGIN=${ORIGIN} PORT=${PORT} node build`,
+		port: PORT,
 		// pino logs (request logs, unhandled server errors incl. logId) go to
 		// stdout, which Playwright discards by default — keep them visible so a
 		// 500 during a test can be traced to its server-side error.

--- a/tests/playwright/account.spec.ts
+++ b/tests/playwright/account.spec.ts
@@ -26,3 +26,31 @@ test('Edit Account Name', async ({ pages }) => {
 	await pages.account.goto(accountName);
 	await pages.account.editName(newName);
 });
+
+test('Account create shows a field error for a duplicate name', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName);
+
+	await pages.budget.createAccountExpectingError(accountName);
+});
+
+test('Account rename shows a field error for a duplicate name', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const existingName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(existingName);
+
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName);
+
+	await pages.account.goto(accountName);
+	await pages.account.editNameExpectingError(existingName);
+});

--- a/tests/playwright/category.spec.ts
+++ b/tests/playwright/category.spec.ts
@@ -32,6 +32,33 @@ test('Edit Category Name', async ({ pages }) => {
 	await pages.category.editName(categoryName, newName);
 });
 
+test('Category create shows a field error for a duplicate name', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	await pages.category.createExpectingError(categoryName);
+});
+
+test('Category rename shows a field error for a duplicate name', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const existingName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(existingName);
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	await pages.category.editNameExpectingError(categoryName, existingName);
+});
+
 test('Archive Category', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
 

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -126,6 +126,27 @@ export class AccountPage extends BasePage {
 		await expect(this.page.getByRole('heading', { name })).toBeVisible();
 	}
 
+	/**
+	 * Opens the account settings dialog and renames the account to `existingName`
+	 * (another account in the same budget). Asserts the duplicate-name error
+	 * surfaces as a field error within the dialog.
+	 */
+	async editNameExpectingError(existingName: string) {
+		await this.page.getByRole('button', { name: 'Account Settings' }).click();
+
+		const dialog = this.page.getByRole('dialog');
+		await expect(dialog.getByRole('heading', { name: 'Change Account Name' })).toBeVisible();
+
+		const nameInput = dialog.getByRole('textbox', { name: 'Account Name' });
+		await nameInput.clear();
+		await nameInput.fill(existingName);
+		await dialog.getByRole('button', { name: 'Save Changes' }).click();
+
+		await expect(dialog.getByText(`${existingName} already exists.`)).toBeVisible();
+		// The error keeps the dialog open.
+		await expect(dialog).toBeVisible();
+	}
+
 	async editTransaction(params: EditTransactionParams) {
 		// Click first editable row to enter edit mode
 		const row = this.page

--- a/tests/playwright/pom/base-page.ts
+++ b/tests/playwright/pom/base-page.ts
@@ -17,6 +17,8 @@ import { expect, type Page } from '@playwright/test';
 export type TestContext = {
 	/** account name -> account page URL */
 	accounts: Map<string, string>;
+	/** the current budget's id (captured after createBudget) */
+	budgetId?: string;
 	/** the current budget's page URL (captured after createBudget) */
 	budgetUrl?: string;
 };

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -47,6 +47,26 @@ export class BudgetPage extends BasePage {
 		}
 	}
 
+	/**
+	 * Opens the create-account dialog and submits a name that already exists.
+	 * Asserts the duplicate-name error surfaces as a field error and the dialog
+	 * stays open (no redirect to a new account page).
+	 */
+	async createAccountExpectingError(name: string) {
+		await this.page.getByRole('button', { name: 'Show Accounts' }).click();
+		await this.page.getByRole('menuitem', { name: 'Add Account' }).click();
+
+		const dialog = this.page.getByRole('dialog');
+		await expect(dialog.getByRole('heading', { name: 'Add New Account' })).toBeVisible();
+
+		await dialog.getByRole('textbox', { name: 'Account Name' }).fill(name);
+		await dialog.getByRole('button', { name: 'Create Account' }).click();
+
+		await expect(dialog.getByText(`${name} already exists.`)).toBeVisible();
+		// The error keeps the dialog open — a successful create would redirect away.
+		await expect(dialog).toBeVisible();
+	}
+
 	async createBudget(name: string) {
 		await this.page.goto('/new');
 		await expect(
@@ -60,6 +80,10 @@ export class BudgetPage extends BasePage {
 		// current month page where the budget name is the heading.
 		await expect(this.page.getByRole('heading', { name })).toBeVisible();
 		this.ctx.budgetUrl = this.page.url();
+		// The budget id is the first path segment (the `(app)` group has no URL
+		// segment): /{budgetId}/{month}. Captured for direct navigation to
+		// budget-scoped pages like the standalone category create page.
+		this.ctx.budgetId = new URL(this.page.url()).pathname.split('/')[1];
 	}
 
 	async createCategory(name: string) {

--- a/tests/playwright/pom/category.ts
+++ b/tests/playwright/pom/category.ts
@@ -27,6 +27,27 @@ export class CategoryPage extends BasePage {
 		await expect(this.page.getByRole('button', { exact: true, name })).toBeVisible();
 	}
 
+	/**
+	 * On the standalone create page (`/{budgetId}/categories/new`), submits a
+	 * name that already exists in the budget. Asserts the duplicate-name error
+	 * renders as a field error below the input and no navigation occurs.
+	 */
+	async createExpectingError(name: string) {
+		if (!this.ctx.budgetId) {
+			throw new Error('createBudget must be called before createExpectingError');
+		}
+		await this.page.goto(`/${this.ctx.budgetId}/categories/new`);
+		await expect(this.page.getByRole('heading', { name: 'Add a new category' })).toBeVisible();
+
+		const input = this.page.getByRole('textbox', { name: 'Category Name' });
+		await input.fill(name);
+		await input.press('Enter');
+
+		await expect(this.page.getByText(`${name} already exists.`)).toBeVisible();
+		// A successful create navigates back to the budget page; the error keeps us here.
+		await expect(this.page).toHaveURL(/\/categories\/new$/);
+	}
+
 	async editName(currentName: string, newName: string) {
 		await this.openDetail(currentName);
 
@@ -47,6 +68,27 @@ export class CategoryPage extends BasePage {
 		await expect(
 			this.page.getByRole('table').getByRole('button', { exact: true, name: newName })
 		).toBeVisible();
+	}
+
+	/**
+	 * Opens the edit dialog for `currentName` and renames it to `existingName`
+	 * (another category in the same budget). Asserts the duplicate-name error
+	 * surfaces within the dialog and saving does not happen.
+	 */
+	async editNameExpectingError(currentName: string, existingName: string) {
+		await this.openDetail(currentName);
+
+		const dialog = this.page.getByRole('dialog');
+		const nameInput = dialog.getByRole('textbox', { name: 'Category Name' });
+		await expect(nameInput).toHaveValue(currentName);
+		await nameInput.clear();
+		await nameInput.fill(existingName);
+		await dialog.getByRole('button', { exact: true, name: 'Save' }).click();
+
+		await expect(dialog.getByText(`${existingName} already exists.`)).toBeVisible();
+		// The error keeps the dialog open and no "Saved" indicator appears.
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByText('Saved')).not.toBeVisible();
 	}
 
 	/** From the budget month page: opens the archived list and follows the category link back. */


### PR DESCRIPTION
Closes #23.

Follow-up from #14, which added duplicate-name pre-checks in user-context and field-level error mapping in the remote functions but had no e2e coverage that the error actually surfaces as a field error instead of the 500 page.

## Tests

Four new Playwright tests, using the existing page-object layer:

1. **Category create** — standalone `/categories/new` page; asserts the inline field error appears and the URL stays on `/categories/new` (no navigation).
2. **Category rename** — edit dialog; asserts the error shows, the dialog stays open, and no "Saved" indicator appears.
3. **Account create** — create dialog; asserts the error below the name field and the dialog stays open (no redirect).
4. **Account rename** — set-name dialog; asserts the error within the dialog.

## Supporting changes

- `*ExpectingError` helpers on the `BudgetPage`, `CategoryPage`, and `AccountPage` page objects.
- `budgetId` captured on `TestContext` in `createBudget`, so the standalone category create page can be reached by direct navigation (consistent with the base-page URL-capture pattern).
- `playwright.config.ts`: `E2E_PORT` env override (default 3000, behavior unchanged) so parallel worktrees can run the suite against isolated servers/databases.

## Verification

- `npm run check` — 0 errors
- `npm run lint` — clean
- Full e2e suite on an isolated port — 46 passed across `tablet` and `chromium`, including the 4 new tests × 2 viewports.

Stays within the issue's scope: no quick-create popover, no server-side changes.