### PR TITLE
test(coverage): scoped 100% lines+functions CI gate (#120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide
-      - run: npm run test:unit
+      - run: npm run test:unit -- run --coverage
         env:
           DATABASE_URL: ':memory:'
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ vite.config.ts.timestamp-*
 src/lib/paraglide
 project.inlang/cache/
 
+# Coverage
+/coverage
+
 # Playwright
 tests/playwright/results/
 blob-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
 				"@types/better-sqlite3": "^7.6.13",
 				"@types/node": "^22",
 				"@types/sortablejs": "^1.15.9",
+				"@vitest/coverage-v8": "^4.1.10",
 				"bits-ui": "^2.16.3",
 				"drizzle-kit": "^1.0.0-rc.3",
 				"drizzle-orm": "^1.0.0-rc.3",
@@ -486,14 +487,40 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.7"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -504,6 +531,30 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@bramus/specificity": {
@@ -3412,17 +3463,48 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+			"integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.10",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "4.1.10",
+				"vitest": "4.1.10"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-			"integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3431,13 +3513,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-			"integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.2",
+				"@vitest/spy": "4.1.10",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -3458,9 +3540,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-			"integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3471,13 +3553,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-			"integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.2",
+				"@vitest/utils": "4.1.10",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -3485,14 +3567,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-			"integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -3501,9 +3583,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-			"integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -3511,13 +3593,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-			"integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
+				"@vitest/pretty-format": "4.1.10",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -3683,6 +3765,25 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+			"integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/atomic-sleep": {
 			"version": "1.0.0",
@@ -5660,6 +5761,16 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -5692,6 +5803,13 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -5981,6 +6099,45 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
@@ -6724,6 +6881,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+			"integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.3",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mdn-data": {
@@ -8459,6 +8644,19 @@
 				"inline-style-parser": "0.2.7"
 			}
 		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -9872,19 +10070,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-			"integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.2",
-				"@vitest/mocker": "4.1.2",
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/runner": "4.1.2",
-				"@vitest/snapshot": "4.1.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -9912,10 +10110,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.2",
-				"@vitest/browser-preview": "4.1.2",
-				"@vitest/browser-webdriverio": "4.1.2",
-				"@vitest/ui": "4.1.2",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9937,6 +10137,12 @@
 					"optional": true
 				},
 				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "^22",
 		"@types/sortablejs": "^1.15.9",
+		"@vitest/coverage-v8": "^4.1.10",
 		"bits-ui": "^2.16.3",
 		"drizzle-kit": "^1.0.0-rc.3",
 		"drizzle-orm": "^1.0.0-rc.3",

--- a/src/lib/server/db/auth/auth.test.ts
+++ b/src/lib/server/db/auth/auth.test.ts
@@ -1,3 +1,5 @@
+import type { Cookies } from '@sveltejs/kit';
+
 import { createDatabase, type Database } from '$db';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
@@ -6,12 +8,16 @@ import {
 	createSession,
 	createSessionToken,
 	deleteSession,
+	deleteSessionCookie,
+	deleteUserSessions,
+	getSessionCookie,
 	hashPassword,
 	refreshSession,
+	setSessionCookie,
 	validateSession
 } from './index';
 import { createUser } from './user';
-import { DAY_IN_MS, InvalidCredentialsError, type Session } from './utils';
+import { DAY_IN_MS, InvalidCredentialsError, type Session, SESSION_COOKIE_NAME } from './utils';
 
 async function createSessionForTest(db: Database): Promise<Session> {
 	const passwordHash = await hashPassword({ password: 'password123' });
@@ -91,6 +97,37 @@ it('deleteSession - ignores missing session ids', () => {
 	const db = createDatabase(':memory:');
 
 	expect(deleteSession({ db, sessionId: 'missing-session-id' })).toBeUndefined();
+});
+
+it('deleteUserSessions - removes every session belonging to a user', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	const user = createUser({ db, passwordHash, username: 'testuser' });
+	createSession({ db, userId: user.id });
+	createSession({ db, userId: user.id });
+
+	deleteUserSessions({ db, userId: user.id });
+
+	await expect(
+		db.query.sessions.findFirst({ where: { userId: user.id } })
+	).resolves.toBeUndefined();
+});
+
+it('setSessionCookie / getSessionCookie / deleteSessionCookie - round-trip via Cookies', () => {
+	const store = new Map<string, string>();
+	const cookies = {
+		delete: (name: string) => store.delete(name),
+		get: (name: string) => store.get(name),
+		set: (name: string, value: string) => store.set(name, value)
+	} as unknown as Cookies;
+
+	const expiresAt = new Date(DAY_IN_MS * 20);
+	setSessionCookie({ cookies, expiresAt, sessionToken: 'token-value' });
+	expect(store.get(SESSION_COOKIE_NAME)).toBe('token-value');
+	expect(getSessionCookie({ cookies })).toBe('token-value');
+
+	deleteSessionCookie({ cookies });
+	expect(getSessionCookie({ cookies })).toBeUndefined();
 });
 
 beforeEach(() => {

--- a/src/lib/server/db/auth/user.test.ts
+++ b/src/lib/server/db/auth/user.test.ts
@@ -1,8 +1,9 @@
-import { createDatabase } from '$db';
+import { createDatabase, tables } from '$db';
+import { and, eq } from 'drizzle-orm';
 import { expect, it } from 'vitest';
 
 import { hashPassword } from './index';
-import { createUser, deleteUser, isFirstUser } from './user';
+import { createUser, deleteUser, getAllUsers, isFirstUser, setPassword, setUsername } from './user';
 
 it('createUser - creates user with correct properties', async () => {
 	const db = createDatabase(':memory:');
@@ -46,4 +47,127 @@ it('isFirstUser - returns true on empty db, false after first user', async () =>
 	createUser({ db, passwordHash, username: 'testuser' });
 
 	await expect(isFirstUser({ db })).resolves.toBe(false);
+});
+
+it('deleteUser - deletes budgets the user solely owns, even when others exist elsewhere', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	const user = createUser({ db, passwordHash, username: 'soloowner' });
+	// An unrelated user with their own budget must not keep the solo budget alive.
+	const other = createUser({ db, passwordHash, username: 'other' });
+	const otherBudget = db.insert(tables.budgets).values({ name: 'Other Budget' }).returning().get();
+	db.insert(tables.usersToBudgets)
+		.values({ budgetId: otherBudget.id, role: 'OWNER', userId: other.id })
+		.run();
+	const budget = db.insert(tables.budgets).values({ name: 'Solo Budget' }).returning().get();
+	db.insert(tables.usersToBudgets)
+		.values({ budgetId: budget.id, role: 'OWNER', userId: user.id })
+		.run();
+
+	deleteUser({ db, userId: user.id });
+
+	await expect(db.query.budgets.findFirst({ where: { id: budget.id } })).resolves.toBeUndefined();
+	const otherStillExists = await db.query.budgets.findFirst({ where: { id: otherBudget.id } });
+	expect(otherStillExists).toBeDefined();
+});
+
+it('deleteUser - promotes another member to owner when the budget has members', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	const owner = createUser({ db, passwordHash, username: 'owner' });
+	const member = createUser({ db, passwordHash, username: 'member' });
+	const budget = db.insert(tables.budgets).values({ name: 'Shared Budget' }).returning().get();
+	// The owner also solely owns a second budget, so the solo-owner cleanup and the
+	// member-promotion path both run in the same deletion.
+	const soloBudget = db.insert(tables.budgets).values({ name: 'Solo Budget' }).returning().get();
+	db.insert(tables.usersToBudgets)
+		.values([
+			{ budgetId: budget.id, role: 'OWNER', userId: owner.id },
+			{ budgetId: budget.id, role: 'MEMBER', userId: member.id },
+			{ budgetId: soloBudget.id, role: 'OWNER', userId: owner.id }
+		])
+		.run();
+
+	deleteUser({ db, userId: owner.id });
+
+	const budgetStillExists = await db.query.budgets.findFirst({ where: { id: budget.id } });
+	expect(budgetStillExists).toBeDefined();
+	await expect(
+		db.query.budgets.findFirst({ where: { id: soloBudget.id } })
+	).resolves.toBeUndefined();
+
+	const promoted = db
+		.select({ role: tables.usersToBudgets.role })
+		.from(tables.usersToBudgets)
+		.where(
+			and(
+				eq(tables.usersToBudgets.budgetId, budget.id),
+				eq(tables.usersToBudgets.userId, member.id)
+			)
+		)
+		.get();
+	expect(promoted?.role).toBe('OWNER');
+});
+
+it('deleteUser - leaves budgets owned by others untouched', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	const owner = createUser({ db, passwordHash, username: 'owner' });
+	const member = createUser({ db, passwordHash, username: 'member' });
+	const budget = db.insert(tables.budgets).values({ name: 'Shared Budget' }).returning().get();
+	db.insert(tables.usersToBudgets)
+		.values([
+			{ budgetId: budget.id, role: 'OWNER', userId: owner.id },
+			{ budgetId: budget.id, role: 'MEMBER', userId: member.id }
+		])
+		.run();
+
+	deleteUser({ db, userId: member.id });
+
+	const budgetStillExists = await db.query.budgets.findFirst({ where: { id: budget.id } });
+	expect(budgetStillExists).toBeDefined();
+
+	const ownerStillOwner = db
+		.select({ role: tables.usersToBudgets.role })
+		.from(tables.usersToBudgets)
+		.where(
+			and(eq(tables.usersToBudgets.budgetId, budget.id), eq(tables.usersToBudgets.userId, owner.id))
+		)
+		.get();
+	expect(ownerStillOwner?.role).toBe('OWNER');
+});
+
+it('getAllUsers - returns id and username, admins first', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	createUser({ db, passwordHash, username: 'regular' });
+	createUser({ db, isAdmin: true, passwordHash, username: 'admin' });
+
+	const users = getAllUsers({ db });
+
+	expect(users).toHaveLength(2);
+	expect(users[0]).toEqual({ id: expect.any(String), username: 'admin' });
+	expect(users[1]).toMatchObject({ username: 'regular' });
+});
+
+it('setPassword - updates the hash so the new password authenticates', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'oldpassword' });
+	const user = createUser({ db, passwordHash, username: 'testuser' });
+
+	await setPassword({ db, password: 'newpassword', userId: user.id });
+
+	const stored = await db.query.users.findFirst({ where: { id: user.id } });
+	expect(stored?.passwordHash).not.toBe(passwordHash);
+});
+
+it('setUsername - updates the username', async () => {
+	const db = createDatabase(':memory:');
+	const passwordHash = await hashPassword({ password: 'password123' });
+	const user = createUser({ db, passwordHash, username: 'oldname' });
+
+	setUsername({ db, userId: user.id, username: 'newname' });
+
+	const stored = await db.query.users.findFirst({ where: { id: user.id } });
+	expect(stored?.username).toBe('newname');
 });

--- a/src/lib/server/db/auth/user.ts
+++ b/src/lib/server/db/auth/user.ts
@@ -1,5 +1,6 @@
 import { database, type Database, tables } from '$db';
 import { and, desc, eq, getColumns, ne, notExists } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/sqlite-core';
 
 import { hashPassword } from './index';
 
@@ -15,6 +16,7 @@ export function createUser({
 
 export function deleteUser({ db = database, userId }: { db?: Database; userId: string }) {
 	db.transaction((tx) => {
+		const otherMembers = alias(tables.usersToBudgets, 'other_members');
 		const soloOwnerBudgets = tx
 			.select({ budgetId: tables.usersToBudgets.budgetId })
 			.from(tables.usersToBudgets)
@@ -24,11 +26,11 @@ export function deleteUser({ db = database, userId }: { db?: Database; userId: s
 					notExists(
 						tx
 							.select()
-							.from(tables.usersToBudgets)
+							.from(otherMembers)
 							.where(
 								and(
-									eq(tables.usersToBudgets.budgetId, tables.usersToBudgets.budgetId),
-									ne(tables.usersToBudgets.userId, userId)
+									eq(otherMembers.budgetId, tables.usersToBudgets.budgetId),
+									ne(otherMembers.userId, userId)
 								)
 							)
 					)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,26 @@ export default defineConfig({
 			}
 		: undefined,
 	test: {
+		coverage: {
+			// Scoped floor: gate the server data layer where access control and
+			// persistence rules live. Boilerplate and generated code are excluded.
+			exclude: [
+				'src/lib/server/db/tables/**',
+				'src/lib/server/db/relations.ts',
+				'src/lib/server/db/create-database.ts',
+				'src/lib/server/db/migrations/**',
+				'src/lib/server/db/index.ts',
+				'src/lib/server/db/user-context/index.ts'
+			],
+			include: ['src/lib/server/db/**'],
+			provider: 'v8',
+			reporter: ['text', 'html'],
+			// 100% lines + functions on the guarded modules; branches reported, not gated.
+			thresholds: {
+				'src/lib/server/db/auth/**': { functions: 100, lines: 100 },
+				'src/lib/server/db/user-context/**': { functions: 100, lines: 100 }
+			}
+		},
 		environment: 'jsdom',
 		include: ['src/**/*.{test,spec}.{ts,tsx}'],
 		includeSource: ['src/**/*.{js,ts}'],


### PR DESCRIPTION
Closes #120.

Adds a scoped test-coverage gate over the server data layer (decision #113) as a pre-flip step for the Public Release milestone.

## What

- Add `@vitest/coverage-v8` devDependency.
- Configure `coverage` in `vite.config.ts`: v8 provider, `include` scoped to `src/lib/server/db/**`, `exclude` for Drizzle schema, `relations.ts`, `create-database.ts`, migrations, and barrel `index.ts` files.
- Per-glob `thresholds`: **100% lines + functions** on `server/db/auth/**` and `server/db/user-context/**`. Branches reported, not gated.
- Bring `auth/user.ts` from ~47% to 100% — tests for `deleteUser` budget cleanup, `getAllUsers` ordering, `setPassword`, `setUsername`, plus the previously-untested session/cookie helpers in `auth/index.ts` (the gate spans the whole `auth/` glob).
- Fold `vitest run --coverage` into the existing `unit-test` CI job.

## Bug found and fixed

Reaching 100% functions surfaced dead code in `deleteUser`: the solo-owner `notExists` subquery compared `usersToBudgets.budgetId` to itself, so it checked for any other member **globally** instead of **within the same budget**. This left the member-promotion branch unreachable and failed to clean up solo-owned budgets whenever any other user existed. Fixed by aliasing the inner table so the subquery correlates per budget; covered by the new deletion tests.

## Verification

- `npm run check` clean, `npm run lint` clean.
- Full unit suite green; coverage gate passes at exit 0 with gated modules at 100% lines+functions.
- No new e2e (critical-flow bar already covered by the e2e suite).