### PR TITLE
feat: form foundation — Button.loading, createFormSubmit, DialogForm refactor (#86)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,3 +59,11 @@ _Avoid_: remaining (envelope-side), funds
 **Feature module**:
 A component directory coupled to a specific application capability — imports remote functions, orchestrates forms, owns interaction state. Lives under `src/lib/components/features/`, one directory per capability with an `index.ts` barrel; consumers import from the explicit path (e.g. `$lib/components/features/account`). Primitives in `src/lib/components/ui` stay feature-agnostic: no remote functions, no domain logic, at most type-only domain imports.
 _Avoid_: shared component, domain component, widget
+
+**Contained form**:
+A form living inside a closing container — dialog, alert-dialog, or popover. The container closing is the success signal; validation issues render inline at the field; thrown errors (see ADR-0001) render inline in the container, which stays open. The counterpart of a Standing form. Feedback rules in ADR-0009.
+_Avoid_: modal form, popup form
+
+**Standing form**:
+A form that remains on screen after a successful submit (settings, in-place edits, invitations). Success must be signaled explicitly — an anchored toast at the element that triggered the submit — but only when the submit produces no visible state change there; a visible change (an item appearing, moving, or leaving) is itself the signal, and adding a toast on top is noise. The counterpart of a Contained form. Feedback rules in ADR-0009.
+_Avoid_: inline form, static form, page form

--- a/docs/adr/0009-form-feedback-follows-the-origin-rule.md
+++ b/docs/adr/0009-form-feedback-follows-the-origin-rule.md
@@ -1,0 +1,90 @@
+# ADR-0009: Form feedback follows the origin rule; submit lifecycle behind one primitive
+
+Date: 2026-07-13
+Status: accepted
+
+## Context
+
+The app has ~27 form sites and, before this decision, no single contract for
+how a form talks back to the user. Five distinct error-handling patterns and
+five success-feedback patterns coexisted; thrown errors (authorization,
+not-found, unexpected server failures) were silently swallowed in at least six
+sites; only one submit button in the whole app disabled while a request was in
+flight. The full submit lifecycle — reset error → submit → catch → normalize →
+route feedback — was implemented completely only inside `DialogForm`; every
+other site re-decided it from scratch, usually partially.
+
+Feedback also had no principle for _where_ it appears: some actions toasted,
+some cleared the form, some did nothing, regardless of whether the user could
+already see the effect.
+
+## Decision
+
+**Every form is either a Contained form or a Standing form** (see the glossary
+in `CONTEXT.md`), and feedback follows the **origin rule**: it appears at the
+element the user is already looking at.
+
+| Form context                                           | Success signal                       | Validation errors             | Thrown errors (403/404/500/…)                   |
+| ------------------------------------------------------ | ------------------------------------ | ----------------------------- | ----------------------------------------------- |
+| Contained form (dialog / alert-dialog / popover)       | container closes                     | inline at the field           | inline alert in the container, which stays open |
+| Standing form with no visible change at the origin     | anchored success toast               | inline at the field           | anchored error toast                            |
+| Standing form whose success visibly changes the origin | the visible change itself — no toast | inline at the field           | anchored error toast                            |
+| Create-then-navigate                                   | the redirect                         | inline at the field           | anchored error toast                            |
+| Row-scoped micro-form                                  | row exits edit mode / updates        | shared error line for the row | anchored error toast                            |
+
+Thrown errors are never silent anywhere. Toasts are reserved for outcomes,
+never progress.
+
+**The submit lifecycle exists exactly once**, in `createFormSubmit`
+(`src/lib/utils/form-submit.svelte.ts`): per submit it clears the previous
+error, submits (chaining `updates` single-flight refreshes), runs `onSuccess`
+and the optional success toast, and routes thrown errors through the existing
+normalizer (`normalizeFormError`, ADR-0001 messages surface verbatim,
+everything else maps to the generic localized fallback).
+
+**Toast-owns-errors:** when the primitive's `toast` option is configured,
+thrown errors go to the anchored error toast and the returned `error` state
+stays `null`; without it, they land in `error` for inline rendering. Exactly
+one error surface is ever active per form — no site checks two channels.
+
+Containers (`DialogForm`, and its planned alert-dialog and popover siblings)
+are thin skins over the primitive: they render container markup, the inline
+thrown-error alert, and hand `pending` to their footer snippet. Pending state
+reaches the user through the `Button` `loading` prop — delay-gated spinner,
+stable size, disabled and busy semantics. Hot-path forms (see glossary) stay
+exempt: their optimistic model is its own feedback.
+
+## Rejected alternatives
+
+- **Toast-everywhere.** One uniform success/error toast for all forms is easy
+  to implement but violates the origin rule twice: a contained form's close is
+  already the signal (a toast on top is noise), and a visible change at a
+  standing form's origin (item appears, moves, leaves) says more than any
+  toast. Toasts would degrade into background chatter and stop meaning
+  anything precisely where they are needed (password change, invite).
+- **Per-container lifecycle duplication.** Giving each container (dialog,
+  alert-dialog, popover) and each bare site its own try/catch-and-route
+  implementation is the status quo that produced five error patterns and six
+  silent-failure sites. The lifecycle is subtle (error reset timing, update
+  chaining, exactly-one-surface) and must not be re-derived per site.
+- **One mega form component.** A single `<AppForm>` that renders container,
+  fields, errors, and footer for every context would need props for every
+  variation (dialog vs popover vs bare, footer shapes, reset semantics,
+  row-scoped layouts) and would still exempt the dense transaction rows. A
+  headless primitive composes into all of these without owning markup.
+
+## Consequences
+
+- New form sites wire feedback by composing `createFormSubmit` (or a container
+  built on it) instead of hand-rolling try/catch — getting error routing,
+  pending state, and cache refresh for free.
+- The lifecycle is unit-tested once at the primitive's public surface;
+  containers test only container behavior against fixtures; migrated sites
+  need no per-site lifecycle tests.
+- `DialogForm` takes the remote form object directly (breaking API change,
+  all sites migrated with the refactor); its footer snippet receives
+  `pending` alongside the form id so submit buttons forward it without
+  reaching into the form object.
+- The migration to this contract is sliced per domain (containers, settings,
+  auth, admin, categories, accounts, transaction rows) and is consistent
+  within each domain at every merge.

--- a/src/lib/components/features/account/account-set-name.svelte
+++ b/src/lib/components/features/account/account-set-name.svelte
@@ -14,7 +14,7 @@
 	const account = $derived(await getAccount(accountId));
 </script>
 
-<DialogForm enhance={editAccount.enhance}>
+<DialogForm form={editAccount}>
 	{#snippet trigger(props)}
 		<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
 			<PencilIcon class="size-5" />
@@ -41,8 +41,8 @@
 		</div>
 	{/snippet}
 
-	{#snippet footer({ formId })}
+	{#snippet footer({ formId, pending })}
 		<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-		<Button type="submit" form={formId}>{m.account_save()}</Button>
+		<Button type="submit" form={formId} loading={pending}>{m.account_save()}</Button>
 	{/snippet}
 </DialogForm>

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -19,7 +19,7 @@
 	const form = $derived(editBudget.for(budgetId()));
 </script>
 
-<DialogForm enhance={form.enhance} contentClass="gap-0" interactOutsideBehavior="ignore">
+<DialogForm {form} contentClass="gap-0" interactOutsideBehavior="ignore">
 	{#snippet trigger(props)}
 		<Button {...props} variant="ghost" size="icon-lg" class="bg-muted/10 hover:bg-muted/20">
 			<PencilIcon class="size-5" />
@@ -77,8 +77,8 @@
 		</div>
 	{/snippet}
 
-	{#snippet footer({ formId })}
+	{#snippet footer({ formId, pending })}
 		<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-		<Button type="submit" form={formId}>{m.save()}</Button>
+		<Button type="submit" form={formId} loading={pending}>{m.save()}</Button>
 	{/snippet}
 </DialogForm>

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -41,23 +41,57 @@
 
 	export type ButtonProps = WithElementRef<HTMLAnchorAttributes> &
 		WithElementRef<HTMLButtonAttributes> & {
+			/** In-flight submit state: disables the button and, for slow requests, overlays a spinner. */
+			loading?: boolean;
 			size?: ButtonSize;
 			variant?: ButtonVariant;
 		};
+
+	/** Spinner appears only when the request is still in flight after this delay — fast submits render none. */
+	const SPINNER_DELAY_MS = 200;
+	/** Once shown, the spinner stays at least this long so it never flashes. */
+	const SPINNER_MIN_VISIBLE_MS = 250;
 </script>
 
 <script lang="ts">
+	import CircleNotchIcon from '~icons/ph/circle-notch';
+
 	let {
 		children,
 		class: className,
 		disabled,
 		href = undefined,
+		loading = false,
 		ref = $bindable(null),
 		size = 'default',
 		type = 'button',
 		variant = 'default',
 		...restProps
 	}: ButtonProps = $props();
+
+	let spinnerVisible = $state(false);
+	// Deliberately non-reactive: only the timer callbacks and the effect below
+	// consult it, and making it reactive would re-run the effect on expiry.
+	let minVisibleElapsed = true;
+
+	// Timer-driven visibility cannot be derived; this is the imperative escape
+	// hatch the delay gate needs (see docs/code-style.md on $effect).
+	$effect(() => {
+		if (!loading) {
+			if (minVisibleElapsed) spinnerVisible = false;
+			// Otherwise the min-visible timer below hides it once it expires.
+			return;
+		}
+		const delay = setTimeout(() => {
+			spinnerVisible = true;
+			minVisibleElapsed = false;
+			setTimeout(() => {
+				minVisibleElapsed = true;
+				if (!loading) spinnerVisible = false;
+			}, SPINNER_MIN_VISIBLE_MS);
+		}, SPINNER_DELAY_MS);
+		return () => clearTimeout(delay);
+	});
 </script>
 
 {#if href}
@@ -77,11 +111,25 @@
 	<button
 		bind:this={ref}
 		data-slot="button"
-		class={cn(variants({ size, variant }), className)}
+		class={cn(variants({ size, variant }), spinnerVisible && 'relative', className)}
 		{type}
-		{disabled}
+		disabled={disabled || loading}
+		aria-busy={loading ? true : undefined}
 		{...restProps}
 	>
-		{@render children?.()}
+		{#if spinnerVisible}
+			<span
+				data-slot="button-spinner"
+				class="absolute inset-0 grid place-items-center"
+				aria-hidden="true"
+			>
+				<CircleNotchIcon class="animate-spin" />
+			</span>
+		{/if}
+		<!-- `contents` keeps children direct flex items; `invisible` inherits onto
+		     them so the label holds the button's size under the spinner. -->
+		<span class={cn('contents', spinnerVisible && 'invisible')}>
+			{@render children?.()}
+		</span>
 	</button>
 {/if}

--- a/src/lib/components/ui/button/button.svelte.test.ts
+++ b/src/lib/components/ui/button/button.svelte.test.ts
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet, tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Button from './button.svelte';
+
+const label = createRawSnippet(() => ({ render: () => '<span>Save</span>' }));
+
+async function advance(ms: number) {
+	vi.advanceTimersByTime(ms);
+	await tick();
+}
+
+function spinner() {
+	return document.querySelector('[data-slot="button-spinner"]');
+}
+
+beforeEach(() => {
+	// Svelte flushes via real microtasks; faking those would deadlock `tick()`.
+	vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('Button — loading', () => {
+	it('is disabled and marked busy immediately, before the spinner appears', async () => {
+		render(Button, { props: { children: label, loading: true } });
+
+		const button = screen.getByRole('button');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('aria-busy', 'true');
+		expect(spinner()).toBeNull();
+	});
+
+	it('shows no spinner at all when loading ends within the delay window', async () => {
+		const { rerender } = render(Button, { props: { children: label, loading: true } });
+
+		await advance(150);
+		expect(spinner()).toBeNull();
+
+		await rerender({ loading: false });
+		await advance(10_000);
+
+		expect(spinner()).toBeNull();
+		expect(screen.getByRole('button')).toBeEnabled();
+		expect(screen.getByRole('button')).not.toHaveAttribute('aria-busy');
+	});
+
+	it('shows the spinner once the submit is still pending after the delay', async () => {
+		render(Button, { props: { children: label, loading: true } });
+
+		await advance(199);
+		expect(spinner()).toBeNull();
+
+		await advance(1);
+		expect(spinner()).not.toBeNull();
+	});
+
+	it('keeps the label in the DOM while the spinner is visible, so the button never changes size', async () => {
+		render(Button, { props: { children: label, loading: true } });
+
+		await advance(200);
+
+		expect(spinner()).not.toBeNull();
+		const button = screen.getByRole('button');
+		expect(button).toHaveTextContent('Save');
+	});
+
+	it('keeps the spinner visible for the minimum time when loading ends right after it appeared', async () => {
+		const { rerender } = render(Button, { props: { children: label, loading: true } });
+
+		await advance(200);
+		expect(spinner()).not.toBeNull();
+
+		await rerender({ loading: false });
+		await advance(249);
+		expect(spinner()).not.toBeNull();
+
+		await advance(1);
+		expect(spinner()).toBeNull();
+	});
+
+	it('hides the spinner immediately when loading ends after the minimum visible time', async () => {
+		const { rerender } = render(Button, { props: { children: label, loading: true } });
+
+		await advance(200);
+		await advance(250);
+		expect(spinner()).not.toBeNull();
+
+		await rerender({ loading: false });
+		await tick();
+
+		expect(spinner()).toBeNull();
+	});
+
+	it('re-enables the button and clears busy state when loading ends', async () => {
+		const { rerender } = render(Button, { props: { children: label, loading: true } });
+
+		await advance(200);
+		await rerender({ loading: false });
+		await advance(250);
+
+		const button = screen.getByRole('button');
+		expect(button).toBeEnabled();
+		expect(button).not.toHaveAttribute('aria-busy');
+	});
+
+	it('does not restart the spinner cycle for a fast follow-up submit after one completed', async () => {
+		const { rerender } = render(Button, { props: { children: label, loading: true } });
+
+		await advance(200);
+		await advance(250);
+		await rerender({ loading: false });
+		await tick();
+		expect(spinner()).toBeNull();
+
+		await rerender({ loading: true });
+		await advance(150);
+		await rerender({ loading: false });
+		await advance(10_000);
+
+		expect(spinner()).toBeNull();
+	});
+});

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte
@@ -1,48 +1,62 @@
-<script lang="ts">
+<script lang="ts" generics="TForm extends FormSubmitTarget">
+	import type { NormalizedFormError } from '$lib/utils/form-error';
+	import type { RemoteQueryUpdate } from '@sveltejs/kit';
 	import type { Snippet } from 'svelte';
 
 	import * as Dialog from '$lib/components/ui/dialog';
-	import { type NormalizedFormError, normalizeFormError } from '$lib/utils/form-error';
+	import {
+		createFormSubmit,
+		type EnhancedForm,
+		type FormSubmitTarget
+	} from '$lib/utils/form-submit.svelte';
 	import { cn } from 'tailwind-variants';
 
 	let {
 		contentClass = '',
-		enhance,
 		errors,
 		fields,
 		footer,
+		form,
 		header,
 		interactOutsideBehavior = undefined,
+		onSuccess,
 		open = $bindable(false),
 		resetOnClose = true,
 		trigger,
+		updates,
 		...restProps
 	}: {
 		contentClass?: string;
-		enhance: (
-			onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>
-		) => Record<string, unknown>;
 		errors?: Snippet<[NormalizedFormError]>;
 		fields: Snippet;
-		footer: Snippet<[{ formId: string }]>;
+		footer: Snippet<[{ formId: string; pending: boolean }]>;
+		form: TForm;
 		header: Snippet;
 		interactOutsideBehavior?: 'ignore' | undefined;
+		/** Replaces the default success behavior of closing the dialog. */
+		onSuccess?: (form: EnhancedForm<TForm>) => Promise<void> | void;
 		open?: boolean;
 		resetOnClose?: boolean;
 		trigger: Snippet<[Record<string, unknown>]>;
+		updates?: () => RemoteQueryUpdate[];
 	} = $props();
 
 	const formId = $props.id();
 
-	let _error = $state<NormalizedFormError | null>(null);
-
-	function resetError() {
-		_error = null;
-	}
+	const submit = createFormSubmit(() => form, {
+		onSuccess: async (instance) => {
+			if (onSuccess) await onSuccess(instance);
+			else open = false;
+		},
+		// Getter keeps the prop live instead of capturing its initial value.
+		get updates() {
+			return updates;
+		}
+	});
 
 	// Clear any thrown error when the dialog closes so it never flashes on reopen.
 	$effect(() => {
-		if (!open) resetError();
+		if (!open) submit.reset();
 	});
 </script>
 
@@ -58,19 +72,7 @@
 			{@render header()}
 		</Dialog.Header>
 
-		<form
-			id={formId}
-			{...enhance(async (f) => {
-				resetError();
-				try {
-					if (await f.submit()) {
-						open = false;
-					}
-				} catch (e) {
-					_error = normalizeFormError(e);
-				}
-			})}
-		>
+		<form id={formId} {...submit.attrs}>
 			{#if resetOnClose}
 				{#key open}
 					{@render fields()}
@@ -80,16 +82,16 @@
 			{/if}
 		</form>
 
-		{#if _error}
+		{#if submit.error}
 			{#if errors}
-				{@render errors(_error)}
+				{@render errors(submit.error)}
 			{:else}
-				<p class="text-sm text-error" role="alert">{_error.message}</p>
+				<p class="text-sm text-error" role="alert">{submit.error.message}</p>
 			{/if}
 		{/if}
 
 		<Dialog.Footer>
-			{@render footer({ formId })}
+			{@render footer({ formId, pending: submit.pending })}
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
+++ b/src/lib/components/ui/dialog-form/dialog-form.svelte.test.ts
@@ -9,16 +9,30 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import Fixture from './dialog-form.test-fixture.svelte';
 
 /**
- * A mock of a remote-form's `enhance`: returns props for the `<form>` whose
- * `onsubmit` drives the DialogForm submit wrapper with the given `submit`.
+ * A remote-form double for the DialogForm `form` prop: submitting the dialog's
+ * form plays `submit` through the primitive's lifecycle.
  */
-function mockEnhance(submit: () => Promise<boolean>) {
-	return (onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>) => ({
-		onsubmit: (event: SubmitEvent) => {
-			event.preventDefault();
-			return onSubmit({ submit });
+function mockForm(submit: () => Promise<boolean>, pending = 0) {
+	type SubmitResult = Promise<boolean> & { updates: (...updates: unknown[]) => Promise<boolean> };
+
+	const instance = {
+		element: document.createElement('form'),
+		submit: (): SubmitResult => {
+			const promise = submit() as SubmitResult;
+			promise.updates = () => promise;
+			return promise;
 		}
-	});
+	};
+
+	return {
+		enhance: (callback: (form: typeof instance) => Promise<void>) => ({
+			onsubmit: (event: SubmitEvent) => {
+				event.preventDefault();
+				return callback(instance);
+			}
+		}),
+		pending
+	};
 }
 
 // Opening a Dialog makes bits-ui lock body scroll; unmounting schedules a
@@ -51,18 +65,71 @@ const throwsHttp = () => {
 
 const throwsUnexpected = () => Promise.reject(new Error('better-sqlite3 exploded'));
 
+describe('DialogForm — success', () => {
+	it('closes the dialog on a successful submit by default', async () => {
+		render(Fixture, { props: { form: mockForm(() => Promise.resolve(true)), open: true } });
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+
+	it('stays open when the submit reports validation issues', async () => {
+		render(Fixture, { props: { form: mockForm(() => Promise.resolve(false)), open: true } });
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+	});
+
+	it('lets onSuccess replace the default close behavior', async () => {
+		let received: unknown;
+		render(Fixture, {
+			props: {
+				form: mockForm(() => Promise.resolve(true)),
+				onSuccess: (form: unknown) => {
+					received = form;
+				},
+				open: true
+			}
+		});
+
+		screen.getByRole('button', { name: 'Save' }).click();
+
+		await waitFor(() => expect(received).toBeDefined());
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect(received).toHaveProperty('element');
+	});
+});
+
+describe('DialogForm — footer', () => {
+	it('hands pending to the footer snippet', async () => {
+		render(Fixture, { props: { form: mockForm(() => Promise.resolve(true), 1), open: true } });
+
+		expect(screen.getByTestId('pending')).toHaveTextContent('true');
+	});
+
+	it('reports pending false while no submission is in flight', async () => {
+		render(Fixture, { props: { form: mockForm(() => Promise.resolve(true)), open: true } });
+
+		expect(screen.getByTestId('pending')).toHaveTextContent('false');
+	});
+});
+
 describe('DialogForm — thrown error surface', () => {
 	it('renders the built-in default inline error on a thrown non-validation error', async () => {
-		render(Fixture, { props: { enhance: mockEnhance(throwsUnexpected), open: true } });
+		render(Fixture, { props: { form: mockForm(throwsUnexpected), open: true } });
 
 		screen.getByRole('button', { name: 'Save' }).click();
 
 		const alert = await screen.findByRole('alert');
 		expect(alert).toHaveTextContent(m.form_error_unexpected());
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
 	});
 
 	it('shows the localized HttpError body message, not internal text', async () => {
-		render(Fixture, { props: { enhance: mockEnhance(throwsHttp), open: true } });
+		render(Fixture, { props: { form: mockForm(throwsHttp), open: true } });
 
 		screen.getByRole('button', { name: 'Save' }).click();
 
@@ -72,7 +139,7 @@ describe('DialogForm — thrown error surface', () => {
 	});
 
 	it('does not leak internal error text for unexpected errors', async () => {
-		render(Fixture, { props: { enhance: mockEnhance(throwsUnexpected), open: true } });
+		render(Fixture, { props: { form: mockForm(throwsUnexpected), open: true } });
 
 		screen.getByRole('button', { name: 'Save' }).click();
 
@@ -89,7 +156,7 @@ describe('DialogForm — thrown error surface', () => {
 		});
 
 		render(Fixture, {
-			props: { enhance: mockEnhance(throwsUnexpected), errors, open: true }
+			props: { errors, form: mockForm(throwsUnexpected), open: true }
 		});
 
 		screen.getByRole('button', { name: 'Save' }).click();
@@ -101,7 +168,7 @@ describe('DialogForm — thrown error surface', () => {
 
 	it('clears the error when the dialog closes and does not flash it on reopen', async () => {
 		const { rerender } = render(Fixture, {
-			props: { enhance: mockEnhance(throwsUnexpected), open: true }
+			props: { form: mockForm(throwsUnexpected), open: true }
 		});
 
 		screen.getByRole('button', { name: 'Save' }).click();

--- a/src/lib/components/ui/dialog-form/dialog-form.test-fixture.svelte
+++ b/src/lib/components/ui/dialog-form/dialog-form.test-fixture.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { NormalizedFormError } from '$lib/utils/form-error';
+	import type { FormSubmitTarget } from '$lib/utils/form-submit.svelte';
 	import type { Snippet } from 'svelte';
 
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -7,19 +8,19 @@
 	import { DialogForm } from './index';
 
 	let {
-		enhance,
 		errors,
+		form,
+		onSuccess,
 		open = $bindable(false)
 	}: {
-		enhance: (
-			onSubmit: (form: { submit: () => Promise<boolean> }) => Promise<void>
-		) => Record<string, unknown>;
 		errors?: Snippet<[NormalizedFormError]>;
+		form: FormSubmitTarget;
+		onSuccess?: (form: unknown) => Promise<void> | void;
 		open?: boolean;
 	} = $props();
 </script>
 
-<DialogForm {enhance} bind:open {errors}>
+<DialogForm {form} bind:open {errors} {onSuccess}>
 	{#snippet trigger(props)}
 		<button {...props}>open</button>
 	{/snippet}
@@ -32,7 +33,8 @@
 		<input name="value" aria-label="value" />
 	{/snippet}
 
-	{#snippet footer({ formId })}
+	{#snippet footer({ formId, pending })}
+		<span data-testid="pending">{pending}</span>
 		<button type="submit" form={formId}>Save</button>
 	{/snippet}
 </DialogForm>

--- a/src/lib/utils/form-submit.svelte.test.ts
+++ b/src/lib/utils/form-submit.svelte.test.ts
@@ -1,0 +1,244 @@
+import { m } from '$lib/paraglide/messages';
+import { error as httpError } from '@sveltejs/kit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { toasts } from './anchored-toast.svelte';
+import { createFormSubmit } from './form-submit.svelte';
+
+vi.mock('$app/environment', () => ({ browser: true, dev: true }));
+
+type SubmitResult = Promise<boolean> & { updates: (...updates: unknown[]) => Promise<boolean> };
+
+/** Reads `attrs` so the lazy `$derived` runs `enhance` and captures the handler. */
+function armed<T extends { attrs: unknown }>(submit: T) {
+	void submit.attrs;
+	return submit;
+}
+
+/**
+ * A minimal remote-form double: `enhance` captures the primitive's submit
+ * handler, `trigger()` plays one form submission through it.
+ */
+function mockForm(submit: () => Promise<boolean>, pending = 0) {
+	const updateCalls: unknown[][] = [];
+
+	const instance = {
+		element: document.createElement('form'),
+		submit: (): SubmitResult => {
+			const promise = submit() as SubmitResult;
+			promise.updates = (...updates: unknown[]) => {
+				updateCalls.push(updates);
+				return promise;
+			};
+			return promise;
+		}
+	};
+
+	let handler: ((form: typeof instance) => Promise<void>) | undefined;
+
+	const form = {
+		enhance: (callback: (form: typeof instance) => Promise<void>) => {
+			handler = callback;
+			return { onsubmit: () => callback(instance) };
+		},
+		pending
+	};
+
+	return {
+		form,
+		instance,
+		trigger: () => handler!(instance),
+		updateCalls
+	};
+}
+
+const forbidden = () => {
+	httpError(403, { message: 'You are not allowed to do this.' });
+	return Promise.resolve(true); // unreachable — satisfies the type
+};
+
+afterEach(() => {
+	[...toasts].forEach((toast) => toast.dismiss());
+	vi.restoreAllMocks();
+});
+
+describe('createFormSubmit — attrs and pending', () => {
+	it('spreads the enhanced form attributes from the current form instance', () => {
+		const mock = mockForm(() => Promise.resolve(true));
+		const submit = createFormSubmit(() => mock.form);
+
+		expect(submit.attrs).toHaveProperty('onsubmit');
+	});
+
+	it('projects the form pending counter as a boolean', () => {
+		const idle = createFormSubmit(() => mockForm(() => Promise.resolve(true), 0).form);
+		const busy = createFormSubmit(() => mockForm(() => Promise.resolve(true), 2).form);
+
+		expect(idle.pending).toBe(false);
+		expect(busy.pending).toBe(true);
+	});
+});
+
+describe('createFormSubmit — success path', () => {
+	it('runs onSuccess with the live form instance', async () => {
+		const mock = mockForm(() => Promise.resolve(true));
+		const onSuccess = vi.fn();
+		armed(createFormSubmit(() => mock.form, { onSuccess }));
+
+		await mock.trigger();
+
+		expect(onSuccess).toHaveBeenCalledExactlyOnceWith(mock.instance);
+	});
+
+	it('does not run onSuccess when the submit reports validation issues', async () => {
+		const mock = mockForm(() => Promise.resolve(false));
+		const onSuccess = vi.fn();
+		const submit = armed(createFormSubmit(() => mock.form, { onSuccess }));
+
+		await mock.trigger();
+
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(submit.error).toBeNull();
+	});
+
+	it('chains the configured updates into the submission', async () => {
+		const queryA = () => {};
+		const queryB = () => {};
+		const mock = mockForm(() => Promise.resolve(true));
+		armed(createFormSubmit(() => mock.form, { updates: () => [queryA, queryB] }));
+
+		await mock.trigger();
+
+		expect(mock.updateCalls).toEqual([[queryA, queryB]]);
+	});
+
+	it('submits without update chaining when updates is not configured', async () => {
+		const mock = mockForm(() => Promise.resolve(true));
+		armed(createFormSubmit(() => mock.form));
+
+		await mock.trigger();
+
+		expect(mock.updateCalls).toEqual([]);
+	});
+
+	it('pushes the success toast after onSuccess when toast.success is configured', async () => {
+		const order: string[] = [];
+		const mock = mockForm(() => Promise.resolve(true));
+		const submit = armed(
+			createFormSubmit(() => mock.form, {
+				onSuccess: () => {
+					order.push('onSuccess');
+				},
+				toast: { placement: 'left', success: () => 'Saved' }
+			})
+		);
+
+		const anchor = document.createElement('button');
+		submit.anchor!(anchor);
+		await mock.trigger();
+
+		expect(order).toEqual(['onSuccess']);
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].variant).toBe('success');
+		expect(toasts[0].message).toBe('Saved');
+		expect(toasts[0].placement).toBe('left');
+		expect(toasts[0].anchor).toBe(anchor);
+	});
+
+	it('pushes no success toast when toast is configured without a success message', async () => {
+		const mock = mockForm(() => Promise.resolve(true));
+		const submit = armed(createFormSubmit(() => mock.form, { toast: {} }));
+
+		submit.anchor!(document.createElement('button'));
+		await mock.trigger();
+
+		expect(toasts).toHaveLength(0);
+	});
+});
+
+describe('createFormSubmit — error routing (toast-owns-errors)', () => {
+	it('lands a thrown HttpError in error with its localized message when no toast is configured', async () => {
+		const mock = mockForm(forbidden);
+		const submit = armed(createFormSubmit(() => mock.form));
+
+		await mock.trigger();
+
+		expect(submit.error).not.toBeNull();
+		expect(submit.error!.kind).toBe('known');
+		expect(submit.error!.message).toBe('You are not allowed to do this.');
+		expect(toasts).toHaveLength(0);
+	});
+
+	it('normalizes unexpected errors to the generic localized message', async () => {
+		const mock = mockForm(() => Promise.reject(new Error('better-sqlite3 exploded')));
+		const submit = armed(createFormSubmit(() => mock.form));
+
+		await mock.trigger();
+
+		expect(submit.error!.kind).toBe('unexpected');
+		expect(submit.error!.message).toBe(m.form_error_unexpected());
+	});
+
+	it('routes thrown errors to the anchored error toast and keeps error null when toast is configured', async () => {
+		const mock = mockForm(forbidden);
+		const submit = armed(createFormSubmit(() => mock.form, { toast: {} }));
+
+		submit.anchor!(document.createElement('button'));
+		await mock.trigger();
+
+		expect(submit.error).toBeNull();
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].variant).toBe('error');
+		expect(toasts[0].message).toBe('You are not allowed to do this.');
+	});
+
+	it('does not run onSuccess or the success toast on a thrown error', async () => {
+		const mock = mockForm(forbidden);
+		const onSuccess = vi.fn();
+		const submit = armed(
+			createFormSubmit(() => mock.form, {
+				onSuccess,
+				toast: { success: () => 'Saved' }
+			})
+		);
+
+		submit.anchor!(document.createElement('button'));
+		await mock.trigger();
+
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(toasts).toHaveLength(1);
+		expect(toasts[0].variant).toBe('error');
+	});
+
+	it('clears the previous error at the start of the next submit', async () => {
+		let fail = true;
+		const mock = mockForm(() => (fail ? Promise.reject(new Error('boom')) : Promise.resolve(true)));
+		const submit = armed(createFormSubmit(() => mock.form));
+
+		await mock.trigger();
+		expect(submit.error).not.toBeNull();
+
+		fail = false;
+		await mock.trigger();
+		expect(submit.error).toBeNull();
+	});
+
+	it('clears the error on reset()', async () => {
+		const mock = mockForm(forbidden);
+		const submit = armed(createFormSubmit(() => mock.form));
+
+		await mock.trigger();
+		expect(submit.error).not.toBeNull();
+
+		submit.reset();
+		expect(submit.error).toBeNull();
+	});
+});
+
+describe('createFormSubmit — anchor', () => {
+	it('exposes no anchor without toast configuration', () => {
+		const submit = createFormSubmit(() => mockForm(() => Promise.resolve(true)).form);
+
+		expect(submit.anchor).toBeUndefined();
+	});
+});

--- a/src/lib/utils/form-submit.svelte.ts
+++ b/src/lib/utils/form-submit.svelte.ts
@@ -1,0 +1,100 @@
+import type { RemoteQueryUpdate } from '@sveltejs/kit';
+
+import { createAnchoredToast, type ToastPlacement } from './anchored-toast.svelte';
+import { type NormalizedFormError, normalizeFormError } from './form-error';
+
+/** The live form instance a remote form hands its `enhance` callback. */
+export type EnhancedForm<TForm extends FormSubmitTarget> = Parameters<
+	Parameters<TForm['enhance']>[0]
+>[0];
+
+export type FormSubmitOptions<TForm extends FormSubmitTarget> = {
+	/** Runs after a successful submit — express close, reset-and-continue, etc. here. */
+	onSuccess?: (form: EnhancedForm<TForm>) => Promise<void> | void;
+	/**
+	 * Configures the anchored toast surface. With it, thrown errors go to an
+	 * anchored error toast and `error` stays `null` (toast-owns-errors);
+	 * `success` additionally pushes a success toast after `onSuccess`.
+	 */
+	toast?: { placement?: ToastPlacement; success?: () => string };
+	/** Queries to refresh single-flight, chained via `submit().updates(...)`. Evaluated per submit. */
+	updates?: () => RemoteQueryUpdate[];
+};
+
+/**
+ * The remote-form surface the primitive drives: `enhance` for the submit
+ * lifecycle, `pending` for in-flight state. Structural on purpose so every
+ * SvelteKit remote form (including `.for(id)` instances) satisfies it.
+ */
+export type FormSubmitTarget = {
+	enhance: (callback: (form: SubmittedForm) => Promise<void>) => Record<string, unknown>;
+	pending: number;
+};
+
+/** The submit-capable instance a remote form hands its `enhance` callback. */
+type SubmittedForm = {
+	element: HTMLFormElement;
+	submit: () => Promise<boolean> & {
+		updates: (...updates: RemoteQueryUpdate[]) => Promise<boolean>;
+	};
+};
+
+/**
+ * The single submit lifecycle for remote forms (see ADR-0009): per submit it
+ * clears the previous error, submits (chaining `updates`), runs `onSuccess`
+ * and the success toast on success, and routes thrown errors through
+ * {@link normalizeFormError} to exactly one surface — the anchored error
+ * toast when `toast` is configured, the returned `error` state otherwise.
+ *
+ * `form` is a thunk so per-item instances (`form.for(id)`) stay reactive.
+ * Spread `attrs` onto the `<form>`; attach `anchor` to the toast origin.
+ */
+export function createFormSubmit<TForm extends FormSubmitTarget>(
+	form: () => TForm,
+	options: FormSubmitOptions<TForm> = {}
+) {
+	const toast = options.toast
+		? createAnchoredToast({ placement: options.toast.placement })
+		: undefined;
+
+	let error = $state<NormalizedFormError | null>(null);
+
+	const attrs = $derived(
+		form().enhance(async (instance) => {
+			error = null;
+			try {
+				const submission = instance.submit();
+				const submitted = options.updates
+					? await submission.updates(...options.updates())
+					: await submission;
+				if (!submitted) return;
+
+				await options.onSuccess?.(instance as EnhancedForm<TForm>);
+				const message = options.toast?.success?.();
+				if (message !== undefined) toast?.success(message);
+			} catch (e) {
+				const normalized = normalizeFormError(e);
+				if (toast) toast.error(normalized.message);
+				else error = normalized;
+			}
+		})
+	);
+
+	return {
+		/** Toast-origin attachment (`{@attach ...}`); only present when `toast` is configured. */
+		anchor: toast?.attach,
+		get attrs() {
+			return attrs;
+		},
+		get error() {
+			return error;
+		},
+		get pending() {
+			return form().pending > 0;
+		},
+		/** Clears the inline error, e.g. when a containing dialog closes. */
+		reset() {
+			error = null;
+		}
+	};
+}


### PR DESCRIPTION
Closes #86. Part of #85.

## What

The foundation of the unified form contract (ADR-0009): one submit lifecycle, one loading-capable button, and the dialog container refactored onto both.

- **`Button` gains `loading`**: the label stays in the DOM but turns invisible with a spinner absolutely centered over it, so the button never changes size; `disabled` and `aria-busy` are set for the whole flight. The spinner is delay-gated — shown only if the request is still in flight after 200 ms, and once shown it stays a minimum 250 ms. Fast submits render no spinner at all.
- **`createFormSubmit`** (`src/lib/utils/form-submit.svelte.ts`): headless runes primitive owning the submit lifecycle — clear error → submit (chaining `updates`) → `onSuccess` + optional success toast → thrown errors through `normalizeFormError`. Returns `attrs`, `error`, `pending`, `anchor`, and `reset()` for containers. **Toast-owns-errors**: with `toast` configured, thrown errors go to the anchored error toast and `error` stays `null`; without it they land in `error` for inline rendering. Exactly one error surface is ever active.
- **`DialogForm`** is now a thin skin over the primitive: takes the remote form object directly (breaking API change), defaults success to closing, keeps the inline thrown-error alert with the optional override snippet and reset-on-close, and its footer snippet receives `pending` alongside the form id. Both existing call sites (`budget-settings`, `account-set-name`) migrated and bind `loading` on their submit buttons.
- **Docs**: glossary terms *Contained form* and *Standing form* in `CONTEXT.md`; ADR-0009 records the origin rule and the rejected alternatives (toast-everywhere, per-container lifecycle duplication, one mega form component).

## Tests

- Button: 8 component tests with fake timers — delay gate, minimum visible time, size stability (label stays in the DOM), busy/disabled semantics.
- Primitive: 15 unit tests at the public surface — error routing per toast-owns-errors, pending projection, success callback and toast firing, update chaining, error clearing.
- DialogForm: 10 fixture-based tests — close-on-success, inline thrown-error rendering without leaking internals, error reset on close, footer receiving `pending`.

Checks, lint, and the full unit suite are green (460 passed, 1 pre-existing expected fail).