### PR TITLE
fix: latch route params feeding remote queries (#15)

### DIFF
--- a/docs/adr/0006-route-params-feeding-queries-are-latched.md
+++ b/docs/adr/0006-route-params-feeding-queries-are-latched.md
@@ -1,0 +1,71 @@
+# ADR-0006: Route params feeding remote queries are read through a latched accessor
+
+Date: 2026-07-12
+Status: accepted
+
+## Context
+
+During client-side navigation _away_ from the budget/account subtree,
+SvelteKit's `params` transiently reflects the target route while the old page
+is still mounted. An id feeding a still-live top-level
+`$derived(await getX(...))` (see ADR-0003) briefly becomes `undefined`, the
+query runs with that arg, the bare `v.string()` / object schemas reject it, and
+the server logs `Remote function schema validation failed` and returns 400. It
+is timing-dependent — it surfaces on slow CI runners, not locally (#15).
+
+The same id was read three inconsistent ways across the subtree:
+
+- the budget-id context getter (`getBudgetId` / `setBudgetId`),
+- raw `params.budgetId` / `params.accountId` via `PageProps`,
+- `page.params.budgetId!` via `$app/state` with non-null assertions.
+
+The `!` assertions were papering over exactly this transient `undefined`. The
+month page already documented the teardown behavior and dodged it for `month`
+via `parseMonth` (which returns `null` for the transient value, gating
+month-dependent UI) — but nothing gated the ids.
+
+Alternatives considered:
+
+- **`handleValidationError` logging hook.** Only surfaces the symptom; the
+  query still fires with `undefined`. Out of scope here; file separately if a
+  safety net is wanted.
+- **Non-null assertions everywhere.** The status quo. Lies to the type system
+  and does nothing at runtime — the value really is `undefined` mid-teardown.
+- **Guard each call site** (`{#if id}` / early return per query). Repetitive,
+  easy to forget on the next query, and pushes teardown-awareness into every
+  consumer.
+
+## Decision
+
+**One canonical way to read a route param that feeds a query: a latched
+("sticky") accessor.** `stickyParam(get: () => T | undefined): () => T` in
+`$lib/utils/sticky-param` wraps a reactive getter, caches the last non-nullish
+value, and returns the cached value while the source is currently nullish.
+Reading it inside a reactive scope still tracks the source, so consumers re-run
+when the param genuinely changes.
+
+- The budget-id context provider latches through `stickyParam`; the consumer
+  contract stays `() => string`, so every `getBudgetId()` consumer is fixed at
+  the single provider seam.
+- The account-detail page reads `accountId` through `stickyParam` and
+  `budgetId` through the (now latched) context.
+- The three prior read patterns collapse to this one for query args; the `!`
+  assertions on `page.params` disappear for those reads.
+
+This is orthogonal to ADR-0003: the awaited-top-level _consumption_ pattern is
+unchanged — only the argument _source_ is latched.
+
+## Consequences
+
+- No remote query (`getBudget`, `getAccount`, `getAccountBalances`,
+  `getBudgetUsers`, `getUnassigned`, `getArchivedCategories`, `getMonthly`,
+  `listTransactions`) can be invoked with an `undefined` id during navigation
+  away from the subtree; the 400 + validation-error log class is removed
+  structurally rather than logged.
+- `stickyParam` is a pure, deterministically unit-tested helper — no reactive
+  framework mock needed.
+- Pure non-query uses of route params (navigation hrefs, hidden form fields)
+  are left as-is; they fire on user interaction when `params` is defined, and
+  latching them would drill props for no benefit.
+- One accessor to learn and review; a new budget-scoped query is safe by
+  construction as long as its id comes from the context or `stickyParam`.

--- a/src/lib/utils/sticky-param.test.ts
+++ b/src/lib/utils/sticky-param.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { stickyParam } from './sticky-param';
+
+describe('stickyParam', () => {
+	it('returns the source value while it is defined', () => {
+		let source: string | undefined = 'a';
+		const sticky = stickyParam(() => source);
+		expect(sticky()).toBe('a');
+		source = 'b';
+		expect(sticky()).toBe('b');
+	});
+
+	it('returns the last defined value once the source becomes undefined', () => {
+		let source: string | undefined = 'a';
+		const sticky = stickyParam(() => source);
+		expect(sticky()).toBe('a');
+		source = undefined;
+		expect(sticky()).toBe('a');
+	});
+
+	it('returns undefined before any defined value', () => {
+		const sticky = stickyParam<string>(() => undefined);
+		expect(sticky()).toBeUndefined();
+	});
+
+	it('latches the newest defined value across a transient gap', () => {
+		let source: string | undefined = 'a';
+		const sticky = stickyParam(() => source);
+		expect(sticky()).toBe('a');
+		source = 'b';
+		expect(sticky()).toBe('b');
+		source = undefined;
+		expect(sticky()).toBe('b');
+	});
+});

--- a/src/lib/utils/sticky-param.ts
+++ b/src/lib/utils/sticky-param.ts
@@ -1,0 +1,19 @@
+/**
+ * Wraps a reactive getter that may transiently yield `undefined` — such as a
+ * route param during client-side navigation teardown, when SvelteKit's
+ * `params` briefly reflects the target route while the old page is still
+ * mounted — and returns the last defined value while the source is nullish.
+ *
+ * This keeps remote queries from firing with `undefined` args mid-navigation
+ * (the 400 + `Remote function schema validation failed` class). Reading the
+ * wrapped getter inside a reactive scope still tracks the source, so consumers
+ * re-run when the param actually changes. See ADR-0006.
+ */
+export function stickyParam<T>(get: () => T | undefined): () => T {
+	let last: T | undefined;
+	return () => {
+		const value = get();
+		if (value != null) last = value;
+		return last as T;
+	};
+}

--- a/src/routes/(app)/[budgetId=id]/+layout.svelte
+++ b/src/routes/(app)/[budgetId=id]/+layout.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { setBudgetId } from '$lib/utils/budget-id-context';
+	import { stickyParam } from '$lib/utils/sticky-param';
 
 	import type { LayoutProps } from './$types';
 
 	let { children, params }: LayoutProps = $props();
 
-	setBudgetId(() => params.budgetId);
+	setBudgetId(stickyParam(() => params.budgetId));
 </script>
 
 {@render children?.()}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -6,6 +6,7 @@
 	import * as ButtonGroup from '$lib/components/ui/button-group';
 	import * as Page from '$lib/components/ui/page';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { parseMonth } from '$lib/utils/month';
 
 	import type { PageProps } from './$types';
@@ -17,7 +18,9 @@
 
 	let { params }: PageProps = $props();
 
-	const budget = $derived(await getBudget(params.budgetId));
+	const budgetId = getBudgetId();
+
+	const budget = $derived(await getBudget(budgetId()));
 
 	// The matcher guarantees a valid param on this route, but during client-side
 	// navigation away, `params` briefly reflects the target route (no month) while

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -12,15 +12,20 @@
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { listTransactions } from '$lib/remote-functions/transaction.remote';
 	import { TransactionsURLParamsSchema } from '$lib/schemas/transaction';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
+	import { stickyParam } from '$lib/utils/sticky-param';
 	import * as v from 'valibot';
 
 	import type { PageProps } from './$types';
 
 	let { params }: PageProps = $props();
 
-	const account = $derived(await getAccount(params.accountId));
-	const balanceDetail = $derived(await getAccountBalances(params.accountId));
-	const budget = $derived(await getBudget(params.budgetId));
+	const budgetId = getBudgetId();
+	const accountId = stickyParam(() => params.accountId);
+
+	const account = $derived(await getAccount(accountId()));
+	const balanceDetail = $derived(await getAccountBalances(accountId()));
+	const budget = $derived(await getBudget(budgetId()));
 
 	const balances = $derived({
 		balance: account.balance,
@@ -60,17 +65,15 @@
 
 	const tableState = new TableState(parseURLParams(page.url));
 
-	const result = $derived(
-		await listTransactions({ accountId: params.accountId, ...tableState.params })
-	);
+	const result = $derived(await listTransactions({ accountId: accountId(), ...tableState.params }));
 
 	$effect(() => {
 		const nextQuery = buildSearch(tableState.params);
 		if (nextQuery === page.url.searchParams.toString()) return;
 		goto(
 			resolve(`/(app)/[budgetId=id]/accounts/[accountId=id]?${nextQuery}`, {
-				accountId: params.accountId,
-				budgetId: params.budgetId
+				accountId: accountId(),
+				budgetId: budgetId()
 			}),
 			{ keepFocus: true, noScroll: true }
 		);
@@ -83,7 +86,7 @@
 			{account.name}
 		</Page.Title>
 
-		<AccountSetName accountId={params.accountId} />
+		<AccountSetName accountId={accountId()} />
 	</Page.Header>
 
 	<Page.Content>
@@ -92,8 +95,8 @@
 		<Separator orientation="horizontal" />
 
 		<TransactionTable
-			accountId={params.accountId}
-			budgetId={params.budgetId}
+			accountId={accountId()}
+			budgetId={budgetId()}
 			currency={budget.currency}
 			pagination={{
 				page: result.pagination.page,

--- a/src/routes/(app)/[budgetId=id]/categories/archived/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/archived/+page.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button';
 	import * as Page from '$lib/components/ui/page';
 	import { m } from '$lib/paraglide/messages';
 	import { getArchivedCategories, restoreCategory } from '$lib/remote-functions/category.remote';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { formatDate } from '$lib/utils/format-date';
 	import { currentMonth, toParam } from '$lib/utils/month';
 	import { flip } from 'svelte/animate';
 	import PhArchive from '~icons/ph/archive';
 	import PhHandWithdraw from '~icons/ph/hand-withdraw';
 
-	const budgetId = page.params.budgetId!;
+	const budgetId = getBudgetId();
 
-	const categories = $derived(await getArchivedCategories({ budgetId }));
+	const categories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
 </script>
 
 <Page.Root>


### PR DESCRIPTION
Closes #15.

## Problem

During client-side navigation *away* from the budget/account subtree, SvelteKit's `params` transiently reflects the target route while the old page is still mounted. An id feeding a still-live top-level `$derived(await getX(...))` briefly became `undefined`, the query ran with that arg, the bare `v.string()` / object schemas rejected it, and the server returned 400 with a `Remote function schema validation failed` log. Timing-dependent — only reproduced on slow CI runners.

The same id was read three inconsistent ways across the subtree: the budget-id context getter, raw `params.x`, and `page.params.x!` with non-null assertions (which papered over exactly this transient `undefined`).

## Change

Collapse the query-arg reads to one canonical **latched ("sticky") accessor**:

- **`stickyParam(get)`** in `$lib/utils/sticky-param` — caches the last non-nullish value and returns it while the source is transiently nullish; reading inside a reactive scope still tracks the source, so consumers re-run on real param changes.
- The **budget-id context provider** latches through `stickyParam`, fixing every `getBudgetId()` consumer (`getBudgetUsers`, `getUnassigned`, `getMonthly`, …) at the single seam.
- The **account-detail page** reads `accountId` via `stickyParam` and `budgetId` via the latched context; the **month** and **archived-categories** pages read `budgetId` via the context.
- The `!` assertions on `page.params` disappear for query args.

The awaited-top-level consumption pattern (ADR-0003) is untouched — only the argument *source* is latched. **ADR-0006** records the decision and cross-links ADR-0003.

Out of scope (per the issue): the ADR-0003 pattern, a `handleValidationError` logging hook, pure non-query param uses (hrefs, hidden form fields), and `month`/`parseMonth` (already correct).

## Verification

- `npm run check` — 0 errors, 0 warnings.
- `DATABASE_URL=:memory: npm run test:unit` — 379 passed + 1 expected-fail; `stickyParam` has 4 deterministic tests.
- Playwright — 38 passed (run on an isolated port to avoid colliding with parallel worktree runs).
- `/code-review` — Standards and Spec axes both clean.
