### PR TITLE
fix: month-scope Unassigned with reach-back (#44)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ The envelope-side running position of a category: the sum of its assignments plu
 _Avoid_: balance (account-side, see Balance), leftover, available
 
 **Unassigned**:
-Budget money outside every envelope: income (transactions without a category) minus all assignments, budget-lifetime. Computed only in user-context.
+Budget money outside every envelope, as seen from a Month: income (transactions without a category) up to the Month, minus assignments up to the Month, minus the part of later assignments that later income does not yet cover (reach-back). Like Remaining, the term is incomplete without a cutoff — it is month-scoped, not budget-lifetime, and comparisons are month-granular. Reach-back keeps the no-double-assignment guarantee without painting fully-assigned past months red; assigning in a future month with no income there is the intended negative "spending money you don't have" warning (ADR-0007). Advisory only — never a thrown rule. Computed only in user-context.
 _Avoid_: available, to be budgeted, free money
 
 **Balance**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ The envelope-side running position of a category: the sum of its assignments plu
 _Avoid_: balance (account-side, see Balance), leftover, available
 
 **Unassigned**:
-Budget money outside every envelope, as seen from a Month: the lowest running position — income (transactions without a category) minus assignments, accumulated month by month — at the Month or any later month. Like Remaining, the term is incomplete without a cutoff — it is month-scoped, not budget-lifetime, and comparisons are month-granular. Taking the minimum over future positions keeps the no-double-assignment guarantee (a future deficit reaches back as the intended negative "spending money you don't have" warning) while future income counts only from its own month onward — it can never fund an assignment in a month before it arrives (ADR-0007). Advisory only — never a thrown rule. Computed only in user-context.
+Budget money outside every envelope, as seen from a Month: the lowest running position — income (transactions without a category) minus assignments, accumulated month by month — at the Month or any later month. Exactly: `Unassigned(M) = min over K ≥ M of (income≤K − assignments≤K)`. Like Remaining, the term is incomplete without a cutoff — it is month-scoped, not budget-lifetime, and comparisons are month-granular. Taking the minimum over future positions keeps the no-double-assignment guarantee (a future deficit reaches back as the intended negative "spending money you don't have" warning) while future income counts only from its own month onward — it can never fund an assignment in a month before it arrives (ADR-0007). Advisory only — never a thrown rule. Computed only in user-context.
 _Avoid_: available, to be budgeted, free money
 
 **Balance**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ The envelope-side running position of a category: the sum of its assignments plu
 _Avoid_: balance (account-side, see Balance), leftover, available
 
 **Unassigned**:
-Budget money outside every envelope, as seen from a Month: income (transactions without a category) up to the Month, minus assignments up to the Month, minus the part of later assignments that later income does not yet cover (reach-back). Like Remaining, the term is incomplete without a cutoff — it is month-scoped, not budget-lifetime, and comparisons are month-granular. Reach-back keeps the no-double-assignment guarantee without painting fully-assigned past months red; assigning in a future month with no income there is the intended negative "spending money you don't have" warning (ADR-0007). Advisory only — never a thrown rule. Computed only in user-context.
+Budget money outside every envelope, as seen from a Month: the lowest running position — income (transactions without a category) minus assignments, accumulated month by month — at the Month or any later month. Like Remaining, the term is incomplete without a cutoff — it is month-scoped, not budget-lifetime, and comparisons are month-granular. Taking the minimum over future positions keeps the no-double-assignment guarantee (a future deficit reaches back as the intended negative "spending money you don't have" warning) while future income counts only from its own month onward — it can never fund an assignment in a month before it arrives (ADR-0007). Advisory only — never a thrown rule. Computed only in user-context.
 _Avoid_: available, to be budgeted, free money
 
 **Balance**:

--- a/docs/adr/0007-unassigned-is-month-scoped-with-reach-back.md
+++ b/docs/adr/0007-unassigned-is-month-scoped-with-reach-back.md
@@ -21,7 +21,7 @@ Making income month-scoped is the fix, but the two sides are not symmetric:
 - **Income should not leak from the future.** A later-dated income raising the
   present month's unassigned is the reported bug.
 
-Three cutoff shapes were considered:
+Four cutoff shapes were considered:
 
 - **Symmetric (`both ≤ M`).** Ruled out in the issue body: dropping future
   assignments reintroduces the double-assignment hole.
@@ -29,17 +29,33 @@ Three cutoff shapes were considered:
   successor months carry assignments shows a large spurious negative — January
   fully assigned plus February fully assigned makes the January page read
   `−(February assignments)` — pinning the error state on permanently.
-- **Reach-back.** Charge the present month only for the part of future
-  assignments that future income does not yet cover.
+- **Lump-sum reach-back (`income≤M − assignments≤M − max(0, assignments>M −
+income>M)`).** Charge the present month only for the part of future
+  assignments that future income does not yet cover. Rejected after it shipped
+  briefly on this branch: it treats the future as one pool and ignores ordering
+  _within_ it, so an August income "covers" May–July assignments it cannot
+  possibly fund — recording a future income raised Unassigned on every earlier
+  month page (the exact #44 leak, reproduced on production data). Algebraically
+  it is `min(position(M), position(∞))`: it checks only the final position and
+  skips every intermediate month.
+- **Lowest future position.** Evaluate the running position at M and at every
+  later month with activity, and take the minimum.
 
 ## Decision
 
-Unassigned becomes month-scoped with reach-back, computed only in `envelope.ts`
-(ADR-0004 — the assignment⨝transaction math lives there and nowhere else):
+Unassigned becomes month-scoped with reach-back via the lowest future running
+position, computed only in `envelope.ts` (ADR-0004 — the
+assignment⨝transaction math lives there and nowhere else):
 
 ```
-Unassigned(M) = income≤M − assignments≤M − max(0, assignments>M − income>M)
+position(K)   = income≤K − assignments≤K
+Unassigned(M) = min over K ≥ M of position(K)
 ```
+
+This is the largest amount assignable at M without driving any present or
+future month's position negative. A future deficit still reaches back (it drags
+the minimum down), but future income counts only from its own month onward — it
+can never fund an assignment in a month before it arrives.
 
 - Comparisons are **month-granular**: income by `strftime('%Y%m', date)`,
   assignments by their `month` column. A salary dated July 25 counts on the July
@@ -59,12 +75,16 @@ Unassigned(M) = income≤M − assignments≤M − max(0, assignments>M − inco
 
 ## Consequences
 
-- A fully-assigned past month reads zero instead of a spurious negative:
-  future assignments covered by future income reach back nothing.
+- A fully-assigned past month reads zero instead of a spurious negative: its
+  own position and all later positions sit at zero.
 - Assigning in a future month with no recorded income there turns the present
   month's Unassigned negative — the intended "assigning money you don't have"
-  warning. Pre-recording the expected income clears it.
-- The no-double-assignment guarantee holds: future assignments reduce present
-  Unassigned exactly to the extent future income does not cover them.
+  warning. Pre-recording the expected income (in or before the assignment's
+  month) clears it.
+- The no-double-assignment guarantee holds: assigning exactly Unassigned(M) at
+  M brings the lowest future position to zero; one cent more sends some month
+  negative.
+- Unassigned(M) is monotone non-decreasing in M: navigating forward can only
+  reveal money, never lose it.
 - Unassigned now carries a cutoff like Remaining; CONTEXT.md records the term as
   incomplete without one.

--- a/docs/adr/0007-unassigned-is-month-scoped-with-reach-back.md
+++ b/docs/adr/0007-unassigned-is-month-scoped-with-reach-back.md
@@ -1,0 +1,70 @@
+# ADR-0007: Unassigned is month-scoped with reach-back
+
+Date: 2026-07-12
+Status: accepted
+
+## Context
+
+`budget.unassigned` computed income (transactions with `categoryId IS NULL`)
+minus **all** assignments, with no date condition on either side (#44). The
+number is therefore budget-lifetime: the month-view unassigned summary shows the
+same value on every month page, and a future-dated income (salary dated the 25th,
+recorded on the 11th) raises unassigned today, letting the user assign money they
+have not received — with no view flagging it. Unlike Remaining, which already
+carried a cutoff, Unassigned had none.
+
+Making income month-scoped is the fix, but the two sides are not symmetric:
+
+- **Assignments must stay reach-across-time.** Money assigned to a future month
+  is spoken for and must reduce unassigned now, or the same euro could be
+  assigned twice (once in January, again in March).
+- **Income should not leak from the future.** A later-dated income raising the
+  present month's unassigned is the reported bug.
+
+Three cutoff shapes were considered:
+
+- **Symmetric (`both ≤ M`).** Ruled out in the issue body: dropping future
+  assignments reintroduces the double-assignment hole.
+- **Plain asymmetric (`income ≤ M − all assignments`).** Every past month whose
+  successor months carry assignments shows a large spurious negative — January
+  fully assigned plus February fully assigned makes the January page read
+  `−(February assignments)` — pinning the error state on permanently.
+- **Reach-back.** Charge the present month only for the part of future
+  assignments that future income does not yet cover.
+
+## Decision
+
+Unassigned becomes month-scoped with reach-back, computed only in `envelope.ts`
+(ADR-0004 — the assignment⨝transaction math lives there and nowhere else):
+
+```
+Unassigned(M) = income≤M − assignments≤M − max(0, assignments>M − income>M)
+```
+
+- Comparisons are **month-granular**: income by `strftime('%Y%m', date)`,
+  assignments by their `month` column. A salary dated July 25 counts on the July
+  page even on July 11 — the month is the planning unit; only cross-month leakage
+  was the bug.
+- **No `today`.** The envelope seam stays pure (no clock injection); numbers are
+  deterministic per month.
+- `unassigned(db, budgetId, month)` and `queries.unassigned(budgetId, month)`
+  widen to take the month; `getUnassigned` widens to `BudgetMonthSchema`. It
+  stays a **separate scalar query**, not folded into `getMonthly` — both
+  consumers want exactly one number and `refreshBudgetData` already unifies the
+  refresh flow.
+- **Advisory only.** `budget.assignment` keeps accepting anything; a negative
+  Unassigned stays a displayed warning (red state in `unassigned-summary.svelte`),
+  never a thrown rule. This preserves the optimistic assignment hot path and
+  pre-assigning before salary lands.
+
+## Consequences
+
+- A fully-assigned past month reads zero instead of a spurious negative:
+  future assignments covered by future income reach back nothing.
+- Assigning in a future month with no recorded income there turns the present
+  month's Unassigned negative — the intended "assigning money you don't have"
+  warning. Pre-recording the expected income clears it.
+- The no-double-assignment guarantee holds: future assignments reduce present
+  Unassigned exactly to the extent future income does not cover them.
+- Unassigned now carries a cutoff like Remaining; CONTEXT.md records the term as
+  incomplete without one.

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -57,8 +57,8 @@ export const getMonthly = guardedQuery(BudgetMonthSchema, async ({ budgetId, mon
 	ctx.budget.monthly(budgetId, month)
 );
 
-export const getUnassigned = guardedQuery(v.string(), async (id, { ctx }) =>
-	ctx.budget.unassigned(id)
+export const getUnassigned = guardedQuery(BudgetMonthSchema, async ({ budgetId, month }, { ctx }) =>
+	ctx.budget.unassigned(budgetId, month)
 );
 
 const refreshBudgetData = () =>

--- a/src/lib/server/db/month-sql.ts
+++ b/src/lib/server/db/month-sql.ts
@@ -7,6 +7,10 @@ import { type AnyColumn, type SQL, sql } from 'drizzle-orm';
  * param string — this file is the only place that knows about this pairing.
  */
 
+export function dateIsAfter(dateColumn: AnyColumn, month: Month): SQL {
+	return sql`strftime('%Y%m', ${dateColumn}) > ${toParam(month)}`;
+}
+
 export function dateIsInMonth(dateColumn: AnyColumn, month: Month): SQL {
 	return sql`strftime('%Y%m', ${dateColumn}) = ${toParam(month)}`;
 }

--- a/src/lib/server/db/month-sql.ts
+++ b/src/lib/server/db/month-sql.ts
@@ -7,10 +7,6 @@ import { type AnyColumn, type SQL, sql } from 'drizzle-orm';
  * param string — this file is the only place that knows about this pairing.
  */
 
-export function dateIsAfter(dateColumn: AnyColumn, month: Month): SQL {
-	return sql`strftime('%Y%m', ${dateColumn}) > ${toParam(month)}`;
-}
-
 export function dateIsInMonth(dateColumn: AnyColumn, month: Month): SQL {
 	return sql`strftime('%Y%m', ${dateColumn}) = ${toParam(month)}`;
 }

--- a/src/lib/server/db/user-context/budget.test.ts
+++ b/src/lib/server/db/user-context/budget.test.ts
@@ -240,7 +240,10 @@ describe('queries.monthly', () => {
 });
 
 describe('queries.unassigned', () => {
-	it('calculates income minus assignments', () => {
+	const jan = parseMonth(202501)!;
+	const feb = parseMonth(202502)!;
+
+	it('calculates income up to the month minus assignments up to the month', () => {
 		const db = createDatabase(':memory:');
 		const { budget, user } = createBudgetWithUser(db);
 		const a = db
@@ -262,7 +265,33 @@ describe('queries.unassigned', () => {
 			.run();
 		const { unassigned } = queries(user.id, db);
 
-		expect(unassigned(budget.id)).toBe(700);
+		expect(unassigned(budget.id, jan)).toBe(700);
+	});
+
+	it('reaches back an uncovered future assignment', () => {
+		const db = createDatabase(':memory:');
+		const { budget, user } = createBudgetWithUser(db);
+		const a = db
+			.insert(tables.accounts)
+			.values({ budgetId: budget.id, name: 'A' })
+			.returning()
+			.get();
+		db.insert(tables.transactions)
+			.values({ accountId: a.id, amount: 1000, budgetId: budget.id, date: '2025-01-01' })
+			.run();
+		const cat = db
+			.insert(tables.categories)
+			.values({ budgetId: budget.id, name: 'Rent' })
+			.returning()
+			.get();
+		// Assigned in February with no February income to cover it.
+		db.insert(tables.budgetAssignments)
+			.values({ amount: 300, budgetId: budget.id, categoryId: cat.id, month: 202502 })
+			.run();
+		const { unassigned } = queries(user.id, db);
+
+		// Viewing January: 1000 - 0 - max(0, 300 - 0) = 700.
+		expect(unassigned(budget.id, jan)).toBe(700);
 	});
 
 	it('returns 0 when no income', () => {
@@ -270,7 +299,16 @@ describe('queries.unassigned', () => {
 		const { budget, user } = createBudgetWithUser(db);
 		const { unassigned } = queries(user.id, db);
 
-		expect(unassigned(budget.id)).toBe(0);
+		expect(unassigned(budget.id, jan)).toBe(0);
+	});
+
+	it('returns 0 for a budget the user cannot access', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const outsider = createUser(db, 'outsider');
+		const { unassigned } = queries(outsider.id, db);
+
+		expect(unassigned(budget.id, feb)).toBe(0);
 	});
 });
 

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -161,14 +161,14 @@ export const queries = (userId: string, db: Database = database) => ({
 		return withOrder(qb, tables.categories, 'category', userId).all();
 	},
 
-	unassigned: (budgetId: string) => {
+	unassigned: (budgetId: string, month: Month) => {
 		const found = db
 			.select({ id: tables.budgets.id })
 			.from(tables.budgets)
 			.where(and(eq(tables.budgets.id, budgetId), hasAccess(tables.budgets, userId, db)))
 			.get();
 		if (!found) return 0;
-		return unassignedForBudget(db, budgetId);
+		return unassignedForBudget(db, budgetId, month);
 	},
 
 	users: (budgetId: string) => {

--- a/src/lib/server/db/user-context/envelope.test.ts
+++ b/src/lib/server/db/user-context/envelope.test.ts
@@ -291,9 +291,57 @@ describe('unassigned', () => {
 		seedAssignment(db, budget.id, cat.id, feb, 50000); // Feb assignment
 		seedAssignment(db, budget.id, cat.id, mar, 10000); // Mar assignment
 
-		// Viewing Jan: assignments after = 60000, income after = 30000.
-		// 100000 - 0 - max(0, 60000 - 30000) = 70000.
+		// Viewing Jan: positions are Feb = 100000 + 30000 - 50000 = 80000,
+		// Mar = 80000 - 10000 = 70000. The lowest future position wins.
 		expect(unassigned(db, budget.id, jan)).toBe(70000);
+	});
+
+	it('does not let income after an uncovered assignment fund it retroactively', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // Jan income
+		seedAssignment(db, budget.id, cat.id, feb, 50000); // Feb assignment, uncovered in Feb
+		seedTransaction(db, budget.id, account.id, null, '2025-03-10', 50000); // Mar income
+
+		// The Mar income arrives AFTER the Feb assignment; it cannot fund it.
+		// Viewing Jan, only 50000 is safe to assign: position(Feb) = 50000 is the
+		// lowest future position. A future-lump formula would report 100000.
+		expect(unassigned(db, budget.id, jan)).toBe(50000);
+		// From Mar onward the income is present: 100000 - 50000 + 50000 = 100000.
+		expect(unassigned(db, budget.id, mar)).toBe(100000);
+	});
+
+	it('keeps earlier months pinned to a fully-consumed month despite later income', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		// The #44 production shape: income fully assigned through Feb, then a
+		// future-dated income in Mar. Jan must stay at zero — the Mar money must
+		// not appear on any month page before Mar.
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // Jan income
+		seedAssignment(db, budget.id, cat.id, feb, 100000); // consumed by Feb
+		seedTransaction(db, budget.id, account.id, null, '2025-03-15', 50000); // Mar income
+
+		expect(unassigned(db, budget.id, jan)).toBe(0);
+		expect(unassigned(db, budget.id, feb)).toBe(0);
+		expect(unassigned(db, budget.id, mar)).toBe(50000);
+	});
+
+	it('shows zero on a month before any activity even when later income exists', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+
+		seedTransaction(db, budget.id, account.id, null, '2025-02-10', 40000); // Feb income only
+
+		// Viewing Jan: position(Jan) = 0 and the Feb income lies ahead — nothing
+		// is assignable yet.
+		expect(unassigned(db, budget.id, jan)).toBe(0);
 	});
 
 	it('excludes income dated in a later month', () => {

--- a/src/lib/server/db/user-context/envelope.test.ts
+++ b/src/lib/server/db/user-context/envelope.test.ts
@@ -204,35 +204,35 @@ describe('categoryBalances', () => {
 });
 
 describe('unassigned', () => {
-	it('returns income minus all assignments, budget-lifetime', () => {
+	const jan = parseMonth(202501)!;
+	const feb = parseMonth(202502)!;
+	const mar = parseMonth(202503)!;
+
+	it('returns income up to the month minus assignments up to the month', () => {
 		const db = createDatabase(':memory:');
 		const { budget } = createBudgetWithUser(db);
 		const account = seedAccount(db, budget.id, 'Checking');
 		const cat = seedCategory(db, budget.id, 'Groceries');
-		const jan = parseMonth(202501)!;
-		const feb = parseMonth(202502)!;
 
 		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // income
 		seedTransaction(db, budget.id, account.id, null, '2025-01-15', 50000); // more income
 		seedTransaction(db, budget.id, account.id, cat.id, '2025-01-20', -30000); // categorized (not income)
 		seedAssignment(db, budget.id, cat.id, jan, 20000);
-		seedAssignment(db, budget.id, cat.id, feb, 10000); // future month, still included
 
-		expect(unassigned(db, budget.id)).toBe(100000 + 50000 - 20000 - 10000); // 120000
+		expect(unassigned(db, budget.id, jan)).toBe(100000 + 50000 - 20000); // 130000
 	});
 
 	it('returns zero when there is no income and no assignments', () => {
 		const db = createDatabase(':memory:');
 		const { budget } = createBudgetWithUser(db);
 
-		expect(unassigned(db, budget.id)).toBe(0);
+		expect(unassigned(db, budget.id, jan)).toBe(0);
 	});
 
-	it('returns negative when assignments exceed income', () => {
+	it('returns negative when assignments in the month exceed income', () => {
 		const db = createDatabase(':memory:');
 		const { budget } = createBudgetWithUser(db);
 		const cat = seedCategory(db, budget.id, 'Overassigned');
-		const jan = parseMonth(202501)!;
 
 		seedTransaction(
 			db,
@@ -244,21 +244,78 @@ describe('unassigned', () => {
 		);
 		seedAssignment(db, budget.id, cat.id, jan, 30000);
 
-		expect(unassigned(db, budget.id)).toBe(-20000);
+		expect(unassigned(db, budget.id, jan)).toBe(-20000);
 	});
 
-	it('includes future-dated income and future-month assignments (all-time quirk, #44)', () => {
+	it('is zero on a fully-assigned past month even when later months are also fully assigned', () => {
 		const db = createDatabase(':memory:');
 		const { budget } = createBudgetWithUser(db);
 		const account = seedAccount(db, budget.id, 'Checking');
-		const cat = seedCategory(db, budget.id, 'Future');
-		const futureMonth = parseMonth(202512)!;
+		const cat = seedCategory(db, budget.id, 'Groceries');
 
-		seedTransaction(db, budget.id, account.id, null, '2025-12-01', 50000); // future income
-		seedAssignment(db, budget.id, cat.id, futureMonth, 50000); // future assignment
+		// Jan: 100000 income, fully assigned.
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000);
+		seedAssignment(db, budget.id, cat.id, jan, 100000);
+		// Feb: 100000 income, fully assigned.
+		seedTransaction(db, budget.id, account.id, null, '2025-02-10', 100000);
+		seedAssignment(db, budget.id, cat.id, feb, 100000);
 
-		// #44 tracks that future income should not count — but behaviour is
-		// preserved as-is behind the seam so it can be changed locally later.
-		expect(unassigned(db, budget.id)).toBe(0); // 50000 - 50000
+		// Viewing Jan: Feb's assignment is fully covered by Feb's income, so it
+		// reaches back nothing. 100000 - 100000 - max(0, 100000 - 100000) = 0.
+		expect(unassigned(db, budget.id, jan)).toBe(0);
+	});
+
+	it('reaches back an uncovered future assignment into the present month', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		// Jan: 100000 income, nothing assigned yet.
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000);
+		// Feb: 50000 assigned, but no Feb income to cover it.
+		seedAssignment(db, budget.id, cat.id, feb, 50000);
+
+		// Viewing Jan: 100000 - 0 - max(0, 50000 - 0) = 50000.
+		expect(unassigned(db, budget.id, jan)).toBe(50000);
+	});
+
+	it('only reaches back the portion of future assignments not covered by future income', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+		const cat = seedCategory(db, budget.id, 'Groceries');
+
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // Jan income
+		seedTransaction(db, budget.id, account.id, null, '2025-02-10', 30000); // Feb income
+		seedAssignment(db, budget.id, cat.id, feb, 50000); // Feb assignment
+		seedAssignment(db, budget.id, cat.id, mar, 10000); // Mar assignment
+
+		// Viewing Jan: assignments after = 60000, income after = 30000.
+		// 100000 - 0 - max(0, 60000 - 30000) = 70000.
+		expect(unassigned(db, budget.id, jan)).toBe(70000);
+	});
+
+	it('excludes income dated in a later month', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+
+		seedTransaction(db, budget.id, account.id, null, '2025-01-10', 100000); // Jan income
+		seedTransaction(db, budget.id, account.id, null, '2025-02-10', 40000); // Feb income
+
+		// Viewing Jan: only Jan income counts, and Feb income covers no assignment.
+		expect(unassigned(db, budget.id, jan)).toBe(100000);
+	});
+
+	it('counts month-granular income on the viewed month regardless of day', () => {
+		const db = createDatabase(':memory:');
+		const { budget } = createBudgetWithUser(db);
+		const account = seedAccount(db, budget.id, 'Checking');
+
+		// Salary dated late in January counts on the January page.
+		seedTransaction(db, budget.id, account.id, null, '2025-01-25', 80000);
+
+		expect(unassigned(db, budget.id, jan)).toBe(80000);
 	});
 });

--- a/src/lib/server/db/user-context/envelope.ts
+++ b/src/lib/server/db/user-context/envelope.ts
@@ -1,7 +1,7 @@
 import type { Month } from '$lib/utils/month';
 
 import { type Database, tables } from '$db';
-import { dateIsAfter, dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
+import { dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
 import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 
 /**
@@ -106,46 +106,51 @@ export function categoryBalances(db: Database, month: Month) {
  * Month-scoped Unassigned with reach-back (ADR-0007): budget money outside
  * every envelope as seen from month `M`.
  *
- *   Unassigned(M) = income≤M − assignments≤M − max(0, assignments>M − income>M)
+ *   Unassigned(M) = min over K ≥ M of (income≤K − assignments≤K)
  *
  * Income is transactions without a category; comparisons are month-granular
  * (income by `strftime('%Y%m', date)`, assignments by their `month` column).
- * The reach-back term charges the present month only for future assignments
- * that future income does not yet cover, so a fully-assigned past month reads
- * zero rather than a spurious negative. Access control is the caller's
- * responsibility.
+ * Taking the lowest running position at M and every later month means a
+ * future deficit reaches back (assigning money that is spoken for later warns
+ * now), while future income counts only from its own month onward — it can
+ * never fund an assignment in a month before it arrives. Access control is
+ * the caller's responsibility.
  */
 export function unassigned(db: Database, budgetId: string, month: Month): number {
-	const [assignments] = db
+	const assignments = db
 		.select({
-			after:
-				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} > ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
-					'after'
-				),
-			until:
-				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} <= ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
-					'until'
-				)
+			month: tables.budgetAssignments.month,
+			total: sql<number>`sum(${tables.budgetAssignments.amount})`.as('total')
 		})
 		.from(tables.budgetAssignments)
 		.where(eq(tables.budgetAssignments.budgetId, budgetId))
+		.groupBy(tables.budgetAssignments.month)
 		.all();
 
-	const [income] = db
+	const income = db
 		.select({
-			after:
-				sql<number>`coalesce(sum(CASE WHEN ${dateIsAfter(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
-					'after'
-				),
-			until:
-				sql<number>`coalesce(sum(CASE WHEN ${dateIsOnOrBefore(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
-					'until'
-				)
+			month: sql<number>`cast(strftime('%Y%m', ${tables.transactions.date}) AS integer)`.as(
+				'month'
+			),
+			total: sql<number>`sum(${tables.transactions.amount})`.as('total')
 		})
 		.from(tables.transactions)
 		.where(and(eq(tables.transactions.budgetId, budgetId), isNull(tables.transactions.categoryId)))
+		.groupBy(sql`strftime('%Y%m', ${tables.transactions.date})`)
 		.all();
 
-	const reachBack = Math.max(0, (assignments?.after ?? 0) - (income?.after ?? 0));
-	return (income?.until ?? 0) - (assignments?.until ?? 0) - reachBack;
+	// Net change of the running position per month, with M itself as a
+	// checkpoint so position(M) participates in the minimum even when the
+	// month has no entries of its own.
+	const deltas = new Map<number, number>([[month, 0]]);
+	for (const row of income) deltas.set(row.month, (deltas.get(row.month) ?? 0) + row.total);
+	for (const row of assignments) deltas.set(row.month, (deltas.get(row.month) ?? 0) - row.total);
+
+	let position = 0;
+	let lowest = Infinity;
+	for (const m of [...deltas.keys()].sort((a, b) => a - b)) {
+		position += deltas.get(m) ?? 0;
+		if (m >= month) lowest = Math.min(lowest, position);
+	}
+	return lowest;
 }

--- a/src/lib/server/db/user-context/envelope.ts
+++ b/src/lib/server/db/user-context/envelope.ts
@@ -1,7 +1,7 @@
 import type { Month } from '$lib/utils/month';
 
 import { type Database, tables } from '$db';
-import { dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
+import { dateIsAfter, dateIsInMonth, dateIsOnOrBefore } from '$db/month-sql';
 import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
 
 /**
@@ -103,25 +103,49 @@ export function categoryBalances(db: Database, month: Month) {
 }
 
 /**
- * Budget-lifetime income (transactions without a category) minus all
- * assignments. Access control is the caller's responsibility.
+ * Month-scoped Unassigned with reach-back (ADR-0007): budget money outside
+ * every envelope as seen from month `M`.
+ *
+ *   Unassigned(M) = income≤M − assignments≤M − max(0, assignments>M − income>M)
+ *
+ * Income is transactions without a category; comparisons are month-granular
+ * (income by `strftime('%Y%m', date)`, assignments by their `month` column).
+ * The reach-back term charges the present month only for future assignments
+ * that future income does not yet cover, so a fully-assigned past month reads
+ * zero rather than a spurious negative. Access control is the caller's
+ * responsibility.
  */
-export function unassigned(db: Database, budgetId: string): number {
-	const [assignmentTotal] = db
+export function unassigned(db: Database, budgetId: string, month: Month): number {
+	const [assignments] = db
 		.select({
-			sum: sql<number>`coalesce(sum(${tables.budgetAssignments.amount}), 0)`.as('sum')
+			after:
+				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} > ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
+					'after'
+				),
+			until:
+				sql<number>`coalesce(sum(CASE WHEN ${tables.budgetAssignments.month} <= ${month} THEN ${tables.budgetAssignments.amount} ELSE 0 END), 0)`.as(
+					'until'
+				)
 		})
 		.from(tables.budgetAssignments)
 		.where(eq(tables.budgetAssignments.budgetId, budgetId))
 		.all();
 
-	const [incomeTotal] = db
+	const [income] = db
 		.select({
-			sum: sql<number>`coalesce(sum(${tables.transactions.amount}), 0)`.as('sum')
+			after:
+				sql<number>`coalesce(sum(CASE WHEN ${dateIsAfter(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
+					'after'
+				),
+			until:
+				sql<number>`coalesce(sum(CASE WHEN ${dateIsOnOrBefore(tables.transactions.date, month)} THEN ${tables.transactions.amount} ELSE 0 END), 0)`.as(
+					'until'
+				)
 		})
 		.from(tables.transactions)
 		.where(and(eq(tables.transactions.budgetId, budgetId), isNull(tables.transactions.categoryId)))
 		.all();
 
-	return (incomeTotal?.sum ?? 0) - (assignmentTotal?.sum ?? 0);
+	const reachBack = Math.max(0, (assignments?.after ?? 0) - (income?.after ?? 0));
+	return (income?.until ?? 0) - (assignments?.until ?? 0) - reachBack;
 }

--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -52,7 +52,7 @@
 
 				<CategoryQuickActions />
 
-				<UnassignedSummary />
+				<UnassignedSummary {month} />
 			</div>
 
 			<CategoryBudgetTable

--- a/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/transfer-popup.svelte
@@ -35,7 +35,7 @@
 
 	const budgetId = getBudgetId();
 	const budget = $derived(await getBudget(budgetId()));
-	const unassigned = $derived(await getUnassigned(budgetId()));
+	const unassigned = $derived(await getUnassigned({ budgetId: budgetId(), month }));
 	const getOtherRemaining = $derived(
 		(id: string) => otherCategories.find((f) => f.id === id)?.remaining ?? 0
 	);

--- a/src/routes/(app)/[budgetId=id]/[month=month]/unassigned-summary.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/unassigned-summary.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import type { Month } from '$lib/utils/month';
+
 	import { m } from '$lib/paraglide/messages';
 	import { getBudget, getUnassigned } from '$lib/remote-functions/budget.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
@@ -7,9 +9,11 @@
 	import CheckFatDuoToneIcon from '~icons/ph/check-fat-duotone';
 	import WarningOctagonBoldIcon from '~icons/ph/warning-octagon-bold';
 
+	let { month }: { month: Month } = $props();
+
 	const budgetId = getBudgetId();
 
-	const unassigned = $derived(await getUnassigned(budgetId()));
+	const unassigned = $derived(await getUnassigned({ budgetId: budgetId(), month }));
 
 	const { currency } = $derived(await getBudget(budgetId()));
 </script>

--- a/tests/playwright/unassigned-month-scope.spec.ts
+++ b/tests/playwright/unassigned-month-scope.spec.ts
@@ -1,0 +1,104 @@
+import { asMoney, formatMoney } from '$lib/utils/money';
+import { addMonths, type Month, parseMonth, toParam } from '$lib/utils/month';
+import { faker } from '@faker-js/faker';
+
+import { expect, test } from './fixture';
+import { uniqueName } from './unique-name';
+
+// Regression for #44: Unassigned is month-scoped. A starting balance is an
+// income transaction dated the current month; on any earlier month it must not
+// count (income ≤ viewed month), so those pages read zero — not the income.
+test('Unassigned does not leak current-month income into earlier months (#44)', async ({
+	page,
+	pages
+}) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	// €5.00 income, dated today → the current month.
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName, '5');
+
+	// Back on the budget page; capture budgetId + current month from the URL.
+	await pages.budget.goto(budgetName);
+	const url = new URL(page.url());
+	const [, budgetId, currentParam] = url.pathname.split('/');
+	const current = parseMonth(currentParam)!;
+	const prev = addMonths(current, -1);
+	const next = addMonths(current, 1);
+	const monthUrl = (m: Month) => `${url.origin}/${budgetId}/${toParam(m)}`;
+
+	const five = formatMoney({ currency: 'EUR', money: asMoney(500) });
+
+	// Current month: the €5.00 is available and unassigned.
+	await page.goto(monthUrl(current));
+	await expect(page.getByText('Unallocated:')).toBeVisible();
+	await expect(page.getByText(five)).toBeVisible();
+
+	// Previous month: income is dated the current month, so it is not yet
+	// present here — Unassigned is zero ("All done."), not €5.00.
+	await page.goto(monthUrl(prev));
+	await expect(page.getByText('All done.')).toBeVisible();
+	await expect(page.getByText(five)).toHaveCount(0);
+
+	// Next month: the income is available (income ≤ next), so €5.00 again.
+	await page.goto(monthUrl(next));
+	await expect(page.getByText('Unallocated:')).toBeVisible();
+	await expect(page.getByText(five)).toBeVisible();
+});
+
+// The exact scenario from the #44 review: an income transaction dated in a
+// FUTURE month (here current + 2). It must count only from that month onward —
+// never on the current month, and never on earlier months.
+test('Unassigned counts a future-dated income only from its month onward (#44)', async ({
+	page,
+	pages
+}) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const url = new URL(page.url());
+	const [, budgetId, currentParam] = url.pathname.split('/');
+	const current = parseMonth(currentParam)!;
+	const monthUrl = (m: Month) => `${url.origin}/${budgetId}/${toParam(m)}`;
+
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName);
+	await pages.account.goto(accountName);
+
+	// New income transaction (no category) dated two months in the future.
+	await page.getByRole('button', { name: 'New Transaction' }).click();
+	const createRow = page.getByRole('row', { name: 'New Transaction' });
+	// The date picker defaults to today, so its accessible name is today's date,
+	// not the "Select date" placeholder — target the popover-trigger button.
+	await createRow.locator('button[aria-haspopup="dialog"]').click();
+	const nextMonth = page.locator('[data-calendar-next-button]');
+	await nextMonth.click();
+	await nextMonth.click();
+	await page.locator('[data-calendar-day]:not([data-outside-month])', { hasText: /^15$/ }).click();
+	await createRow.getByRole('textbox', { name: 'Amount' }).fill('5');
+	await createRow.getByRole('button', { exact: true, name: 'Save' }).click();
+	await expect(createRow).toBeHidden();
+
+	const incomeMonth = addMonths(current, 2);
+	const five = formatMoney({ currency: 'EUR', money: asMoney(500) });
+
+	// Earlier month, current month, and the month right before the income month:
+	// the money is not present yet, so Unassigned is zero.
+	for (const m of [addMonths(current, -1), current, addMonths(current, 1)]) {
+		await page.goto(monthUrl(m));
+		await expect(page.getByText('All done.')).toBeVisible();
+		await expect(page.getByText(five)).toHaveCount(0);
+	}
+
+	// The income month and the one after it: €5.00 is available and unassigned.
+	for (const m of [incomeMonth, addMonths(incomeMonth, 1)]) {
+		await page.goto(monthUrl(m));
+		await expect(page.getByText('Unallocated:')).toBeVisible();
+		await expect(page.getByText(five)).toBeVisible();
+	}
+});


### PR DESCRIPTION
Closes #44.

## Problem

`budget.unassigned` computed income (transactions with `categoryId IS NULL`) minus **all** assignments, with no date cutoff on either side. The number was budget-lifetime, so the month-view summary showed the same value on every month page, and future-dated income (salary dated the 25th, recorded on the 11th) raised Unassigned *today* — letting the user assign money they had not received, with no view flagging it.

## Fix

`Unassigned` becomes month-scoped with **reach-back**, computed as the lowest future running position:

```
position(K)   = income≤K − assignments≤K
Unassigned(M) = min over K ≥ M of position(K)
```

- Comparisons are month-granular (income by `strftime('%Y%m', date)`, assignments by their `month` column); a salary dated July 25 counts on the July page. No `today` — the envelope seam stays pure.
- The minimum is the largest amount assignable at M without driving any present or future month negative: a future deficit still reaches back (drags the minimum down), but future income counts only from its own month onward — it can never fund an assignment in a month before it arrives. A fully-assigned past month reads zero, and the no-double-assignment guarantee holds.
- An earlier revision of this branch used a lump-sum reach-back (`income≤M − assignments≤M − max(0, assignments>M − income>M)`). It treated the future as one pool and ignored ordering within it, so recording a future-dated income raised Unassigned on every *earlier* month page — the exact #44 leak, reproduced on production data. ADR-0007 records both shapes and why the lump sum was rejected.
- Advisory only — a negative Unassigned stays a displayed warning, never a thrown rule.

## Changes

- `envelope.ts` — `unassigned(db, budgetId, month)` groups income and assignments per month and scans for the lowest running position at/after M (ADR-0004: math lives only here).
- `budget.ts` `queries.unassigned` and `budget.remote.ts` `getUnassigned` widen to `{ budgetId, month }` (`BudgetMonthSchema`); stays a separate scalar query.
- `unassigned-summary.svelte` (new `month` prop from `+page.svelte`) and `transfer-popup.svelte` pass the route month.
- Docs — CONTEXT.md `Unassigned` entry rewritten; ADR-0007 added.
- Tests — `envelope.test.ts` and `budget.test.ts` unassigned suites rewritten: fully-assigned past month = 0, uncovered future assignment reaches back, partial future coverage, income dated later month excluded, month-granular salary, and the ordering cases the lump sum missed (income after an uncovered assignment does not fund it retroactively; earlier months stay pinned to a fully-consumed month despite later income). E2E `unassigned-month-scope.spec.ts` locks the month-navigation behavior.

## Verification

- `npm run check` — 0 errors, lint clean
- Unit suite — 388 passed, 1 expected-fail
- E2E `unassigned-month-scope.spec.ts` — 6 passed; `budget.spec.ts` — 10 passed
- Real `unassigned()` run against a production snapshot: with a future-dated +500 income in August, April–July read 6130 and August+ read 56130 — the 500 appears only from its month onward (previously it leaked into every month except the current one)
