### PR TITLE
fix(admin): drive delete-user hidden userId from selected user (#101)

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -148,7 +148,7 @@
 				/>
 			</div>
 
-			<div role="cell" class="grid items-center bg-interactive/5 p-2">
+			<div role="cell" class="grid place-content-center bg-interactive/5 p-2">
 				<ValidationCheckbox {...createTransaction.fields.validated.as('checkbox')} />
 			</div>
 

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -126,7 +126,7 @@
 		/>
 	</div>
 
-	<div role="cell" class="grid items-center bg-interactive/5 p-2">
+	<div role="cell" class="grid place-content-center bg-interactive/5 p-2">
 		<ValidationCheckbox {...form.fields.validated.as('checkbox', transaction.validated)} />
 	</div>
 

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -35,6 +35,7 @@
 
 	let openDialog = $state(false);
 	let openAlertDialog = $state(false);
+	let selectedUserId = $state('');
 	let generatedPassword = $derived(
 		createUser.result?.password ?? resetUserPassword.result?.newPassword
 	);
@@ -118,7 +119,7 @@
 										size="icon-sm"
 										variant="destructive"
 										onclick={() => {
-											removeUser.fields.userId.set(user.id);
+											selectedUserId = user.id;
 											openAlertDialog = true;
 										}}
 									>
@@ -167,7 +168,7 @@
 	{/snippet}
 
 	{#snippet fields()}
-		<input {...removeUser.fields.userId.as('hidden', '')} />
+		<input {...removeUser.fields.userId.as('hidden', selectedUserId)} />
 	{/snippet}
 
 	{#snippet footer({ formId, pending })}

--- a/tests/playwright/admin.spec.ts
+++ b/tests/playwright/admin.spec.ts
@@ -3,3 +3,9 @@ import { test } from './fixture';
 test('Create User', async ({ pages }) => {
 	const _user = await pages.auth.createUserAndLogin();
 });
+
+test('Delete User', async ({ pages }) => {
+	await pages.auth.login(...pages.auth.admin);
+	const [username] = await pages.auth.createUser();
+	await pages.admin.deleteUser(username);
+});

--- a/tests/playwright/pom/admin.ts
+++ b/tests/playwright/pom/admin.ts
@@ -3,6 +3,21 @@ import { expect } from '@playwright/test';
 import { BasePage } from './base-page';
 
 export class AdminPage extends BasePage {
+	async deleteUser(username: string) {
+		await this.page.goto('/admin');
+
+		const row = this.page.getByRole('listitem').filter({ hasText: username });
+		await row.getByRole('button', { name: 'Remove User' }).click();
+
+		// The delete is confirmed through the app's own alert dialog.
+		const dialog = this.page.getByRole('alertdialog');
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Delete' }).click();
+
+		await expect(dialog).toBeHidden();
+		await expect(row).toHaveCount(0);
+	}
+
 	async resetDatabase() {
 		await this.page.goto('/admin');
 		await this.page.getByRole('button', { name: 'Reset Instance' }).click();


### PR DESCRIPTION
## Was

Fixt den Admin-"Delete User"-Flow, der beim Bestätigen mit `Invalid length: Expected >=1 but received 0` auf `userId` fehlschlug.

## Warum

Der geteilte Confirm-Dialog kodierte das versteckte `userId`-Feld fest als leeren Default (`.as('hidden', '')`). Das überschrieb die beim Klick per `removeUser.fields.userId.set(user.id)` gesetzte id, sodass das Formular `userId: ""` absendete — und `UserIdSchema`'s `minLength(1)` das ablehnte.

## Wie

- Ausgewählten User in lokalem State halten (`selectedUserId`) und ans versteckte Input binden (`.as('hidden', selectedUserId)`) — analog zum Inline-id-Muster in `invitation.svelte`.
- E2E-Test in `tests/playwright`, der einen Admin einen User löschen lässt (POM-Methode `deleteUser`).

## Test

- `npm run check` — 0 Errors
- `npm run lint` — clean
- Admin-E2E-Tests grün auf allen Projekten

Closes #101