### PR TITLE
feat: quick category-create as a dialog form with inline errors (#62)

### DIFF
--- a/src/lib/components/features/category/category-create.svelte
+++ b/src/lib/components/features/category/category-create.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+	import { getMonthly } from '$lib/remote-functions/budget.remote';
+	import { createCategory } from '$lib/remote-functions/category.remote';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
+
+	import { Button } from '../../ui/button';
+	import { FormBody } from '../../ui/form-body';
+	import { FormField } from '../../ui/form-field';
+	import { Input } from '../../ui/input';
+
+	let { onSuccess }: { onSuccess?: () => void } = $props();
+
+	const budgetId = getBudgetId();
+</script>
+
+<FormBody
+	{...createCategory.enhance(async (form) => {
+		if (await form.submit().updates(getMonthly)) {
+			form.element.reset();
+			onSuccess?.();
+		}
+	})}
+>
+	<input {...createCategory.fields.budgetId.as('hidden', budgetId())} />
+
+	<FormField field={createCategory.fields.categoryName} label={m.category_label_name()}>
+		{#snippet input(field)}
+			<Input {...field.as('text')} placeholder={m.category_placeholder_name()} />
+		{/snippet}
+	</FormField>
+
+	<Button type="submit" class="ml-auto">
+		{m.category_create_button()}
+	</Button>
+</FormBody>

--- a/src/lib/components/features/category/index.ts
+++ b/src/lib/components/features/category/index.ts
@@ -1,1 +1,2 @@
+export { default as CategoryCreate } from './category-create.svelte';
 export { default as CategoryDetailDialog } from './category-detail-dialog.svelte';

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-quick-actions.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-quick-actions.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { CategoryCreate } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
-	import * as Popover from '$lib/components/ui/popover';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { m } from '$lib/paraglide/messages';
-	import { getMonthly } from '$lib/remote-functions/budget.remote';
-	import { createCategory, getArchivedCategories } from '$lib/remote-functions/category.remote';
+	import { getArchivedCategories } from '$lib/remote-functions/category.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import PhArchive from '~icons/ph/archive';
 	import PhStackPlus from '~icons/ph/stack-plus';
@@ -18,42 +17,18 @@
 </script>
 
 <div class="flex gap-0.5">
-	<Popover.Root bind:open>
-		<Button
-			href={resolve('/(app)/[budgetId=id]/categories/new', { budgetId: budgetId() })}
-			class="md:hidden"
-		>
-			<PhStackPlus class="size-6" />
-			{m.category_create_button()}
-		</Button>
+	<Button
+		href={resolve('/(app)/[budgetId=id]/categories/new', { budgetId: budgetId() })}
+		class="md:hidden"
+	>
+		<PhStackPlus class="size-6" />
+		{m.category_create_button()}
+	</Button>
 
-		<Popover.Trigger>
-			{#snippet child({ props })}
-				<Button {...props} class="hidden md:flex">
-					<PhStackPlus class="size-6" />
-					{m.category_create_button()}
-				</Button>
-			{/snippet}
-		</Popover.Trigger>
-
-		<Popover.Content align="end" class="w-fit p-4">
-			<form
-				{...createCategory.enhance(async (form) => {
-					if (await form.submit().updates(getMonthly)) {
-						open = false;
-						form.element.reset();
-					}
-				})}
-			>
-				<input {...createCategory.fields.budgetId.as('hidden', budgetId())} />
-				<Input
-					{...createCategory.fields.categoryName.as('text')}
-					placeholder={m.category_placeholder_name()}
-					aria-label={m.category_label_name()}
-				/>
-			</form>
-		</Popover.Content>
-	</Popover.Root>
+	<Button class="hidden md:flex" onclick={() => (open = true)}>
+		<PhStackPlus class="size-6" />
+		{m.category_create_button()}
+	</Button>
 
 	<Button
 		variant="ghost"
@@ -63,3 +38,16 @@
 		{m.category_archived_link({ amount: archivedCategories.length })}
 	</Button>
 </div>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-lg gap-6">
+		<Dialog.Header>
+			<Dialog.Title>{m.new_category_title()}</Dialog.Title>
+			<Dialog.Description class="grid gap-4">
+				<p>{m.new_category_description()}</p>
+			</Dialog.Description>
+		</Dialog.Header>
+
+		<CategoryCreate onSuccess={() => (open = false)} />
+	</Dialog.Content>
+</Dialog.Root>

--- a/tests/playwright/category.spec.ts
+++ b/tests/playwright/category.spec.ts
@@ -59,6 +59,18 @@ test('Category rename shows a field error for a duplicate name', async ({ pages 
 	await pages.category.editNameExpectingError(categoryName, existingName);
 });
 
+test('Quick category create shows a field error for a duplicate name', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	await pages.budget.createCategoryExpectingError(categoryName);
+});
+
 test('Archive Category', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
 

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -89,9 +89,14 @@ export class BudgetPage extends BasePage {
 	async createCategory(name: string) {
 		await this.page.getByRole('button', { name: 'Create Category' }).click();
 
-		const input = this.page.getByRole('textbox', { name: 'Category Name' });
+		const dialog = this.page.getByRole('dialog');
+		const input = dialog.getByRole('textbox', { name: 'Category Name' });
 		await input.fill(name);
 		await input.press('Enter');
+
+		// A successful create closes the dialog; wait for it so callers don't race
+		// the close animation (which briefly leaves two "Create Category" buttons).
+		await expect(dialog).toBeHidden();
 
 		const row = this.categoryRow(name);
 		// The row button is rendered directly in the row (no async wait).
@@ -100,6 +105,25 @@ export class BudgetPage extends BasePage {
 		// Budget button to confirm it has mounted before returning. All rows share
 		// the same getBudget cache, so this also unblocks other rows' buttons.
 		await expect(row.getByRole('button', { name: 'Budget' })).toBeVisible();
+	}
+
+	/**
+	 * Opens the quick category-create dialog and submits a name that already
+	 * exists. Asserts the duplicate-name error surfaces as a field error and the
+	 * dialog stays open (a successful create would close it).
+	 */
+	async createCategoryExpectingError(name: string) {
+		await this.page.getByRole('button', { name: 'Create Category' }).click();
+
+		const dialog = this.page.getByRole('dialog');
+		await expect(dialog.getByRole('heading', { name: 'Add a new category' })).toBeVisible();
+
+		await dialog.getByRole('textbox', { name: 'Category Name' }).fill(name);
+		await dialog.getByRole('button', { name: 'Create Category' }).click();
+
+		await expect(dialog.getByText(`${name} already exists.`)).toBeVisible();
+		// The error keeps the dialog open — a successful create would close it.
+		await expect(dialog).toBeVisible();
 	}
 
 	async goto(budgetName: string) {


### PR DESCRIPTION
Closes #62.

Replaces the category quick-create popover on the budget page with a responsive `Dialog` hosting a new `CategoryCreate` feature component, built on `FormBody` + `FormField` like `AccountCreate` and exported via the `features/category` barrel.

Because `FormField` renders `field.issues()` inline, duplicate-name errors from `createCategory.fields.categoryName.issues()` now surface under the name field instead of being silently dropped (the original motivation, follow-up from #23). On success the dialog closes, the form resets, and the Monthly query refreshes.

Since `createCategory` — unlike `createAccount` — does not redirect, `CategoryCreate` takes an `onSuccess` callback that the quick-actions dialog uses to close on success. The archive link and mobile create-button path are unchanged.

## Testing
- `npm run check` and `npm run lint` green.
- `category.spec.ts` 20/20 green, including a new test `Quick category create shows a field error for a duplicate name`.
- The existing `createCategory` page-object now waits for the dialog to close (`toBeHidden()`) so callers don't race the close animation, which briefly leaves two "Create Category" buttons.
- The pre-existing `category-responsive` drawer test flake is unrelated — it fails identically on `origin/main`.