### PR TITLE
fix: reopen category detail dialog for the same category (#81)

### DIFF
--- a/src/lib/components/features/category/category-detail-dialog.svelte
+++ b/src/lib/components/features/category/category-detail-dialog.svelte
@@ -5,11 +5,10 @@
 
 	import CategoryDetail from './category-detail.svelte';
 
-	let { categoryId = $bindable() }: { categoryId: null | string } = $props();
-
-	// Writable derived: the primitive flips this locally on close so the exit
-	// transition can play; the bound id is reset afterwards.
-	let open = $derived(categoryId !== null);
+	let {
+		categoryId = $bindable(),
+		open = $bindable(false)
+	}: { categoryId: null | string; open?: boolean } = $props();
 
 	// Deleting a category from the detail view removes it entirely, so the
 	// dialog must close itself — flipping `open` plays the exit transition and

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
@@ -2,9 +2,9 @@ import type { NormalizedFormError } from '$lib/utils/form-error';
 
 import { m } from '$lib/paraglide/messages';
 import { error } from '@sveltejs/kit';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import Fixture from './dialog-form.test-fixture.svelte';
 
@@ -20,6 +20,15 @@ function mockEnhance(submit: () => Promise<boolean>) {
 		}
 	});
 }
+
+// Opening a Dialog makes bits-ui lock body scroll; unmounting schedules a
+// ~24ms `setTimeout` cleanup that touches `document.body`. If that timer fires
+// after vitest tears down jsdom, it throws `document is not defined`. Unmount
+// eagerly and wait past the delay so the cleanup runs while document is alive.
+afterEach(async () => {
+	cleanup();
+	await new Promise((resolve) => setTimeout(resolve, 50));
+});
 
 // jsdom lacks the Web Animations API the dialog's exit transition calls into.
 // Fire `onfinish` as soon as it is assigned so the outro completes and the

--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -28,6 +28,7 @@
 	const month = $derived(parseMonth(params.month));
 
 	let selectedCategoryId = $state<null | string>(null);
+	let categoryDialogOpen = $state(false);
 </script>
 
 <Page.Root>
@@ -59,10 +60,11 @@
 				{month}
 				openCategoryDialog={(categoryId) => {
 					selectedCategoryId = categoryId;
+					categoryDialogOpen = true;
 				}}
 			/>
 		{/if}
 	</Page.Content>
 </Page.Root>
 
-<CategoryDetailDialog bind:categoryId={selectedCategoryId} />
+<CategoryDetailDialog bind:categoryId={selectedCategoryId} bind:open={categoryDialogOpen} />

--- a/tests/playwright/category-responsive.spec.ts
+++ b/tests/playwright/category-responsive.spec.ts
@@ -32,6 +32,23 @@ test('Category detail opens as a dialog on wide viewports', async ({ page, pages
 	await expect(page.locator('[data-slot="drawer-content"]')).toHaveCount(0);
 });
 
+test('Category detail reopens for the same category after closing', async ({ page, pages }) => {
+	const categoryName = await seedCategory(pages);
+
+	await pages.category.openDetail(categoryName);
+	const dialog = page.locator('[data-slot="dialog-content"]');
+	await expect(dialog).toBeVisible();
+
+	// Close, then click the exact same category again. Because open state and the
+	// selected id used to be the same derived value, reopening the same id was a
+	// no-op — the dialog stayed shut until a different category was picked.
+	await page.keyboard.press('Escape');
+	await expect(dialog).toHaveCount(0);
+
+	await pages.category.openDetail(categoryName);
+	await expect(page.locator('[data-slot="dialog-content"]')).toBeVisible();
+});
+
 test('Category detail opens as a bottom drawer on narrow viewports', async ({ page, pages }) => {
 	const categoryName = await seedCategory(pages);
 


### PR DESCRIPTION
Closes #81.

## Problem

Reopening the category detail dialog for the *same* category after closing it did nothing — clicking the category name had no effect until a *different* category was clicked.

## Root cause

The dialog's visibility was derived straight from the selected id:

```
let open = $derived(categoryId !== null);
```

and the trigger was just `selectedCategoryId = id`. "Which category" and "is the dialog open" were the same piece of state, so reopening the same category re-assigned `selectedCategoryId` to the value it already held — no state change — and the derived `open` never flipped back to `true`. A different id was a real change, which is why switching categories worked.

## Fix

Decouple the open flag from the id:

- The budget page owns a real `open` boolean `$state` alongside `selectedCategoryId`; opening sets both (`id` + `open = true`) and binds `open` to the dialog.
- The dialog takes `open` as a bindable prop instead of deriving it.
- The id is still cleared on `onOpenChangeComplete`, and the inner content stays guarded on `categoryId !== null`, so the exit transition still plays with content mounted.

Reopening the same category is now always a genuine `false → true` transition.

## Tests

- New desktop-Dialog regression test in `category-responsive.spec.ts` (open → Escape → reopen same category).
- `npm run check`: 0 errors. `category.spec.ts`: 10 pass. Unit suite: 417 pass, 1 expected fail.

Note: the pre-existing narrow-viewport drawer test fails in the local headless env (vaul exit animation does not complete on Escape); confirmed via `git stash` that it fails identically on untouched `main`, so it is not a regression from this change.