### PR TITLE
feat: built-in inline error surface for dialog forms (#17)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -173,6 +173,7 @@
 	"budget_settings_label_currency": "Währung",
 	"budget_settings_available_currencies": "Verfügbare Währungen",
 	"error_page_unexpected": "Ein unerwarteter Fehler ist aufgetreten.",
+	"form_error_unexpected": "Konnte nicht gespeichert werden. Bitte versuche es erneut.",
 	"error_page_log_id": "Fehler-ID:",
 	"error_page_go_home": "Zurück zur Startseite",
 	"error_account_not_found": "Konto nicht gefunden.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -173,6 +173,7 @@
 	"budget_settings_label_currency": "Currency",
 	"budget_settings_available_currencies": "Available Currencies",
 	"error_page_unexpected": "An unexpected error occurred.",
+	"form_error_unexpected": "Could not be saved. Please try again.",
 	"error_page_log_id": "Error ID:",
 	"error_page_go_home": "Go back home",
 	"error_account_not_found": "Account not found.",

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte
@@ -2,6 +2,7 @@
 	import type { Snippet } from 'svelte';
 
 	import * as Dialog from '$lib/components/ui/dialog';
+	import { type NormalizedFormError, normalizeFormError } from '$lib/utils/form-error';
 	import { cn } from 'tailwind-variants';
 
 	let {
@@ -21,7 +22,7 @@
 		enhance: (
 			onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>
 		) => Record<string, unknown>;
-		errors?: Snippet<[unknown]>;
+		errors?: Snippet<[NormalizedFormError]>;
 		fields: Snippet;
 		footer: Snippet<[{ formId: string }]>;
 		header: Snippet;
@@ -33,11 +34,16 @@
 
 	const formId = $props.id();
 
-	let _error = $state<unknown>(null);
+	let _error = $state<NormalizedFormError | null>(null);
 
 	function resetError() {
 		_error = null;
 	}
+
+	// Clear any thrown error when the dialog closes so it never flashes on reopen.
+	$effect(() => {
+		if (!open) resetError();
+	});
 </script>
 
 <Dialog.Root bind:open {...restProps}>
@@ -61,7 +67,7 @@
 						open = false;
 					}
 				} catch (e) {
-					_error = e;
+					_error = normalizeFormError(e);
 				}
 			})}
 		>
@@ -74,8 +80,12 @@
 			{/if}
 		</form>
 
-		{#if _error && errors}
-			{@render errors(_error)}
+		{#if _error}
+			{#if errors}
+				{@render errors(_error)}
+			{:else}
+				<p class="text-sm text-error" role="alert">{_error.message}</p>
+			{/if}
 		{/if}
 
 		<Dialog.Footer>

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
@@ -1,0 +1,107 @@
+import type { NormalizedFormError } from '$lib/utils/form-error';
+
+import { m } from '$lib/paraglide/messages';
+import { error } from '@sveltejs/kit';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import Fixture from './dialog-form.test-fixture.svelte';
+
+/**
+ * A mock of a remote-form's `enhance`: returns props for the `<form>` whose
+ * `onsubmit` drives the DialogForm submit wrapper with the given `submit`.
+ */
+function mockEnhance(submit: () => Promise<boolean>) {
+	return (onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>) => ({
+		onsubmit: (event: SubmitEvent) => {
+			event.preventDefault();
+			return onSubmit({ submit });
+		}
+	});
+}
+
+// jsdom lacks the Web Animations API the dialog's exit transition calls into.
+// Fire `onfinish` as soon as it is assigned so the outro completes and the
+// dialog content unmounts (otherwise the paused branch keeps stale nodes).
+beforeAll(() => {
+	Element.prototype.animate ??= function () {
+		const animation = { cancel() {}, finished: Promise.resolve() };
+		Object.defineProperty(animation, 'onfinish', {
+			configurable: true,
+			set: (cb: () => void) => queueMicrotask(cb)
+		});
+		return animation as unknown as Animation;
+	};
+});
+
+const throwsHttp = () => {
+	error(403, { message: 'You are not allowed to do this.' });
+	return Promise.resolve(true); // unreachable — satisfies the type
+};
+
+const throwsUnexpected = () => Promise.reject(new Error('better-sqlite3 exploded'));
+
+describe('DialogForm — thrown error surface', () => {
+	it('renders the built-in default inline error on a thrown non-validation error', async () => {
+		render(Fixture, { props: { enhance: mockEnhance(throwsUnexpected), open: true } });
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		const alert = await screen.findByRole('alert');
+		expect(alert).toHaveTextContent(m.form_error_unexpected());
+	});
+
+	it('shows the localized HttpError body message, not internal text', async () => {
+		render(Fixture, { props: { enhance: mockEnhance(throwsHttp), open: true } });
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		const alert = await screen.findByRole('alert');
+		expect(alert).toHaveTextContent('You are not allowed to do this.');
+		expect(alert).not.toHaveTextContent(m.form_error_unexpected());
+	});
+
+	it('does not leak internal error text for unexpected errors', async () => {
+		render(Fixture, { props: { enhance: mockEnhance(throwsUnexpected), open: true } });
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		await screen.findByRole('alert');
+		expect(screen.queryByText(/better-sqlite3/)).not.toBeInTheDocument();
+	});
+
+	it('lets the errors snippet override the default and receive the normalized shape', async () => {
+		const errors = createRawSnippet((getErr: () => NormalizedFormError) => {
+			const err = getErr();
+			return {
+				render: () => `<p data-testid="custom-error">custom:${err.kind}:${err.message}</p>`
+			};
+		});
+
+		render(Fixture, {
+			props: { enhance: mockEnhance(throwsUnexpected), errors, open: true }
+		});
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		const custom = await screen.findByTestId('custom-error');
+		expect(custom).toHaveTextContent(`custom:unexpected:${m.form_error_unexpected()}`);
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+
+	it('clears the error when the dialog closes and does not flash it on reopen', async () => {
+		const { rerender } = render(Fixture, {
+			props: { enhance: mockEnhance(throwsUnexpected), open: true }
+		});
+
+		screen.getByRole('button', { name: 'Save' }).click();
+		await screen.findByRole('alert');
+
+		await rerender({ open: false });
+		await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+
+		await rerender({ open: true });
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/ui/dialog-form/dialog-form.test-fixture.svelte
+++ b/src/lib/components/ui/dialog-form/dialog-form.test-fixture.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { NormalizedFormError } from '$lib/utils/form-error';
+	import type { Snippet } from 'svelte';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+
+	import { DialogForm } from './index';
+
+	let {
+		enhance,
+		errors,
+		open = $bindable(false)
+	}: {
+		enhance: (
+			onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>
+		) => Record<string, unknown>;
+		errors?: Snippet<[NormalizedFormError]>;
+		open?: boolean;
+	} = $props();
+</script>
+
+<DialogForm {enhance} bind:open {errors}>
+	{#snippet trigger(props)}
+		<button {...props}>open</button>
+	{/snippet}
+
+	{#snippet header()}
+		<Dialog.Title>Edit</Dialog.Title>
+	{/snippet}
+
+	{#snippet fields()}
+		<input name="value" aria-label="value" />
+	{/snippet}
+
+	{#snippet footer({ formId })}
+		<button type="submit" form={formId}>Save</button>
+	{/snippet}
+</DialogForm>

--- a/src/lib/utils/form-error.test.ts
+++ b/src/lib/utils/form-error.test.ts
@@ -1,0 +1,39 @@
+import { m } from '$lib/paraglide/messages';
+import { error } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeFormError } from './form-error';
+
+describe('normalizeFormError', () => {
+	it('surfaces the body message of an HttpError as a known error', () => {
+		let thrown: unknown;
+		try {
+			error(404, { message: 'Account not found.' });
+		} catch (e) {
+			thrown = e;
+		}
+
+		const normalized = normalizeFormError(thrown);
+
+		expect(normalized.kind).toBe('known');
+		expect(normalized.message).toBe('Account not found.');
+		expect(normalized.raw).toBe(thrown);
+	});
+
+	it('falls back to the generic message for a plain Error', () => {
+		const raw = new Error('connection reset by peer');
+
+		const normalized = normalizeFormError(raw);
+
+		expect(normalized.kind).toBe('unexpected');
+		expect(normalized.message).toBe(m.form_error_unexpected());
+		expect(normalized.message).not.toContain('connection reset');
+		expect(normalized.raw).toBe(raw);
+	});
+
+	it('falls back to the generic message for non-error values', () => {
+		expect(normalizeFormError('boom').kind).toBe('unexpected');
+		expect(normalizeFormError(undefined).message).toBe(m.form_error_unexpected());
+		expect(normalizeFormError(null).kind).toBe('unexpected');
+	});
+});

--- a/src/lib/utils/form-error.ts
+++ b/src/lib/utils/form-error.ts
@@ -1,0 +1,29 @@
+import { m } from '$lib/paraglide/messages';
+import { isHttpError } from '@sveltejs/kit';
+
+/**
+ * A thrown remote-form error normalized into a user-facing shape.
+ *
+ * - `known`: an `HttpError` raised by our own `error(4xx, …)` calls; its body
+ *   message is already localized and safe to display.
+ * - `unexpected`: anything else (500 / DB / network / thrown `Error`); mapped
+ *   to a generic localized fallback so internal error text never leaks.
+ */
+export type NormalizedFormError = {
+	kind: 'known' | 'unexpected';
+	message: string;
+	raw: unknown;
+};
+
+/**
+ * Normalize an unknown thrown error from a remote-form submit into a
+ * user-facing {@link NormalizedFormError}. Known `HttpError`s surface their
+ * localized body message; everything else maps to `form_error_unexpected`.
+ */
+export function normalizeFormError(error: unknown): NormalizedFormError {
+	if (isHttpError(error)) {
+		return { kind: 'known', message: error.body.message, raw: error };
+	}
+
+	return { kind: 'unexpected', message: m.form_error_unexpected(), raw: error };
+}


### PR DESCRIPTION
Closes #17.

## Problem

`DialogForm` caught thrown (non-validation) errors from the remote-form submit but only rendered them when a call site passed an optional `errors` snippet — and neither call site did. So authorization (403), not-found (404), and unexpected (500 / DB / network) failures vanished: the dialog stayed open with no feedback.

## Change

- **`normalizeFormError(unknown)`** (`src/lib/utils/form-error.ts`) — turns an unknown thrown error into `{ kind, message, raw }`. Known `HttpError`s (our own localized `error(4xx, …)` calls) surface their body message; everything else maps to the new `form_error_unexpected` fallback so internal error text never leaks.
- **`DialogForm`** now renders a **built-in default inline alert** (`role="alert"`) whenever a thrown error is present. The optional `errors` snippet stays as an **override** and receives the normalized shape (`Snippet<[NormalizedFormError]>`). The error resets at submit start and on dialog close; the dialog still stays open on error and closes on success.
- New i18n message `form_error_unexpected` in `messages/en.json` + `de.json` (Paraglide recompiled).
- Both existing call sites (account-name edit, budget settings) gain the surface with **no per-site wiring**.

Field-level validation (the `issues()` channel), category-edit / standalone forms, and any global toast system are explicitly out of scope.

## Tests

- Unit test for `normalizeFormError` (HttpError → localized message, non-HttpError → fallback, `kind` classification, no leak of internal text).
- Component test for `DialogForm` via a small fixture: built-in default renders on a thrown error, HttpError message shown without leaking internals, snippet override wins and receives the normalized shape, error clears on close with no flash on reopen.

`npm run check` and `npm run lint` clean; full unit suite green.