### PR TITLE
feat: transaction rows — primitive + shared row error line (#89)

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -11,10 +11,12 @@
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 	import { createTransaction, listTransactions } from '$lib/remote-functions/transaction.remote';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import { getLocalTimeZone, parseDate, today } from '@internationalized/date';
 	import { Popover } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
 
+	import RowErrors from './transaction-table-row-errors.svelte';
 	import ValidationCheckbox from './transaction-validation-checkbox.svelte';
 
 	let {
@@ -37,8 +39,21 @@
 	let submitAndContinue = $state(false);
 	let formElement: HTMLFormElement | null = $state(null);
 
+	// Row-scoped micro-form (ADR-0009): thrown errors go to the anchored toast,
+	// validation issues to the shared row error line below the fields.
+	const submit = createFormSubmit(() => createTransaction, {
+		onSuccess: (form) => {
+			if (submitAndContinue) return;
+			form.element.reset();
+			open = false;
+		},
+		toast: {},
+		updates: () => [listTransactions({ accountId, ...urlParams })]
+	});
+
 	const submitWithKeyboard: Attachment<HTMLFormElement> = (node) => {
 		const handle = (ev: KeyboardEvent) => {
+			if (submit.pending) return;
 			if (ev.key === 'Enter' && !(ev.target as HTMLElement)?.closest('[role="combobox"]')) {
 				ev.preventDefault();
 				submitAndContinue = ev.shiftKey;
@@ -78,15 +93,9 @@
 			role="row"
 			aria-label={m.transactions_table_create_transaction()}
 			bind:this={formElement}
-			{...createTransaction.enhance(async (f) => {
-				if (await f.submit().updates(listTransactions({ accountId, ...urlParams }))) {
-					if (!submitAndContinue) {
-						f.element.reset();
-						open = false;
-					}
-				}
-			})}
+			{...submit.attrs}
 			{@attach open && submitWithKeyboard}
+			{@attach submit.anchor}
 		>
 			<input {...createTransaction.fields.accountId.as('hidden', accountId)} />
 			<input {...createTransaction.fields.budgetId.as('hidden', budgetId)} />
@@ -143,17 +152,26 @@
 				<ValidationCheckbox {...createTransaction.fields.validated.as('checkbox')} />
 			</div>
 
+			<RowErrors issues={createTransaction.fields.allIssues()} />
+
 			<div
 				role="cell"
 				class="col-span-full flex items-center justify-end gap-2 bg-interactive/5 p-2"
 			>
-				<Button type="button" variant="ghost" onclick={() => (open = false)}>
+				<Button
+					type="button"
+					variant="ghost"
+					disabled={submit.pending}
+					onclick={() => (open = false)}
+				>
 					{m.cancel()}
 				</Button>
 
-				<Button type="submit" onclick={() => (submitAndContinue = false)}>{m.save()}</Button>
+				<Button type="submit" disabled={submit.pending} onclick={() => (submitAndContinue = false)}>
+					{m.save()}
+				</Button>
 
-				<Button type="submit" onclick={() => (submitAndContinue = true)}>
+				<Button type="submit" disabled={submit.pending} onclick={() => (submitAndContinue = true)}>
 					{m.save_and_continue()}
 				</Button>
 			</div>

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
@@ -1,12 +1,17 @@
+import { m } from '$lib/paraglide/messages';
 import { TransactionsURLParamsSchema } from '$lib/schemas/transaction';
+import { toasts } from '$lib/utils/anchored-toast.svelte';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { parse } from 'valibot';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const remote = vi.hoisted(() => {
 	let fieldState: Record<string, unknown> = {};
-	let submitResult: Promise<unknown> = Promise.resolve(true);
+	// A thunk so a rejection is only created once the submit awaits it —
+	// otherwise vitest reports it as unhandled before the lifecycle catches.
+	let submitResult: () => Promise<unknown> = () => Promise.resolve(true);
+	let allIssuesState: undefined | { message: string; path: (number | string)[] }[];
 
 	const fieldNames = [
 		'accountId',
@@ -48,7 +53,7 @@ const remote = vi.hoisted(() => {
 				submit: () => ({
 					updates: (...queries: unknown[]) => {
 						updatedQueries.push(...queries);
-						return submitResult;
+						return submitResult();
 					}
 				})
 			});
@@ -59,9 +64,10 @@ const remote = vi.hoisted(() => {
 		createTransaction: {
 			enhance,
 			fields: Object.assign(
-				{ set: setAllFields },
+				{ allIssues: () => allIssuesState, set: setAllFields },
 				Object.fromEntries(fieldNames.map((name) => [name, field(name)]))
-			)
+			),
+			pending: 0
 		},
 		fieldState: () => fieldState,
 		getBudget: vi.fn(async () => ({ currency: 'EUR', id: 'budget-1', name: 'Budget' })),
@@ -73,13 +79,17 @@ const remote = vi.hoisted(() => {
 		onSubmit,
 		resetMocks: () => {
 			fieldState = {};
-			submitResult = Promise.resolve(true);
+			submitResult = () => Promise.resolve(true);
+			allIssuesState = undefined;
 			updatedQueries.length = 0;
 			setAllFields.mockClear();
 			onSubmit.mockClear();
 		},
 		setAllFields,
-		setSubmitResult: (result: Promise<unknown>) => {
+		setAllIssues: (issues: { message: string; path: (number | string)[] }[]) => {
+			allIssuesState = issues;
+		},
+		setSubmitResult: (result: () => Promise<unknown>) => {
 			submitResult = result;
 		},
 		updatedQueries
@@ -103,8 +113,17 @@ const baseProps = {
 	urlParams
 };
 
-async function renderRow(props: Partial<typeof baseProps> & { open?: boolean } = {}) {
+afterEach(() => {
+	[...toasts].forEach((toast) => toast.dismiss());
+	remote.createTransaction.pending = 0;
+});
+
+async function renderRow(
+	props: Partial<typeof baseProps> & { open?: boolean } = {},
+	configure?: () => void
+) {
 	remote.resetMocks();
+	configure?.();
 	const merged = { ...baseProps, open: true, ...props };
 	const utils = render(TableRowCreate, { props: merged });
 	const form = merged.open ? await screen.findByRole('row') : null;
@@ -192,7 +211,7 @@ describe('TableRowCreate', () => {
 	it('keeps the popover open when the submission fails', async () => {
 		const user = userEvent.setup();
 		await renderRow();
-		remote.setSubmitResult(Promise.resolve(false));
+		remote.setSubmitResult(() => Promise.resolve(false));
 
 		await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -230,5 +249,68 @@ describe('TableRowCreate', () => {
 		expect(values.notes).toBeUndefined();
 		expect(values.validated).toBe(false);
 		expect(values.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+	});
+});
+
+describe('TableRowCreate — row feedback contract', () => {
+	it('shows all field issues in one shared error line', async () => {
+		await renderRow({}, () =>
+			remote.setAllIssues([
+				{ message: 'Amount must not be zero', path: ['amount'] },
+				{ message: 'Invalid date', path: ['date'] }
+			])
+		);
+
+		const alerts = screen.getAllByRole('alert');
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]).toHaveTextContent('Amount must not be zero');
+		expect(alerts[0]).toHaveTextContent('Invalid date');
+	});
+
+	it('renders no error line without issues', async () => {
+		await renderRow();
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+
+	it('disables the row buttons during flight without a spinner', async () => {
+		await renderRow({}, () => {
+			remote.createTransaction.pending = 1;
+		});
+
+		for (const name of ['Save', 'Save & Continue', 'Cancel']) {
+			const button = screen.getByRole('button', { name });
+			expect(button).toBeDisabled();
+			expect(button).not.toHaveAttribute('aria-busy');
+		}
+		expect(document.querySelector('[data-slot=button-spinner]')).toBeNull();
+	});
+
+	it('does not submit from the keyboard while a submit is in flight', async () => {
+		const user = userEvent.setup();
+		await renderRow({}, () => {
+			remote.createTransaction.pending = 1;
+		});
+
+		const notes = screen.getByRole('textbox', { name: 'Notes' });
+		await user.click(notes);
+		await user.keyboard('{Enter}');
+
+		expect(remote.onSubmit).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a thrown submit error as an anchored error toast and keeps the row open', async () => {
+		const user = userEvent.setup();
+		await renderRow();
+		remote.setSubmitResult(() => Promise.reject(new Error('better-sqlite3 exploded')));
+
+		await user.click(screen.getByRole('button', { name: 'Save' }));
+
+		await waitFor(() => expect(toasts).toHaveLength(1));
+		expect(toasts[0].variant).toBe('error');
+		expect(toasts[0].message).toBe(m.form_error_unexpected());
+		expect(toasts[0].anchor).not.toBeNull();
+		expect(screen.getByRole('row')).toBeInTheDocument();
+		expect(screen.queryByText(/better-sqlite3/)).not.toBeInTheDocument();
 	});
 });

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -15,12 +15,14 @@
 		listTransactions
 	} from '$lib/remote-functions/transaction.remote';
 	import { clickOutside } from '$lib/utils/click-outside';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import { parseDate } from '@internationalized/date';
 	import { onMount } from 'svelte';
 	import { cn } from 'tailwind-variants';
 	import TrashIcon from '~icons/ph/trash';
 
 	import { colsClass } from './transaction-table-cols';
+	import RowErrors from './transaction-table-row-errors.svelte';
 	import ValidationCheckbox from './transaction-validation-checkbox.svelte';
 
 	let {
@@ -37,9 +39,24 @@
 
 	const id = $props.id();
 	const form = editTransaction.for(id);
+	const deleteForm = batchDeleteTransactions.for(id);
 	const deleteFormId = `dform-${id}`;
 
 	const categories = $derived(await getCategories({ budgetId }));
+
+	// Row-scoped micro-form (ADR-0009): thrown errors go to the anchored toast,
+	// validation issues to the shared row error line below the fields.
+	const submit = createFormSubmit(() => form, {
+		onSuccess: () => cancelEditing(),
+		toast: {},
+		updates: () => [listTransactions]
+	});
+
+	// No client-side update chain: the server refreshes the transaction list,
+	// and the refreshed list unmounts this row — that is the success signal.
+	const deleteSubmit = createFormSubmit(() => deleteForm, { toast: {} });
+
+	const pending = $derived(submit.pending || deleteSubmit.pending);
 
 	onMount(() => {
 		form.fields.categoryId.set(transaction.categoryId ?? undefined);
@@ -48,11 +65,8 @@
 </script>
 
 <form
-	{...form.enhance(async (f) => {
-		if (await f.submit().updates(listTransactions)) {
-			cancelEditing();
-		}
-	})}
+	{...submit.attrs}
+	{@attach submit.anchor}
 	role="row"
 	class={cn(
 		colsClass,
@@ -116,8 +130,10 @@
 		<ValidationCheckbox {...form.fields.validated.as('checkbox', transaction.validated)} />
 	</div>
 
+	<RowErrors issues={form.fields.allIssues()} />
+
 	<div role="cell" class="col-span-full flex items-center justify-end gap-2 bg-interactive/5 p-2">
-		<Button type="button" variant="ghost" onclick={cancelEditing}>
+		<Button type="button" variant="ghost" disabled={pending} onclick={cancelEditing}>
 			{m.cancel()}
 		</Button>
 
@@ -126,16 +142,19 @@
 			variant="destructive"
 			size="icon"
 			form={deleteFormId}
+			name={deleteForm.fields.ids.as('select multiple').name}
 			value={[transaction.id]}
+			disabled={pending}
+			{@attach deleteSubmit.anchor}
 		>
 			<TrashIcon />
 			<span class="sr-only">{m.delete()}</span>
 		</Button>
 
-		<Button type="submit">
+		<Button type="submit" disabled={pending}>
 			{m.save()}
 		</Button>
 	</div>
 </form>
 
-<form id={deleteFormId} class="hidden" {...batchDeleteTransactions.for(id)}></form>
+<form id={deleteFormId} class="hidden" {...deleteSubmit.attrs}></form>

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte.test.ts
@@ -1,0 +1,271 @@
+import type { ListTransaction } from '$lib/server/db/user-context/transaction';
+
+import { m } from '$lib/paraglide/messages';
+import { toasts } from '$lib/utils/anchored-toast.svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const remote = vi.hoisted(() => {
+	type Issue = { message: string; path: (number | string)[] };
+
+	/**
+	 * A remote-form double: `enhance` plays submits through the component's
+	 * lifecycle, `fields` serves the template's field accessors. The submit
+	 * result is a thunk so a rejection is only created once the lifecycle
+	 * awaits it — otherwise vitest reports it as unhandled.
+	 */
+	function makeForm(fieldNames: readonly string[]) {
+		let fieldState: Record<string, unknown> = {};
+		let submitResult: () => Promise<unknown> = () => Promise.resolve(true);
+		let allIssuesState: Issue[] | undefined;
+		const onSubmit = vi.fn();
+		const updatedQueries: unknown[] = [];
+
+		const field = (name: string) => ({
+			as: (type: string, value?: unknown) => {
+				if (type === 'hidden') return { name, type, value };
+				if (type === 'checkbox') return { checked: value, name, type };
+				if (type === 'text') return { name, type, value };
+				return { name };
+			},
+			issues: () => undefined,
+			set: (value: unknown) => {
+				fieldState[name] = value;
+			},
+			value: () => fieldState[name]
+		});
+
+		const form = {
+			enhance: (callback: (instance: unknown) => Promise<void>) => ({
+				onsubmit: (event: SubmitEvent) => {
+					event.preventDefault();
+					onSubmit();
+					void callback({
+						element: event.target as HTMLFormElement,
+						submit: () => {
+							const promise = submitResult() as Promise<unknown> & {
+								updates: (...queries: unknown[]) => Promise<unknown>;
+							};
+							promise.updates = (...queries: unknown[]) => {
+								updatedQueries.push(...queries);
+								return promise;
+							};
+							return promise;
+						}
+					});
+				}
+			}),
+			fields: Object.assign(
+				{ allIssues: () => allIssuesState },
+				Object.fromEntries(fieldNames.map((name) => [name, field(name)]))
+			),
+			pending: 0
+		};
+
+		return {
+			form,
+			onSubmit,
+			reset: () => {
+				fieldState = {};
+				submitResult = () => Promise.resolve(true);
+				allIssuesState = undefined;
+				updatedQueries.length = 0;
+				onSubmit.mockClear();
+				form.pending = 0;
+			},
+			setAllIssues: (issues: Issue[]) => {
+				allIssuesState = issues;
+			},
+			setSubmitResult: (result: () => Promise<unknown>) => {
+				submitResult = result;
+			},
+			updatedQueries
+		};
+	}
+
+	const editForm = makeForm([
+		'accountId',
+		'transactionId',
+		'categoryId',
+		'notes',
+		'date',
+		'amount',
+		'validated'
+	]);
+	const deleteForm = makeForm(['ids']);
+
+	return {
+		deleteForm,
+		editForm,
+		getCategories: vi.fn(async () => [
+			{ id: 'category-1', name: 'Groceries' },
+			{ id: 'category-2', name: 'Rent' }
+		]),
+		listTransactions: vi.fn()
+	};
+});
+
+vi.mock('$lib/remote-functions/transaction.remote', () => ({
+	batchDeleteTransactions: { for: () => remote.deleteForm.form },
+	editTransaction: { for: () => remote.editForm.form },
+	listTransactions: remote.listTransactions
+}));
+vi.mock('$lib/remote-functions/category.remote', () => ({ getCategories: remote.getCategories }));
+
+import TableRowEdit from './transaction-table-row-edit.svelte';
+
+const transaction: ListTransaction = {
+	accountId: 'account-1',
+	amount: 4200,
+	budgetId: 'budget-1',
+	categoryId: 'category-1',
+	categoryName: 'Groceries',
+	createdAt: new Date('2026-07-01T00:00:00Z'),
+	createdBy: 'user-1',
+	createdByName: 'user',
+	date: '2026-07-01',
+	id: 'tx-1',
+	notes: 'weekly shop',
+	validated: false
+};
+
+afterEach(() => {
+	[...toasts].forEach((toast) => toast.dismiss());
+});
+
+async function renderRow(configure?: () => void) {
+	remote.editForm.reset();
+	remote.deleteForm.reset();
+	configure?.();
+	const cancelEditing = vi.fn();
+	const utils = render(TableRowEdit, {
+		props: { budgetId: 'budget-1', cancelEditing, currency: 'EUR', transaction }
+	});
+	await screen.findByRole('row');
+	return { ...utils, cancelEditing };
+}
+
+const saveButton = () => screen.getByRole('button', { name: 'Save' });
+const cancelButton = () => screen.getByRole('button', { name: 'Cancel' });
+const deleteButton = () => screen.getByRole('button', { name: 'Delete' });
+
+describe('TableRowEdit — submit lifecycle', () => {
+	it('saves the row and exits edit mode on success', async () => {
+		const user = userEvent.setup();
+		const { cancelEditing } = await renderRow();
+
+		await user.click(saveButton());
+
+		expect(remote.editForm.onSubmit).toHaveBeenCalledTimes(1);
+		await waitFor(() => expect(cancelEditing).toHaveBeenCalledTimes(1));
+	});
+
+	it('chains the transaction list refresh into the submit', async () => {
+		const user = userEvent.setup();
+		await renderRow();
+
+		await user.click(saveButton());
+
+		await waitFor(() => expect(remote.editForm.updatedQueries).toContain(remote.listTransactions));
+	});
+
+	it('stays in edit mode when the submit reports validation issues', async () => {
+		const user = userEvent.setup();
+		const { cancelEditing } = await renderRow();
+		remote.editForm.setSubmitResult(() => Promise.resolve(false));
+
+		await user.click(saveButton());
+
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(cancelEditing).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a thrown save error as an anchored error toast and stays in edit mode', async () => {
+		const user = userEvent.setup();
+		const { cancelEditing } = await renderRow();
+		remote.editForm.setSubmitResult(() => Promise.reject(new Error('better-sqlite3 exploded')));
+
+		await user.click(saveButton());
+
+		await waitFor(() => expect(toasts).toHaveLength(1));
+		expect(toasts[0].variant).toBe('error');
+		expect(toasts[0].message).toBe(m.form_error_unexpected());
+		expect(cancelEditing).not.toHaveBeenCalled();
+		expect(screen.queryByText(/better-sqlite3/)).not.toBeInTheDocument();
+	});
+});
+
+describe('TableRowEdit — shared error line', () => {
+	it('shows all field issues in one shared error line', async () => {
+		await renderRow(() =>
+			remote.editForm.setAllIssues([
+				{ message: 'Amount must not be zero', path: ['amount'] },
+				{ message: 'Invalid date', path: ['date'] }
+			])
+		);
+
+		const alerts = screen.getAllByRole('alert');
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]).toHaveTextContent('Amount must not be zero');
+		expect(alerts[0]).toHaveTextContent('Invalid date');
+	});
+
+	it('renders no error line without issues', async () => {
+		await renderRow();
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});
+
+describe('TableRowEdit — delete', () => {
+	it('submits the row id under the ids field through the hidden delete form', async () => {
+		const user = userEvent.setup();
+		await renderRow();
+
+		expect(deleteButton()).toHaveAttribute('name', 'ids');
+		expect(deleteButton()).toHaveValue('tx-1');
+
+		await user.click(deleteButton());
+
+		expect(remote.deleteForm.onSubmit).toHaveBeenCalledTimes(1);
+		expect(remote.editForm.onSubmit).not.toHaveBeenCalled();
+	});
+
+	it('surfaces a failing delete as an anchored error toast', async () => {
+		const user = userEvent.setup();
+		await renderRow();
+		remote.deleteForm.setSubmitResult(() => Promise.reject(new Error('better-sqlite3 exploded')));
+
+		await user.click(deleteButton());
+
+		await waitFor(() => expect(toasts).toHaveLength(1));
+		expect(toasts[0].variant).toBe('error');
+		expect(toasts[0].message).toBe(m.form_error_unexpected());
+		expect(screen.queryByText(/better-sqlite3/)).not.toBeInTheDocument();
+	});
+});
+
+describe('TableRowEdit — pending', () => {
+	it('disables the row buttons during an edit submit without a spinner', async () => {
+		await renderRow(() => {
+			remote.editForm.form.pending = 1;
+		});
+
+		for (const button of [saveButton(), cancelButton(), deleteButton()]) {
+			expect(button).toBeDisabled();
+			expect(button).not.toHaveAttribute('aria-busy');
+		}
+		expect(document.querySelector('[data-slot=button-spinner]')).toBeNull();
+	});
+
+	it('disables the row buttons during a delete submit', async () => {
+		await renderRow(() => {
+			remote.deleteForm.form.pending = 1;
+		});
+
+		for (const button of [saveButton(), cancelButton(), deleteButton()]) {
+			expect(button).toBeDisabled();
+		}
+	});
+});

--- a/src/lib/components/features/transaction/transaction-table-row-errors.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-errors.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { RemoteFormIssue } from '@sveltejs/kit';
+
+	let { issues }: { issues: RemoteFormIssue[] | undefined } = $props();
+</script>
+
+{#if issues?.length}
+	<div role="cell" class="col-span-full bg-interactive/5 px-4 pb-2">
+		<p role="alert" class="text-sm text-error">
+			{issues.map((issue) => issue.message).join(' · ')}
+		</p>
+	</div>
+{/if}

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -4,13 +4,10 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { m } from '$lib/paraglide/messages';
-	import { batchValidateTransactions } from '$lib/remote-functions/transaction.remote';
 	import { formatTransactionDate } from '$lib/utils/format-transaction-date';
 	import { asMoney, formatMoney } from '$lib/utils/money';
 	import { parseDate } from '@internationalized/date';
 	import PlusBoldIcon from '~icons/ph/plus-bold';
-	import SealIcon from '~icons/ph/seal';
-	import SealCheckDuotoneIcon from '~icons/ph/seal-check-duotone';
 
 	import type { TableState } from './transaction-table-state.svelte';
 
@@ -23,6 +20,7 @@
 	import TableRowCreate from './transaction-table-row-create.svelte';
 	import TableRowEdit from './transaction-table-row-edit.svelte';
 	import TableRow from './transaction-table-row.svelte';
+	import ValidateToggle from './transaction-validate-toggle.svelte';
 
 	let {
 		accountId,
@@ -75,8 +73,6 @@
 				{#if isEditing}
 					<TableRowEdit transaction={item} {budgetId} {currency} {cancelEditing} />
 				{:else}
-					{@const validation = batchValidateTransactions.for(item.id)}
-
 					<TableRow>
 						<TableCell aria-label={m.transactions_table_edit_category()} onclick={setEditing}>
 							{#if item.categoryName}
@@ -110,25 +106,7 @@
 
 						<TableCell>
 							{#snippet child()}
-								<form {...validation} class="grid size-full place-content-center">
-									<input {...validation.fields.validated.as('hidden', !item.validated)} />
-
-									<Button
-										type="submit"
-										name={validation.fields.ids.as('select multiple').name}
-										value={[item.id]}
-										size="icon-lg"
-										variant="ghost"
-										class="rounded-xs hover:bg-transparent"
-										aria-label={m.transactions_table_toggle_validated()}
-									>
-										{#if item.validated}
-											<SealCheckDuotoneIcon class="size-6 text-success" />
-										{:else}
-											<SealIcon class="size-6 text-muted" />
-										{/if}
-									</Button>
-								</form>
+								<ValidateToggle transaction={item} />
 							{/snippet}
 						</TableCell>
 					</TableRow>

--- a/src/lib/components/features/transaction/transaction-validate-toggle.svelte
+++ b/src/lib/components/features/transaction/transaction-validate-toggle.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { ListTransaction } from '$lib/server/db/user-context/transaction';
+
+	import { Button } from '$lib/components/ui/button';
+	import { m } from '$lib/paraglide/messages';
+	import { batchValidateTransactions } from '$lib/remote-functions/transaction.remote';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
+	import SealIcon from '~icons/ph/seal';
+	import SealCheckDuotoneIcon from '~icons/ph/seal-check-duotone';
+
+	let { transaction }: { transaction: ListTransaction } = $props();
+
+	const form = $derived(batchValidateTransactions.for(transaction.id));
+
+	// Row-scoped micro-form (ADR-0009): the seal icon flipping with the
+	// refreshed list is the success signal; thrown errors go to the toast.
+	const submit = createFormSubmit(() => form, { toast: {} });
+</script>
+
+<form {...submit.attrs} class="grid size-full place-content-center">
+	<input {...form.fields.validated.as('hidden', !transaction.validated)} />
+
+	<Button
+		type="submit"
+		name={form.fields.ids.as('select multiple').name}
+		value={[transaction.id]}
+		size="icon-lg"
+		variant="ghost"
+		disabled={submit.pending}
+		class="rounded-xs hover:bg-transparent"
+		aria-label={m.transactions_table_toggle_validated()}
+		{@attach submit.anchor}
+	>
+		{#if transaction.validated}
+			<SealCheckDuotoneIcon class="size-6 text-success" />
+		{:else}
+			<SealIcon class="size-6 text-muted" />
+		{/if}
+	</Button>
+</form>

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -109,8 +109,10 @@ export class AccountPage extends BasePage {
 			.filter({ has: this.page.getByRole('button', { name: 'Save' }) });
 		await editForm.getByRole('button', { name: 'Delete' }).click();
 
-		// Delete submits a hidden batch-delete form — the visible edit form stays
-		// open. The assertion retries until one fewer transaction row remains.
+		// The refreshed list drops the deleted transaction, which unmounts the
+		// edit row. Asserting the edit form is gone distinguishes a real delete
+		// from merely being in edit mode (where the category cell also vanishes).
+		await expect(editForm).not.toBeVisible();
 		await expect(this.page.getByRole('cell', { name: 'Edit category' })).toHaveCount(cellCount - 1);
 	}
 


### PR DESCRIPTION
Closes #89. Part of #85 — last task of the epic.

## What changed

- **Create and edit rows compose `createFormSubmit` directly.** Decision per ticket: not `PopoverForm` — its trigger snippet is mandatory but the create row's trigger lives in the table toolbar, and the keyboard-submit attachment needs the raw form element. Save-and-continue (via `onSuccess` receiving the form instance), Enter/Shift+Enter shortcuts, and query update chaining are preserved.
- **Shared row error line:** new `transaction-table-row-errors.svelte` renders one `role="alert"` line per row fed by `fields.allIssues()`; inputs stay bare with invalid-state styling.
- **Thrown errors are never silent:** create, edit, delete, and the validate toggle route thrown errors to anchored error toasts (toast-owns-errors, ADR-0009).
- **Flight state:** all row buttons disable while pending, the keyboard submit path is guarded, and rows show no spinner (plain `disabled`, not `Button.loading`).
- **Validate toggle** extracted into `transaction-validate-toggle.svelte` and wired through the primitive — row-scoped micro-form per the epic's contract.

## Row delete was silently broken on main

The delete button submitted a `value` with no `name`, so the batch-delete POST carried no ids — server-side schema validation failed and nothing was deleted, with zero UI reaction. The existing "Delete Transaction" e2e passed spuriously: entering edit mode removes the counted "Edit category" cell, satisfying the count assertion without any deletion (verified empirically via payload capture and post-reload state).

Fixed by submitting the button under the `ids` field name (mirroring the validate toggle), and the delete POM now also asserts the edit row unmounts, so the e2e can no longer pass spuriously.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- Unit suite: 497 passing (24 new: 14 create-row, 10 edit-row)
- Playwright: all 68 e2e green (tablet + chromium)
- Production build succeeds