### PR TITLE
fix(transaction): center validate checkbox in create/edit rows (#100)

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -148,7 +148,7 @@
 				/>
 			</div>
 
-			<div role="cell" class="grid items-center bg-interactive/5 p-2">
+			<div role="cell" class="grid place-content-center bg-interactive/5 p-2">
 				<ValidationCheckbox {...createTransaction.fields.validated.as('checkbox')} />
 			</div>
 

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -126,7 +126,7 @@
 		/>
 	</div>
 
-	<div role="cell" class="grid items-center bg-interactive/5 p-2">
+	<div role="cell" class="grid place-content-center bg-interactive/5 p-2">
 		<ValidationCheckbox {...form.fields.validated.as('checkbox', transaction.validated)} />
 	</div>
 


### PR DESCRIPTION
## What

The validate checkbox at the end of the inline transaction **create** and **edit** rows sat flush-left in its cell instead of being centered.

## Why

The cell wrapper used `grid items-center`, which centers only vertically. The other cells look fine because their content (category select, note input, amount input) stretches to fill the cell; the validate checkbox is a fixed icon-sized button, so grid's default `justify-items: start` left it stuck to the left.

## Fix

Swapped `grid items-center` → `grid place-content-center` on the validate cell in both `transaction-table-row-create.svelte` and `transaction-table-row-edit.svelte`. This centers on both axes (vertical centering preserved), matching the display-row validate toggle and the column header, which already center via `place-content-center`.

## Verification

- `npm run check` — 0 errors
- `npm run lint` — prettier + eslint clean
- `npm run test:unit` — 497 pass, 1 expected fail
- `/code-review` — spec axis clean; standards axis's lone finding dismissed as the intended, spec-mandated alignment fix

Closes #100