### PR TITLE
fix(e2e): settle redirect chain before heading assert in createAdmin (#97)

### DIFF
--- a/tests/playwright/pom/auth.ts
+++ b/tests/playwright/pom/auth.ts
@@ -16,6 +16,13 @@ export class AuthPage extends BasePage {
 
 		await this.page.getByRole('button', { name: 'Create Admin' }).click();
 
+		// Creating the admin chains two server redirects (register -> `/` ->
+		// `/new`) and the `/new` screen only renders once its `getBudgets()`
+		// query resolves. This is the run's very first authenticated navigation,
+		// so wait for the redirect chain to settle before asserting the heading —
+		// each phase gets its own budget instead of racing a single timeout.
+		await this.page.waitForURL('/new');
+
 		await expect(
 			this.page.getByRole('heading', { name: 'Create Your First Budget Plan' })
 		).toBeVisible();


### PR DESCRIPTION
Closes #97.

## Problem

The serial `[setup]` step "Create admin" flaked ~1/10 locally: after clicking **Create Admin**, the `Create Your First Budget Plan` heading assertion timed out. Because setup runs `mode: 'serial'` and every project depends on it — with zero local retries — one flake aborts the whole run.

## Root cause

Creating the admin is an unusually long success chain, and it's the run's **first** authenticated navigation (coldest):

1. `register` redirects `302 → /`
2. `(app)/+page.server.ts` redirects `307 → /new` (no first budget yet)
3. `/new` only renders once its `const budgets = $derived(await getBudgets())` query resolves

The old assertion made the heading wait absorb that entire chain (two redirects + a gated async query) inside a single 10s budget, so under cold-start/load it occasionally timed out.

## Investigation

The app behaviour was verified correct, not patched blindly:

- Native no-JS fallback works even with 2.5s JS load delay (heading still reaches `/new`).
- Enhanced path reliable across **85+ scripted iterations** — warm server, cold fresh-server-per-run, and 2× CPU-overloaded — 0 failures.

So this is **test hardening**, not an app fix.

## Fix

Wait for the redirect chain to settle (`waitForURL('/new')`) before asserting the heading, so navigation and render each get their own timeout budget and a failure points at one phase rather than one opaque timeout.

## Checks

- `npm run check` clean, lint clean
- Unit suite: 497 passing (+1 expected-fail)
- Full Playwright suite: **68 passing** on an idle machine
- Two-axis code review (Standards + Spec): 0 findings