### PR TITLE
feat: responsive dialog/drawer shell for modal surfaces (#37)

### DIFF
--- a/src/lib/components/features/category/category-detail-dialog.svelte
+++ b/src/lib/components/features/category/category-detail-dialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import * as Dialog from '$lib/components/ui/dialog';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import HashDuotoneIcon from '~icons/ph/hash-duotone';
 
@@ -7,16 +7,16 @@
 
 	let { categoryId = $bindable() }: { categoryId: null | string } = $props();
 
-	// Writable derived: bits-ui flips this locally on close so the exit
+	// Writable derived: the primitive flips this locally on close so the exit
 	// transition can play; the bound id is reset afterwards.
 	let open = $derived(categoryId !== null);
 </script>
 
-<Dialog.Root bind:open onOpenChangeComplete={(isOpen) => !isOpen && (categoryId = null)}>
-	<Dialog.Content class="max-w-4xl">
+<ResponsiveModal.Root bind:open onOpenChangeComplete={(isOpen) => !isOpen && (categoryId = null)}>
+	<ResponsiveModal.Content class="max-w-4xl">
 		{#if categoryId !== null}
 			<div class="@container flex w-full flex-col gap-6">
-				<Dialog.Title class="flex items-center gap-2 tracking-tighter italic">
+				<ResponsiveModal.Title class="flex items-center gap-2 tracking-tighter italic">
 					<span class="text-xl font-semibold">{m.category_detail_title()}</span>
 
 					<span
@@ -25,10 +25,10 @@
 						<HashDuotoneIcon />
 						{categoryId}
 					</span>
-				</Dialog.Title>
+				</ResponsiveModal.Title>
 
 				<CategoryDetail {categoryId} />
 			</div>
 		{/if}
-	</Dialog.Content>
-</Dialog.Root>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/ui/responsive-modal/context.ts
+++ b/src/lib/components/ui/responsive-modal/context.ts
@@ -1,0 +1,22 @@
+import { getContext, hasContext, setContext } from 'svelte';
+
+/** Viewport at or above which the shell renders as a Dialog instead of a Drawer. */
+export const DESKTOP_QUERY = '(min-width: 640px)';
+
+const CONTEXT_KEY = Symbol('responsive-modal');
+
+export type ResponsiveModalContext = {
+	/** `true` renders the Dialog variant, `false` the Drawer variant. Reactive. */
+	readonly isDesktop: boolean;
+};
+
+export function getResponsiveModalContext(): ResponsiveModalContext {
+	if (!hasContext(CONTEXT_KEY)) {
+		throw new Error('ResponsiveModal sub-components must be used within <ResponsiveModal.Root>.');
+	}
+	return getContext(CONTEXT_KEY);
+}
+
+export function setResponsiveModalContext(context: ResponsiveModalContext): void {
+	setContext(CONTEXT_KEY, context);
+}

--- a/src/lib/components/ui/responsive-modal/index.ts
+++ b/src/lib/components/ui/responsive-modal/index.ts
@@ -1,0 +1,34 @@
+import Close from './responsive-modal-close.svelte';
+import Content from './responsive-modal-content.svelte';
+import Description from './responsive-modal-description.svelte';
+import Footer from './responsive-modal-footer.svelte';
+import Header from './responsive-modal-header.svelte';
+import Overlay from './responsive-modal-overlay.svelte';
+import Portal from './responsive-modal-portal.svelte';
+import Title from './responsive-modal-title.svelte';
+import Trigger from './responsive-modal-trigger.svelte';
+import Root from './responsive-modal.svelte';
+
+export {
+	Close,
+	Content,
+	Description,
+	Footer,
+	Header,
+	Overlay,
+	Portal,
+	//
+	Root as ResponsiveModal,
+	Close as ResponsiveModalClose,
+	Content as ResponsiveModalContent,
+	Description as ResponsiveModalDescription,
+	Footer as ResponsiveModalFooter,
+	Header as ResponsiveModalHeader,
+	Overlay as ResponsiveModalOverlay,
+	Portal as ResponsiveModalPortal,
+	Title as ResponsiveModalTitle,
+	Trigger as ResponsiveModalTrigger,
+	Root,
+	Title,
+	Trigger
+};

--- a/src/lib/components/ui/responsive-modal/media-query.svelte.ts
+++ b/src/lib/components/ui/responsive-modal/media-query.svelte.ts
@@ -1,0 +1,26 @@
+import { browser } from '$app/environment';
+
+/**
+ * Reactive `window.matchMedia` wrapper.
+ *
+ * Instantiate inside a component's `<script>` so the internal `$effect` can
+ * subscribe to media changes and clean up on destroy. On the server (and before
+ * hydration) `matches` falls back to `defaultValue`.
+ */
+export class MediaQuery {
+	matches = $state(false);
+	#query: string;
+
+	constructor(query: string, defaultValue = false) {
+		this.#query = query;
+		this.matches = browser ? window.matchMedia(query).matches : defaultValue;
+
+		$effect(() => {
+			const mql = window.matchMedia(this.#query);
+			const onChange = () => (this.matches = mql.matches);
+			onChange();
+			mql.addEventListener('change', onChange);
+			return () => mql.removeEventListener('change', onChange);
+		});
+	}
+}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-close.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-close.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let {
+		child,
+		children,
+		class: className
+	}: {
+		/** asChild render: spread `props` onto your own close element. */
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		children?: Snippet;
+		class?: string;
+	} = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Close {child} class={className}>
+		{@render children?.()}
+	</Dialog.Close>
+{:else}
+	<Drawer.Close {child} class={className}>
+		{@render children?.()}
+	</Drawer.Close>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
@@ -3,6 +3,7 @@
 
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Drawer from '$lib/components/ui/drawer';
+	import { cn } from 'tailwind-variants';
 
 	import { getResponsiveModalContext } from './context';
 
@@ -25,7 +26,7 @@
 		{@render children()}
 	</Dialog.Content>
 {:else}
-	<Drawer.Content class={className}>
+	<Drawer.Content class={cn('px-6 pb-6', className)}>
 		{@render children()}
 	</Drawer.Content>
 {/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let {
+		children,
+		class: className,
+		showCloseButton = true
+	}: {
+		children: Snippet;
+		class?: string;
+		/** Dialog-only close button; the Drawer variant uses its drag handle. */
+		showCloseButton?: boolean;
+	} = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Content class={className} {showCloseButton}>
+		{@render children()}
+	</Dialog.Content>
+{:else}
+	<Drawer.Content class={className}>
+		{@render children()}
+	</Drawer.Content>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-description.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-description.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { children, class: className }: { children?: Snippet; class?: string } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Description class={className}>
+		{@render children?.()}
+	</Dialog.Description>
+{:else}
+	<Drawer.Description class={className}>
+		{@render children?.()}
+	</Drawer.Description>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-footer.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-footer.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { children, class: className }: { children?: Snippet; class?: string } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Footer class={className}>
+		{@render children?.()}
+	</Dialog.Footer>
+{:else}
+	<Drawer.Footer class={className}>
+		{@render children?.()}
+	</Drawer.Footer>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-header.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-header.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { children, class: className }: { children?: Snippet; class?: string } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Header class={className}>
+		{@render children?.()}
+	</Dialog.Header>
+{:else}
+	<Drawer.Header class={className}>
+		{@render children?.()}
+	</Drawer.Header>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-overlay.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-overlay.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { class: className }: { class?: string } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Overlay class={className} />
+{:else}
+	<Drawer.Overlay class={className} />
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-portal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-portal.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { children }: { children?: Snippet } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Portal>
+		{@render children?.()}
+	</Dialog.Portal>
+{:else}
+	<Drawer.Portal>
+		{@render children?.()}
+	</Drawer.Portal>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-title.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-title.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let { children, class: className }: { children?: Snippet; class?: string } = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Title class={className}>
+		{@render children?.()}
+	</Dialog.Title>
+{:else}
+	<Drawer.Title class={className}>
+		{@render children?.()}
+	</Drawer.Title>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-trigger.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-trigger.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { getResponsiveModalContext } from './context';
+
+	let {
+		child,
+		children,
+		class: className
+	}: {
+		/** asChild render: spread `props` onto your own trigger element. */
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		children?: Snippet;
+		class?: string;
+	} = $props();
+
+	const ctx = getResponsiveModalContext();
+</script>
+
+{#if ctx.isDesktop}
+	<Dialog.Trigger {child} class={className}>
+		{@render children?.()}
+	</Dialog.Trigger>
+{:else}
+	<Drawer.Trigger {child} class={className}>
+		{@render children?.()}
+	</Drawer.Trigger>
+{/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import { DESKTOP_QUERY, setResponsiveModalContext } from './context';
+	import { MediaQuery } from './media-query.svelte';
+
+	let {
+		children,
+		onOpenChangeComplete,
+		open = $bindable(false)
+	}: {
+		children?: Snippet;
+		/**
+		 * Fires after the open/close transition finishes, with the resulting open
+		 * state. Bridges bits-ui `onOpenChangeComplete` and vaul `onAnimationEnd`.
+		 */
+		onOpenChangeComplete?: (open: boolean) => void;
+		open?: boolean;
+	} = $props();
+
+	const media = new MediaQuery(DESKTOP_QUERY, true);
+
+	setResponsiveModalContext({
+		get isDesktop() {
+			return media.matches;
+		}
+	});
+</script>
+
+{#if media.matches}
+	<Dialog.Root bind:open {onOpenChangeComplete}>
+		{@render children?.()}
+	</Dialog.Root>
+{:else}
+	<Drawer.Root bind:open direction="bottom" onAnimationEnd={onOpenChangeComplete}>
+		{@render children?.()}
+	</Drawer.Root>
+{/if}

--- a/tests/playwright/category-responsive.spec.ts
+++ b/tests/playwright/category-responsive.spec.ts
@@ -1,0 +1,52 @@
+import { faker } from '@faker-js/faker';
+
+import type { Pages } from './pom';
+
+import { expect, test } from './fixture';
+import { uniqueName } from './unique-name';
+
+/**
+ * The category detail surface uses the responsive modal shell: a Dialog at
+ * >=640px and a bottom Drawer below.
+ *
+ * Seeding runs at the project's default desktop viewport (the POM navigation
+ * assumes a desktop/tablet layout); the narrow case only shrinks the viewport
+ * right before opening the detail, which is all the shell's media query reads.
+ */
+async function seedCategory(pages: Pages) {
+	await pages.auth.createUserAndLogin();
+	await pages.budget.createBudget(faker.commerce.department());
+	await pages.budget.createAccount(uniqueName(faker.finance.accountName()));
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+	return categoryName;
+}
+
+test('Category detail opens as a dialog on wide viewports', async ({ page, pages }) => {
+	const categoryName = await seedCategory(pages);
+
+	await pages.category.openDetail(categoryName);
+
+	await expect(page.locator('[data-slot="dialog-content"]')).toBeVisible();
+	await expect(page.locator('[data-slot="drawer-content"]')).toHaveCount(0);
+});
+
+test('Category detail opens as a bottom drawer on narrow viewports', async ({ page, pages }) => {
+	const categoryName = await seedCategory(pages);
+
+	await page.setViewportSize({ height: 720, width: 390 });
+	await pages.category.openDetail(categoryName);
+
+	const drawer = page.locator('[data-slot="drawer-content"]');
+	await expect(drawer).toBeVisible();
+	await expect(drawer).toHaveAttribute('data-vaul-drawer-direction', 'bottom');
+	await expect(page.locator('[data-slot="dialog-content"]')).toHaveCount(0);
+
+	// Escape dismisses the drawer, and the onOpenChangeComplete -> onAnimationEnd
+	// bridge must reset state so the same category can be reopened.
+	await page.keyboard.press('Escape');
+	await expect(drawer).toHaveCount(0);
+	await pages.category.openDetail(categoryName);
+	await expect(page.locator('[data-slot="drawer-content"]')).toBeVisible();
+});


### PR DESCRIPTION
Closes #37.

## What

A new UI-tier `ResponsiveModal` primitive that renders as a bits-ui **Dialog at ≥640px** and a vaul **bottom Drawer below**, behind one component API — so feature modules don't branch on viewport themselves.

- A small reactive `MediaQuery` helper (no new deps) reads `(min-width: 640px)`; `Root` mounts the matching primitive. No consumer-side branching.
- Full sub-component surface (`Root`/`Content`/`Header`/`Footer`/`Title`/`Description`/`Trigger`/`Close`/`Overlay`/`Portal`) delegates to the active variant via context, mirroring the existing `dialog/`/`drawer/` barrel export shape.
- `Root` bridges the two close-transition callbacks — bits-ui `onOpenChangeComplete` ↔ vaul `onAnimationEnd` (both `(open: boolean) => void`) — so state resets after the exit animation in either variant.
- Drawer variant uses `direction="bottom"` (→ `max-h-[80vh]` + existing drag handle).

## Adoption

`CategoryDetailDialog` migrated to the shell as the first adopter (incremental adoption, as the issue allows — no other surfaces touched, no primitive internals changed).

## Tests

`tests/playwright/category-responsive.spec.ts` asserts the dialog variant on wide viewports and the bottom drawer — with escape-to-dismiss and reopen — on narrow ones.

## Verification

- `npm run check`: 0 errors · `npm run lint`: clean · 375 unit tests pass
- Playwright (isolated port): both variants render correctly in a real browser, including the drawer close→reset path