### PR TITLE
chore: pre-commit hooks via husky + tightened lint-staged (#121)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+# husky v9: no shebang needed — the wrapper in .husky/_/ provides it
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"eslint-plugin-perfectionist": "^5.7.0",
 				"eslint-plugin-svelte": "^3.15.2",
 				"globals": "^17.4.0",
+				"husky": "^9.1.7",
 				"jsdom": "^29.0.2",
 				"lint-staged": "^16.4.0",
 				"phosphor-svelte": "^3.1.0",
@@ -5732,6 +5733,22 @@
 			"license": "MIT",
 			"bin": {
 				"human-id": "dist/cli.js"
+			}
+		},
+		"node_modules/husky": {
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"husky": "bin.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
 			}
 		},
 		"node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo ''",
+		"prepare": "svelte-kit sync || echo '' ; husky",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
@@ -55,6 +55,7 @@
 		"eslint-plugin-perfectionist": "^5.7.0",
 		"eslint-plugin-svelte": "^3.15.2",
 		"globals": "^17.4.0",
+		"husky": "^9.1.7",
 		"jsdom": "^29.0.2",
 		"lint-staged": "^16.4.0",
 		"phosphor-svelte": "^3.1.0",
@@ -78,9 +79,7 @@
 		"vitest": "^4.1.2"
 	},
 	"lint-staged": {
-		"*": [
-			"prettier --write --ignore-unknown",
-			"eslint --fix"
-		]
+		"*": "prettier --write --ignore-unknown",
+		"*.{js,ts,svelte,svelte.ts,svelte.js}": "eslint --fix"
 	}
 }


### PR DESCRIPTION
Adds husky as the pre-commit runner, replacing the ad-hoc `.githooks/` mechanism that only worked via a non-portable local `core.hooksPath`. Pre-flip gate for the Public Release milestone; execution follow-on for the runner-and-policy decision (#111).

## Changes
- husky `^9.1.7` devDependency; `.husky/pre-commit` runs `npx lint-staged`
- wire husky into `prepare` with a sequencing `;` (not `&&`, which would short-circuit husky when `svelte-kit sync` fails)
- split `lint-staged`: `prettier --write --ignore-unknown` on all files, `eslint --fix` only on `*.{js,ts,svelte,svelte.ts,svelte.js}`
- remove the superseded `.githooks/pre-commit`

## Verification
- mis-formatted staged file (`{a:1,b:2}`) auto-reformats and commits
- an eslint unused-var error blocks the commit
- typecheck clean (0 errors); 505 unit tests pass

Closes #121