### PR TITLE
ci: cut e2e Actions minutes (fewer shards, shared build, skip gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  # dorny/paths-filter (in the `gate` job) lists changed files via the API.
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -148,6 +150,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
+          if [ "${{ needs.gate.result }}" != "success" ]; then
+            echo "Gate job did not succeed (${{ needs.gate.result }}) — cannot confirm e2e status."
+            exit 1
+          fi
           if [ "${{ needs.gate.outputs.run_e2e }}" != "true" ]; then
             echo "E2E skipped (draft or docs-only change)."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,6 @@ jobs:
       - run: npm run build
         env:
           DATABASE_URL: ':memory:'
-      # Share the built server with the e2e shards so they don't each rebuild it.
-      - uses: actions/upload-artifact@v4
-        with:
-          name: app-build
-          path: build/
-          retention-days: 1
 
   check:
     runs-on: ubuntu-latest
@@ -102,7 +96,7 @@ jobs:
           fi
 
   e2e-test:
-    needs: [gate, build]
+    needs: [gate]
     if: needs.gate.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -126,14 +120,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps chromium webkit
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-      # Reuse the server built by the `build` job instead of rebuilding per shard.
-      - uses: actions/download-artifact@v4
-        with:
-          name: app-build
-          path: build/
+      - run: npx paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
       - run: npx playwright test --shard=${{ matrix.shard }}/2
-        env:
-          PW_SKIP_BUILD: '1'
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -25,6 +26,12 @@ jobs:
       - run: npm run build
         env:
           DATABASE_URL: ':memory:'
+      # Share the built server with the e2e shards so they don't each rebuild it.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: app-build
+          path: build/
+          retention-days: 1
 
   check:
     runs-on: ubuntu-latest
@@ -64,13 +71,43 @@ jobs:
         env:
           DATABASE_URL: ':memory:'
 
+  # Decide whether the (expensive) e2e suite should run for this PR.
+  # Skips drafts and changes that touch only docs/markdown.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run_e2e: ${{ steps.decide.outputs.run_e2e }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+      - id: decide
+        run: |
+          if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "Draft PR — skipping e2e."
+          elif [ "${{ steps.filter.outputs.code }}" = "true" ]; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+            echo "Code changed — running e2e."
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change — skipping e2e."
+          fi
+
   e2e-test:
+    needs: [gate, build]
+    if: needs.gate.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -87,8 +124,14 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps chromium webkit
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-      - run: npx paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
-      - run: npx playwright test --shard=${{ matrix.shard }}/4
+      # Reuse the server built by the `build` job instead of rebuilding per shard.
+      - uses: actions/download-artifact@v4
+        with:
+          name: app-build
+          path: build/
+      - run: npx playwright test --shard=${{ matrix.shard }}/2
+        env:
+          PW_SKIP_BUILD: '1'
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -96,17 +139,29 @@ jobs:
           path: blob-report/
           retention-days: 1
 
+  # Required status check. Always reports a definitive result:
+  # pass when e2e succeeded or was intentionally skipped, fail otherwise.
   e2e-success:
     name: 🎉 E2E Tests Passed
-    needs: [e2e-test]
-    if: success()
+    needs: [gate, e2e-test]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All 4 e2e shards passed."
+      - run: |
+          if [ "${{ needs.gate.outputs.run_e2e }}" != "true" ]; then
+            echo "E2E skipped (draft or docs-only change)."
+            exit 0
+          fi
+          if [ "${{ needs.e2e-test.result }}" = "success" ]; then
+            echo "All e2e shards passed."
+            exit 0
+          fi
+          echo "E2E did not pass: ${{ needs.e2e-test.result }}"
+          exit 1
 
   e2e-merge:
-    needs: [e2e-test]
-    if: always()
+    needs: [gate, e2e-test]
+    if: always() && needs.gate.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,15 @@ const DEFAULT_VIEWPORT = { height: 900, width: 1440 } as const;
 const PORT = Number(process.env.E2E_PORT ?? 3000);
 const ORIGIN = `http://localhost:${PORT}`;
 
+// In CI the app is built once in a dedicated job and the `build/` output is
+// restored as an artifact, so the shards skip the (repeated) vite build.
+// Set PW_SKIP_BUILD=1 to boot the prebuilt server directly.
+const START_SERVER = `DATABASE_URL=:memory: ORIGIN=${ORIGIN} PORT=${PORT} node build`;
+const WEB_SERVER_COMMAND =
+	process.env.PW_SKIP_BUILD === '1'
+		? START_SERVER
+		: `DATABASE_URL=:memory: npm run build && ${START_SERVER}`;
+
 export default defineConfig({
 	expect: {
 		timeout: 10000
@@ -50,7 +59,7 @@ export default defineConfig({
 	},
 
 	webServer: {
-		command: `DATABASE_URL=:memory: npm run build && DATABASE_URL=:memory: ORIGIN=${ORIGIN} PORT=${PORT} node build`,
+		command: WEB_SERVER_COMMAND,
 		port: PORT,
 		// pino logs (request logs, unhandled server errors incl. logId) go to
 		// stdout, which Playwright discards by default — keep them visible so a

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,15 +7,6 @@ const DEFAULT_VIEWPORT = { height: 900, width: 1440 } as const;
 const PORT = Number(process.env.E2E_PORT ?? 3000);
 const ORIGIN = `http://localhost:${PORT}`;
 
-// In CI the app is built once in a dedicated job and the `build/` output is
-// restored as an artifact, so the shards skip the (repeated) vite build.
-// Set PW_SKIP_BUILD=1 to boot the prebuilt server directly.
-const START_SERVER = `DATABASE_URL=:memory: ORIGIN=${ORIGIN} PORT=${PORT} node build`;
-const WEB_SERVER_COMMAND =
-	process.env.PW_SKIP_BUILD === '1'
-		? START_SERVER
-		: `DATABASE_URL=:memory: npm run build && ${START_SERVER}`;
-
 export default defineConfig({
 	expect: {
 		timeout: 10000
@@ -59,7 +50,7 @@ export default defineConfig({
 	},
 
 	webServer: {
-		command: WEB_SERVER_COMMAND,
+		command: `DATABASE_URL=:memory: npm run build && DATABASE_URL=:memory: ORIGIN=${ORIGIN} PORT=${PORT} node build`,
 		port: PORT,
 		// pino logs (request logs, unhandled server errors incl. logId) go to
 		// stdout, which Playwright discards by default — keep them visible so a


### PR DESCRIPTION
## Why

The e2e block dominates our GitHub Actions spend, and most of its cost is fixed setup overhead — each shard runs `npm ci`, installs browsers, and builds the app before any test runs. With only 6 spec files × 2 projects, 4-way sharding mostly multiplied that overhead.

## Changes

**1. Shards 4 → 2.** Halves the per-shard fixed setup (npm ci + browser install + build) with negligible impact on test wall-clock for a suite this size. This is the dominant saving.

**2. Skip e2e on drafts and docs-only changes.** A new `gate` job decides whether e2e runs: skipped for draft PRs and for changes touching only markdown/`docs/**`. The `pull_request` trigger now includes `ready_for_review` so marking a draft ready re-triggers CI. The gate uses `dorny/paths-filter`, which needs `pull-requests: read` (added to `permissions`).

## Required-checks safety

Branch protection requires `🎉 E2E Tests Passed`. That job is now `if: always()` and reports a **definitive** status:
- green when e2e passed **or** was intentionally skipped (draft / docs-only),
- red when e2e failed/cancelled **or** the gate job itself errored.

Workflow-level `paths-ignore` was intentionally not used — it would leave required checks unreported and deadlock docs-only PRs.

## Dropped during review: shared build reuse

An earlier revision built the app once and had the shards restore it as an artifact (skipping the per-shard build). This broke at runtime: the experimental `remoteFunctions` build leaves bare `$lib/*` specifiers in the SSR bundle that only resolve when `npm run build` runs in the same working tree — a prebuilt `build/` booted in a fresh environment throws `Cannot find package '$lib'` when tests hit routes whose lazy chunks import `$lib/utils/money`. Not worth the fragility for ~40s/shard, so each shard builds its own server again (as on main).

## Not included (follow-ups)

- Consolidating `build`/`check`/`lint`/`unit-test` into a single job to share one `npm ci`.
- Dropping the `tablet` (webkit) project from per-PR CI and running the full matrix nightly.