### PR TITLE
fix: refresh all requested query instances after mutations (#75)

### DIFF
--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -15,6 +15,8 @@ import { guardedCommand, guardedForm, guardedQuery } from '$server/utils/remote-
 import { redirect } from '@sveltejs/kit';
 import * as v from 'valibot';
 
+import { REFRESH_LIMIT } from './remote.utils';
+
 export const getBudgets = guardedQuery(async ({ ctx }) => ctx.budget.all());
 
 export const getBudget = guardedQuery(v.string(), async (id, { ctx }) => ctx.budget.byId(id));
@@ -61,15 +63,10 @@ export const getUnassigned = guardedQuery(BudgetMonthSchema, async ({ budgetId, 
 	ctx.budget.unassigned(budgetId, month)
 );
 
-// requested(...) limits must stay Infinity: clients pass query functions to
-// .updates(...), which requests a refresh for every live instance — including
-// stale ones from client-side month navigation that are only evicted on GC.
-// A finite limit rejects the excess with a 400, putting the visible query
-// into a failed state (stale table, uncaught error in the console).
 const refreshBudgetData = () =>
 	Promise.all([
-		requested(getMonthly, Infinity).refreshAll(),
-		requested(getUnassigned, Infinity).refreshAll()
+		requested(getMonthly, REFRESH_LIMIT).refreshAll(),
+		requested(getUnassigned, REFRESH_LIMIT).refreshAll()
 	]);
 
 export const assignment = guardedForm(AssignmentSchema, async (data, { ctx }) => {

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -61,8 +61,16 @@ export const getUnassigned = guardedQuery(BudgetMonthSchema, async ({ budgetId, 
 	ctx.budget.unassigned(budgetId, month)
 );
 
+// requested(...) limits must stay Infinity: clients pass query functions to
+// .updates(...), which requests a refresh for every live instance — including
+// stale ones from client-side month navigation that are only evicted on GC.
+// A finite limit rejects the excess with a 400, putting the visible query
+// into a failed state (stale table, uncaught error in the console).
 const refreshBudgetData = () =>
-	Promise.all([requested(getMonthly, 1).refreshAll(), requested(getUnassigned, 1).refreshAll()]);
+	Promise.all([
+		requested(getMonthly, Infinity).refreshAll(),
+		requested(getUnassigned, Infinity).refreshAll()
+	]);
 
 export const assignment = guardedForm(AssignmentSchema, async (data, { ctx }) => {
 	ctx.budget.assignment(data);

--- a/src/lib/remote-functions/category.remote.ts
+++ b/src/lib/remote-functions/category.remote.ts
@@ -11,6 +11,7 @@ import {
 import { invalid, isHttpError } from '@sveltejs/kit';
 
 import { getMonthly } from './budget.remote';
+import { REFRESH_LIMIT } from './remote.utils';
 
 export const getCategories = guardedQuery(BudgetIdSchema, async ({ budgetId }, { ctx }) =>
 	ctx.category.all(budgetId)
@@ -49,11 +50,9 @@ export const createCategory = guardedForm(
 			if (isHttpError(error, 400)) invalid(issue.categoryName(error.body.message));
 			throw error;
 		}
-		// Infinity: see the note on refreshBudgetData in budget.remote.ts —
-		// finite limits reject refreshes of GC-lingering client instances.
 		await Promise.all([
-			requested(getCategories, Infinity).refreshAll(),
-			requested(getMonthly, Infinity).refreshAll()
+			requested(getCategories, REFRESH_LIMIT).refreshAll(),
+			requested(getMonthly, REFRESH_LIMIT).refreshAll()
 		]);
 	}
 );

--- a/src/lib/remote-functions/category.remote.ts
+++ b/src/lib/remote-functions/category.remote.ts
@@ -49,9 +49,11 @@ export const createCategory = guardedForm(
 			if (isHttpError(error, 400)) invalid(issue.categoryName(error.body.message));
 			throw error;
 		}
+		// Infinity: see the note on refreshBudgetData in budget.remote.ts —
+		// finite limits reject refreshes of GC-lingering client instances.
 		await Promise.all([
-			requested(getCategories, 1).refreshAll(),
-			requested(getMonthly, 1).refreshAll()
+			requested(getCategories, Infinity).refreshAll(),
+			requested(getMonthly, Infinity).refreshAll()
 		]);
 	}
 );

--- a/src/lib/remote-functions/remote.utils.ts
+++ b/src/lib/remote-functions/remote.utils.ts
@@ -2,6 +2,16 @@ import { resolve } from '$app/paths';
 import { getRequestEvent } from '$app/server';
 import { error, redirect } from '@sveltejs/kit';
 
+// Limit for requested(...) single-flight refreshes. Clients pass query
+// functions to .updates(...), which requests a refresh for every live
+// instance — including stale ones from client-side navigation that are only
+// evicted on GC, so more than one instance per query is legitimate. Payloads
+// beyond the limit are rejected with a 400 that puts the visible query into a
+// failed state (stale UI, uncaught console error) — the limit must sit far
+// above any realistic instance count. It stays finite only to cap the
+// refresh work a single (authenticated) request can trigger.
+export const REFRESH_LIMIT = 100;
+
 export function requireAdmin() {
 	const event = getRequestEvent();
 	if (!event.locals.session) redirect(307, resolve('/login'));

--- a/src/lib/remote-functions/transaction.remote.ts
+++ b/src/lib/remote-functions/transaction.remote.ts
@@ -13,6 +13,8 @@ import {
 } from '$lib/schemas/transaction';
 import { guardedForm, guardedQuery } from '$server/utils/remote-guard';
 
+import { REFRESH_LIMIT } from './remote.utils';
+
 export const listTransactions = guardedQuery(
 	ListTransactionsSchema,
 	async (
@@ -66,9 +68,7 @@ export const createTransaction = guardedForm(
 			notes: data.notes || null,
 			validated: data.validated
 		});
-		// Infinity: see the note on refreshBudgetData in budget.remote.ts —
-		// finite limits reject refreshes of GC-lingering client instances.
-		await requested(listTransactions, Infinity).refreshAll();
+		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
 	}
 );
 
@@ -82,7 +82,7 @@ export const editTransaction = guardedForm(
 			validated: rest.validated
 		};
 		ctx.transaction.edit(transactionId, update);
-		await requested(listTransactions, Infinity).refreshAll();
+		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
 	}
 );
 
@@ -90,7 +90,7 @@ export const batchDeleteTransactions = guardedForm(
 	BatchTransactionIdsSchema,
 	async ({ ids }, { ctx }) => {
 		ctx.transaction.delete(ids);
-		await requested(listTransactions, Infinity).refreshAll();
+		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
 	}
 );
 
@@ -98,6 +98,6 @@ export const batchValidateTransactions = guardedForm(
 	BatchValidateSchema,
 	async ({ ids, validated }, { ctx }) => {
 		ctx.transaction.validate(ids, validated);
-		await requested(listTransactions, Infinity).refreshAll();
+		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
 	}
 );

--- a/src/lib/remote-functions/transaction.remote.ts
+++ b/src/lib/remote-functions/transaction.remote.ts
@@ -66,7 +66,9 @@ export const createTransaction = guardedForm(
 			notes: data.notes || null,
 			validated: data.validated
 		});
-		await requested(listTransactions, 1).refreshAll();
+		// Infinity: see the note on refreshBudgetData in budget.remote.ts —
+		// finite limits reject refreshes of GC-lingering client instances.
+		await requested(listTransactions, Infinity).refreshAll();
 	}
 );
 
@@ -80,7 +82,7 @@ export const editTransaction = guardedForm(
 			validated: rest.validated
 		};
 		ctx.transaction.edit(transactionId, update);
-		await requested(listTransactions, 1).refreshAll();
+		await requested(listTransactions, Infinity).refreshAll();
 	}
 );
 
@@ -88,7 +90,7 @@ export const batchDeleteTransactions = guardedForm(
 	BatchTransactionIdsSchema,
 	async ({ ids }, { ctx }) => {
 		ctx.transaction.delete(ids);
-		await requested(listTransactions, 1).refreshAll();
+		await requested(listTransactions, Infinity).refreshAll();
 	}
 );
 
@@ -96,6 +98,6 @@ export const batchValidateTransactions = guardedForm(
 	BatchValidateSchema,
 	async ({ ids, validated }, { ctx }) => {
 		ctx.transaction.validate(ids, validated);
-		await requested(listTransactions, 1).refreshAll();
+		await requested(listTransactions, Infinity).refreshAll();
 	}
 );

--- a/tests/playwright/budget.spec.ts
+++ b/tests/playwright/budget.spec.ts
@@ -19,6 +19,36 @@ test('Assign Budget to Category', async ({ pages }) => {
 	await pages.budget.assignAmount(categoryName, '500');
 });
 
+// Regression: after client-side month navigation the previous month's query
+// instances linger in the client cache until the browser GCs them. The form's
+// single-flight refresh requests all of them, and a server-side
+// requested(..., 1) limit rejected the visible month's refresh with a 400 —
+// the assignment saved, but the table stayed stale. Full-page loads
+// (page.goto) reset the client cache and can never hit this.
+test('Assign Budget after client-side month navigation refreshes the table', async ({
+	page,
+	pages
+}) => {
+	await pages.auth.createUserAndLogin();
+
+	await pages.budget.createBudget(faker.commerce.department());
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	// Client-side navigation — each hop leaves the previous month's query
+	// instances in the client cache until GC. Several hops raise the odds
+	// that at least one stale instance is still around at submit time.
+	for (let i = 0; i < 3; i++) {
+		await page.getByRole('button', { name: 'Select next month' }).click();
+	}
+
+	await pages.budget.assignAmount(categoryName, '7');
+	await expect(
+		pages.budget.categoryRow(categoryName).getByRole('button', { name: 'Budget' })
+	).toHaveText(formatMoney({ currency: 'EUR', money: asMoney(700) }));
+});
+
 test('Transfer Assignment — Move between categories', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
 


### PR DESCRIPTION
Closes #75

## Problem

Saving an assignment sometimes leaves the budget table stale, with an uncaught `{ status: 400, body: { message: "Requested refresh was rejected because it exceeded requested(getUnassigned, 1) limit" } }` in the console. The assignment itself is persisted — only the single-flight refresh after the mutation fails.

## Cause

Forms submit with `.updates(getMonthly, getUnassigned)` (query functions, per `docs/remote-functions.md`), which requests a refresh for **every live instance** of those queries in the client cache. After client-side month navigation the previous month's instances linger until the browser GCs their proxies (`FinalizationRegistry`-based eviction). The server's `requested(query, 1)` limit then refreshes the **stale** instance (first in insertion order) and records an `HttpError(400)` for the visible one, putting it into a failed state — stale table, uncaught console error. GC timing decides whether it happens, hence "sometimes".

## Fix

Raise all `requested(...)` limits from `1` to a shared `REFRESH_LIMIT = 100` (`remote.utils.ts`, used in the `budget`, `category`, and `transaction` remote functions). The limit must sit far above any realistic count of GC-lingering instances so the visible query's refresh is never rejected, but stays finite so a single (authenticated) request cannot trigger unbounded refresh work. The rationale is documented on the constant.

## Test

New e2e regression test: create a category, hop three months via the month navigator (client-side — full-page `goto()` resets the client cache and can never hit this), assign, and assert the cell shows the amount. Red before the fix (stale-instance presence is GC-dependent, so pre-fix it fails on at least one project per run), green on all projects after.

- `npm run check`, `npm run lint`: clean
- `npm run test:unit`: 388 passed, 1 expected fail
- `npm run test:e2e`: passed (two unrelated flakes pass on re-run)