### PR TITLE
feat(release): CalVer versioning, release script, publish workflow, version label (#125)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+name: Publish
+
+# Publishes container images to GHCR (ADR-0012). Separate from ci.yml so the PR
+# gate is untouched. main is already green via the PR gate, so this workflow only
+# builds and pushes — it does not re-run the test suite.
+#
+#   push to main        → ghcr.io/lj-n/genug-da:stage + :sha-<short>
+#   push a version tag  → ghcr.io/lj-n/genug-da:<version> + :latest
+on:
+  push:
+    branches: [main]
+    # CalVer tags YYYY.0M.MICRO, e.g. 2026.07.0 — the micro must start with a
+    # digit so a malformed tag can't publish :latest.
+    tags: ['[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9]*']
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/lj-n/genug-da
+
+jobs:
+  # Tag pushes always publish. main pushes skip when only docs/markdown changed,
+  # reusing ci.yml's paths-filter philosophy.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.ref_type == 'branch'
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+      - id: decide
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Version tag — publishing prod image."
+          elif [ "${{ steps.filter.outputs.code }}" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Code changed — publishing stage image."
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Docs-only push to main — skipping image build."
+          fi
+
+  publish:
+    needs: [gate]
+    if: needs.gate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: sha
+        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=stage,enable=${{ github.ref_type == 'branch' }}
+            type=sha,prefix=sha-,format=short,enable=${{ github.ref_type == 'branch' }}
+            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Only stage (branch) builds carry the SHA; prod (tag) builds stay clean.
+          build-args: |
+            BUILD_SHA=${{ github.ref_type == 'branch' && steps.sha.outputs.short || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions use CalVer
+(`YYYY.0M.MICRO`, see [ADR-0012](docs/adr/0012-calver-releases-and-stage-deploy.md)).
+
+Only user-visible changes are recorded here — new or changed features, bug
+fixes, behaviour and UX changes, and new settings. Refactors, tests, CI, docs,
+and dependency bumps get no entry.
+
+## [Unreleased]
+
+### Added
+
+- Envelope budgeting with per-month assignment: assign money to categories, move
+  money between them, and cover overspending.
+- Multiple budget plans, each with its own accounts, categories, and
+  transactions.
+- Accounts with validated and pending balances, plus archive, restore, and
+  delete.
+- Categories with target balances and archive, restore, and delete.
+- Inline transaction editing (category, date, notes, amount) with filtering and
+  a validated toggle.
+- Multi-user support: admin-created users, per-budget invitations, and
+  self-service credential management.
+- German and English localisation, switchable at runtime.
+- Currencies: EUR, USD, GBP, CAD, AUD, JPY.
+- Dark mode following the system preference, with a Settings override persisted
+  across sessions.
+- A muted build-version label beside the logo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Persistent agent and workflow rules for this repository.
 - Match existing code conventions. No drive-by refactors, renames, or reformatting.
 - Verify with real tool output — never fabricate file contents, API responses, or test results.
 - Keep codebase files in English.
+- A user-visible change (new/changed feature, bug fix, behaviour/UX change, new setting) must add an entry under `## [Unreleased]` in `CHANGELOG.md`, categorized `Added`/`Changed`/`Fixed`. Refactors, tests, CI, docs, and dependency bumps get no entry. Releases are cut with `npm run release` (CalVer + changelog stamping, see ADR-0012).
 
 ## Stack
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ COPY vite.config.ts ./
 COPY svelte.config.js ./
 COPY tsconfig.json ./
 
+# Stage builds pass the short commit SHA so the app surfaces a dev-flavoured
+# version (`<version>-dev+<sha>`); prod builds leave it empty (ADR-0012).
+ARG BUILD_SHA=
+ENV BUILD_SHA=$BUILD_SHA
+
 ENV DATABASE_URL=build
 RUN npm run build
 RUN npm prune --production

--- a/README.md
+++ b/README.md
@@ -54,13 +54,38 @@ better-sqlite3, valibot, @node-rs/argon2, Paraglide i18n, Vitest, Playwright.
 `ORIGIN` — public URL of your instance, e.g. `https://budget.example.com`.
 Required for CSRF protection when running behind a reverse proxy.
 
-### Docker Compose
+### Container images (GHCR)
+
+Prebuilt images are published to the GitHub Container Registry at
+`ghcr.io/lj-n/genug-da` (see [ADR-0012](docs/adr/0012-calver-releases-and-stage-deploy.md)):
+
+| Tag           | Built from      | Use                                                                         |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| `latest`      | latest release  | Production — moving pointer to the newest release.                          |
+| `<version>`   | a release       | Production — immutable pin (`2026.07.0`); roll back by pinning a prior one. |
+| `stage`       | tip of `main`   | Testing — rolling build ahead of the last release.                          |
+| `sha-<short>` | a `main` commit | Testing — immutable pin to an exact commit.                                 |
+
+Stage builds show a dev-flavoured version beside the logo (`2026.07.0-dev+a1b2c3d`);
+release builds show the clean CalVer.
+
+While the repository (and image) is private, authenticate the host once with a
+personal access token that has `read:packages`:
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u <github-username> --password-stdin
+```
+
+### Docker Compose (production)
+
+Pulls the released image; swap `latest` for a specific `<version>` to pin or
+roll back.
 
 ```yml
 services:
   genug-da:
     container_name: genug-da
-    build: .
+    image: ghcr.io/lj-n/genug-da:latest
     restart: unless-stopped
     ports:
       - '3002:3002'
@@ -75,6 +100,32 @@ services:
       PORT: 3002
       DATABASE_URL: 'file:/app/data/genug.db'
       ORIGIN: 'https://your.domain'
+      NODE_ENV: 'production'
+```
+
+Update with `docker compose pull && docker compose up -d`. To build locally
+instead of pulling, replace `image:` with `build: .`.
+
+### Docker Compose (stage)
+
+A second stack pulling `:stage` lets you try the tip of `main` before promoting
+it to production. Give it its own data volume, port, and origin so it never
+touches production data.
+
+```yml
+services:
+  genug-da-stage:
+    container_name: genug-da-stage
+    image: ghcr.io/lj-n/genug-da:stage
+    restart: unless-stopped
+    ports:
+      - '3003:3002'
+    volumes:
+      - ./data-stage:/app/data:rw
+    environment:
+      PORT: 3002
+      DATABASE_URL: 'file:/app/data/genug.db'
+      ORIGIN: 'https://stage.your.domain'
       NODE_ENV: 'production'
 ```
 
@@ -113,3 +164,13 @@ npm run test:e2e        # Playwright
 npm run lint
 npm run check
 ```
+
+### Releasing
+
+```sh
+npm run release      # compute the next CalVer, stamp CHANGELOG.md, commit + tag
+git push --follow-tags
+```
+
+Versions are CalVer (`YYYY.0M.MICRO`) and the changelog is hand-curated under
+`## [Unreleased]`; see [ADR-0012](docs/adr/0012-calver-releases-and-stage-deploy.md).

--- a/docs/adr/0012-calver-releases-and-stage-deploy.md
+++ b/docs/adr/0012-calver-releases-and-stage-deploy.md
@@ -1,0 +1,89 @@
+# ADR-0012: CalVer releases, a hand-curated changelog, and a stage deploy lane
+
+Date: 2026-07-14
+Status: accepted
+
+## Context
+
+genug-da is a self-hosted app. Until now there was no way to tell which build
+was live: `package.json` was stuck at `0.0.1`, there were zero git tags,
+deployment was a manual pull of an untagged image straight from `main`, and
+there was no changelog. When something broke the exact shipped code could not be
+pinned down, and a candidate build could not be tried without risking live data
+(issue #99). This is a hard pre-flip gate for going public (#116): the repo
+should ship with a complete self-host + release story.
+
+Several axes were open. **How to version:** SemVer forces a major/minor/patch
+judgement on every change, which is ceremony a small self-hosted project does
+not need. **How to record changes:** auto-generated changelogs (release-please,
+changesets, conventional commits) turn the changelog into a second commit log
+full of refactors and dependency bumps. **How to stage:** a literal `stage` git
+branch means a branch-promotion flow and divergence to manage.
+
+## Decision
+
+**CalVer `YYYY.0M.MICRO`.** Four-digit year, zero-padded two-digit month, and a
+per-month micro counter that resets to `0` each month (`2026.07.0`, `2026.07.1`,
+then `2026.08.0`). The date decides the version, so there is no major/minor/patch
+call to make; zero-padding keeps git tags sorting correctly as strings. The tag
+is the bare version, no `v` prefix. The first release with no existing tags is
+`YYYY.0M.0` — bootstrapping needs no special case.
+
+**A hand-curated `CHANGELOG.md`** in Keep-a-Changelog shape: a top
+`## [Unreleased]` section with `### Added` / `### Changed` / `### Fixed`
+subsections. Only user-visible changes are recorded — refactors, tests, CI,
+docs, and dependency bumps get no entry. Entries land as part of the change that
+introduces them, enforced as a project convention (CLAUDE.md), not by tooling.
+
+**One pure seam.** The fiddly version math and changelog stamping live behind a
+pure module, `src/lib/version/` — given the existing tags, today's date, and the
+current changelog text, it returns the next version and the rewritten changelog.
+No git, no filesystem, no clock inside; the date and tags are inputs. This is the
+only new unit-tested surface (`calver.test.ts`). `scripts/release.ts`
+(`npm run release`) is the mechanical adapter: it reads git tags, `CHANGELOG.md`,
+and `package.json`, delegates to the module, then writes the files and creates
+the release commit and tag. This mirrors ADR-0002 (a mechanical adapter around a
+deep module) and ADR-0004 (isolating fiddly math behind one internal seam).
+
+**A stage lane via image tags, not a branch (Model A).** One long-lived branch
+(`main`); "stage" and "prod" are image tags, not branches. A push to `main`
+publishes a rolling `:stage` plus an immutable `:sha-<short>` to
+`ghcr.io/lj-n/genug-da`; a version tag publishes the frozen `:<version>` plus a
+moving `:latest`. A deploy host runs two Compose stacks pulling `:stage` and
+`:latest`; rollback is pinning prod to a prior `:<version>`. A new `publish.yml`
+handles this, separate from `ci.yml` so the PR gate is untouched; it
+authenticates with the built-in `GITHUB_TOKEN` (`packages: write`), reuses the
+`dorny/paths-filter` gating to skip docs-only pushes, and does not re-run the
+test suite (`main` is already green via the PR gate). Images stay on `ghcr.io`
+even while the repo is private; the host authenticates once via a PAT with
+`read:packages`.
+
+**Version surfacing.** The app exposes its version through SvelteKit's
+`kit.version.name`, fed from `package.json` plus, for stage builds, the short
+build SHA. The `Dockerfile` takes a `BUILD_SHA` build arg that `publish.yml`
+sets only for `main` builds, so stage shows a dev-flavoured `2026.07.0-dev+a1b2c3d`
+and prod (tag) builds show the clean CalVer `2026.07.0`. The UI renders this
+string small and muted beside the `Logo` in both navigations — the fastest
+post-pull sanity check that a new image actually landed. Local dev falls back to
+the plain `package.json` version. Nothing in app logic branches on environment;
+the stage/prod split is entirely a deploy-time concern.
+
+The issue named this "ADR 0010", but 0010 and 0011 were taken by the time this
+landed; it is recorded here as 0012.
+
+## Consequences
+
+- Cutting a release is one command with no hand-calculated micro and no manual
+  git steps; `npm run release` refuses to run on a dirty tree or when
+  `[Unreleased]` is empty (an empty release is a mistake, not a no-op).
+- The changelog stays a readable product log, not a second commit log — at the
+  cost of discipline: a user-visible change that forgets its `[Unreleased]`
+  entry ships unrecorded, since nothing enforces it mechanically.
+- A running instance advertises its exact build beside the logo, so a bad stage
+  build is caught before it is promoted, and prod rollback is a tag pin.
+- The publish workflow, `Dockerfile`, image-tag scheme, image pull, and the
+  trivial version-label rendering are proven by a real stage deploy rather than
+  automated tests — only the pure release module is unit-tested.
+- `npm run release` runs the `.ts` script via Node's type stripping
+  (`--experimental-strip-types`), so it shares the exact module the tests cover
+  without a build step; this depends on Node 22+.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"db:migrations": "drizzle-kit generate",
 		"test:unit": "vitest",
 		"test:e2e": "playwright test",
-		"test:e2e:ui": "playwright test --ui"
+		"test:e2e:ui": "playwright test --ui",
+		"release": "node --experimental-strip-types scripts/release.ts"
 	},
 	"dependencies": {
 		"@node-rs/argon2": "^2.0.2",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,56 @@
+/**
+ * Cuts a CalVer release (ADR-0012). Thin mechanical adapter around the pure
+ * `src/lib/version` module: it reads git tags, `CHANGELOG.md`, and
+ * `package.json`, delegates every version/changelog decision to the module,
+ * then writes the files and creates the release commit + tag. It performs no
+ * version math or changelog parsing of its own.
+ *
+ * Run with `npm run release` (Node's type stripping executes the .ts directly).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { computeRelease } from '../src/lib/version/calver.ts';
+
+const CHANGELOG_PATH = 'CHANGELOG.md';
+const PACKAGE_PATH = 'package.json';
+
+function git(...args: string[]): string {
+	return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function main(): void {
+	if (git('status', '--porcelain')) {
+		throw new Error('Working tree is not clean — commit or stash changes before releasing.');
+	}
+
+	const tags = git('tag', '--list').split('\n').filter(Boolean);
+	const changelog = readFileSync(CHANGELOG_PATH, 'utf8');
+
+	const release = computeRelease({ changelog, tags, today: today() });
+
+	if (tags.includes(release.version)) {
+		throw new Error(`Tag ${release.version} already exists.`);
+	}
+
+	const pkg = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8'));
+	pkg.version = release.version;
+
+	writeFileSync(CHANGELOG_PATH, release.changelog);
+	writeFileSync(PACKAGE_PATH, `${JSON.stringify(pkg, null, '\t')}\n`);
+
+	git('add', CHANGELOG_PATH, PACKAGE_PATH);
+	git('commit', '-m', `chore(release): ${release.version}`);
+	git('tag', '-a', release.version, '-m', release.version);
+
+	console.log(`Released ${release.version}.`);
+	console.log(`Push it with: git push --follow-tags`);
+}
+
+function today(): string {
+	// Adapter-side clock: the pure module takes the date as an input.
+	return new Date().toISOString().slice(0, 10);
+}
+
+main();

--- a/src/lib/components/ui/version-label/index.ts
+++ b/src/lib/components/ui/version-label/index.ts
@@ -1,0 +1,1 @@
+export { default as VersionLabel } from './version-label.svelte';

--- a/src/lib/components/ui/version-label/version-label.svelte
+++ b/src/lib/components/ui/version-label/version-label.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	import { version } from '$app/environment';
+	import { cn } from 'tailwind-variants';
+
+	const { class: className, ...rest }: HTMLAttributes<HTMLSpanElement> = $props();
+</script>
+
+<span {...rest} class={cn('text-xs text-muted', className)}>{version}</span>

--- a/src/lib/version/calver.test.ts
+++ b/src/lib/version/calver.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeRelease, nextVersion, stampChangelog } from './calver';
+
+describe('nextVersion', () => {
+	it('starts at YYYY.0M.0 when no tags exist', () => {
+		expect(nextVersion([], '2026-07-14')).toBe('2026.07.0');
+	});
+
+	it('increments the micro for a second release in the same month', () => {
+		expect(nextVersion(['2026.07.0'], '2026-07-20')).toBe('2026.07.1');
+	});
+
+	it('resets the micro to 0 on the first release of a new month', () => {
+		expect(nextVersion(['2026.06.0', '2026.06.1'], '2026-07-01')).toBe('2026.07.0');
+	});
+
+	it('derives the next version from the current month, not the highest tag', () => {
+		// Tags span June and July; a release cut in June must not continue July's counter.
+		expect(nextVersion(['2026.06.0', '2026.07.0', '2026.07.1'], '2026-06-15')).toBe('2026.06.1');
+	});
+
+	it('zero-pads the month in the output', () => {
+		expect(nextVersion([], '2026-03-09')).toBe('2026.03.0');
+	});
+
+	it('finds the highest micro even when tags are unsorted', () => {
+		expect(nextVersion(['2026.07.2', '2026.07.0', '2026.07.10', '2026.07.1'], '2026-07-31')).toBe(
+			'2026.07.11'
+		);
+	});
+
+	it('ignores tags that are not CalVer for the current month', () => {
+		expect(nextVersion(['v1.0.0', '0.0.1', '2026.07.0', 'stage'], '2026-07-14')).toBe('2026.07.1');
+	});
+
+	it('rejects a malformed date', () => {
+		expect(() => nextVersion([], '2026-7-1')).toThrow();
+		expect(() => nextVersion([], 'not-a-date')).toThrow();
+	});
+});
+
+describe('stampChangelog', () => {
+	const changelog = `# Changelog
+
+All notable changes to this project are documented here.
+
+## [Unreleased]
+
+### Added
+
+- Dark mode toggle in Settings.
+
+### Fixed
+
+- Admin delete-user no longer preselects the wrong user.
+
+## [2026.06.0] - 2026-06-01
+
+### Added
+
+- Initial account archiving.
+`;
+
+	it('renames [Unreleased] to a dated version section and opens a fresh [Unreleased]', () => {
+		const result = stampChangelog(changelog, '2026.07.0', '2026-07-14');
+
+		expect(result).toContain('## [Unreleased]');
+		expect(result).toContain('## [2026.07.0] - 2026-07-14');
+
+		// The fresh Unreleased comes first and is empty; the stamped section carries
+		// the entries that were under Unreleased.
+		const unreleasedIdx = result.indexOf('## [Unreleased]');
+		const stampedIdx = result.indexOf('## [2026.07.0] - 2026-07-14');
+		expect(unreleasedIdx).toBeLessThan(stampedIdx);
+
+		const between = result.slice(unreleasedIdx + '## [Unreleased]'.length, stampedIdx);
+		expect(between.trim()).toBe('');
+	});
+
+	it('moves the Unreleased entries under the stamped version', () => {
+		const result = stampChangelog(changelog, '2026.07.0', '2026-07-14');
+		const stampedIdx = result.indexOf('## [2026.07.0] - 2026-07-14');
+		const nextIdx = result.indexOf('## [2026.06.0]');
+		const section = result.slice(stampedIdx, nextIdx);
+
+		expect(section).toContain('- Dark mode toggle in Settings.');
+		expect(section).toContain('- Admin delete-user no longer preselects the wrong user.');
+	});
+
+	it('leaves already-released sections intact', () => {
+		const result = stampChangelog(changelog, '2026.07.0', '2026-07-14');
+		expect(result).toContain('## [2026.06.0] - 2026-06-01');
+		expect(result).toContain('- Initial account archiving.');
+	});
+
+	it('stamps a first release when Unreleased is the only section', () => {
+		const firstChangelog = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Everything, for the first time.
+`;
+		const result = stampChangelog(firstChangelog, '2026.07.0', '2026-07-14');
+		expect(result).toContain('## [Unreleased]');
+		expect(result).toContain('## [2026.07.0] - 2026-07-14');
+		expect(result).toContain('- Everything, for the first time.');
+		expect(result.endsWith('\n')).toBe(true);
+	});
+
+	it('refuses to stamp when there is nothing to release', () => {
+		const empty = `# Changelog
+
+## [Unreleased]
+
+## [2026.06.0] - 2026-06-01
+
+### Added
+
+- Something old.
+`;
+		expect(() => stampChangelog(empty, '2026.07.0', '2026-07-14')).toThrow(/nothing to release/i);
+	});
+
+	it('throws when there is no Unreleased section', () => {
+		const noUnreleased = `# Changelog
+
+## [2026.06.0] - 2026-06-01
+
+- Something.
+`;
+		expect(() => stampChangelog(noUnreleased, '2026.07.0', '2026-07-14')).toThrow(/unreleased/i);
+	});
+});
+
+describe('computeRelease', () => {
+	it('returns the next version and the rewritten changelog together', () => {
+		const changelog = `# Changelog
+
+## [Unreleased]
+
+### Added
+
+- A user-visible thing.
+`;
+		const result = computeRelease({
+			changelog,
+			tags: ['2026.07.0'],
+			today: '2026-07-14'
+		});
+
+		expect(result.version).toBe('2026.07.1');
+		expect(result.changelog).toContain('## [2026.07.1] - 2026-07-14');
+		expect(result.changelog).toContain('- A user-visible thing.');
+		expect(result.changelog.indexOf('## [Unreleased]')).toBeLessThan(
+			result.changelog.indexOf('## [2026.07.1]')
+		);
+	});
+});

--- a/src/lib/version/calver.ts
+++ b/src/lib/version/calver.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure CalVer release math and Keep-a-Changelog stamping (ADR-0012).
+ *
+ * The version scheme is `YYYY.0M.MICRO`: four-digit year, zero-padded two-digit
+ * month, and a per-month micro counter that resets to 0 each month. Everything
+ * here is a pure function of its inputs — no git, no filesystem, no clock. The
+ * `today` date and the existing tags are supplied by the caller (the release
+ * script), so the fiddly parts stay unit-tested while the adapter stays thin.
+ */
+
+export type Release = {
+	/** The `CHANGELOG.md` contents after stamping. */
+	changelog: string;
+	/** The computed next CalVer version. */
+	version: string;
+};
+
+export type ReleaseInput = {
+	/** Current `CHANGELOG.md` contents. */
+	changelog: string;
+	/** Existing git tags (any strings; non-CalVer entries are ignored). */
+	tags: string[];
+	/** Release date as an ISO `YYYY-MM-DD` string. */
+	today: string;
+};
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Computes the next CalVer version from the existing tags and today's date. The
+ * micro counter is scoped to the current `YYYY.0M`: only tags in this month
+ * count, so the counter derives from the calendar and not from the highest tag
+ * overall. First release of a month → `.0`.
+ */
+export function nextVersion(tags: string[], today: string): string {
+	const prefix = monthPrefix(today);
+	const micro = new RegExp(`^${prefix.replace(/\./g, '\\.')}\\.(\\d+)$`);
+
+	const highest = tags.reduce((max, tag) => {
+		const match = micro.exec(tag);
+		return match ? Math.max(max, Number(match[1])) : max;
+	}, -1);
+
+	return `${prefix}.${highest + 1}`;
+}
+
+/** Splits an ISO `YYYY-MM-DD` string into its `YYYY.0M` prefix, throwing if malformed. */
+function monthPrefix(today: string): string {
+	const match = ISO_DATE.exec(today);
+	if (!match) {
+		throw new Error(`Expected an ISO date (YYYY-MM-DD), got: ${today}`);
+	}
+	const [, year, month] = match;
+	return `${year}.${month}`;
+}
+
+const UNRELEASED = /^## \[Unreleased\]\s*$/i;
+const VERSION_HEADING = /^## \[/;
+const LIST_ITEM = /^\s*[-*]\s+\S/;
+
+/** Computes the next version and the rewritten changelog in one call. */
+export function computeRelease({ changelog, tags, today }: ReleaseInput): Release {
+	const version = nextVersion(tags, today);
+	return { changelog: stampChangelog(changelog, version, today), version };
+}
+
+/**
+ * Stamps the `[Unreleased]` section into a dated `[version] - YYYY-MM-DD`
+ * section and opens a fresh empty `[Unreleased]` above it. Released sections are
+ * left untouched. Throws when there is no `[Unreleased]` heading or when it
+ * carries no entries — an empty release is a mistake, not a no-op.
+ */
+export function stampChangelog(changelog: string, version: string, today: string): string {
+	const lines = changelog.split('\n');
+
+	const start = lines.findIndex((line) => UNRELEASED.test(line));
+	if (start === -1) {
+		throw new Error('CHANGELOG.md has no "## [Unreleased]" section to stamp.');
+	}
+
+	let end = lines.length;
+	for (let i = start + 1; i < lines.length; i++) {
+		if (VERSION_HEADING.test(lines[i])) {
+			end = i;
+			break;
+		}
+	}
+
+	const body = lines.slice(start + 1, end);
+	if (!body.some((line) => LIST_ITEM.test(line))) {
+		throw new Error('CHANGELOG.md [Unreleased] is empty — nothing to release.');
+	}
+
+	const head = lines.slice(0, start + 1).join('\n');
+	const stamped = `## [${version}] - ${today}\n\n${trimBlankEdges(body).join('\n')}`;
+	const rest = lines.slice(end).join('\n');
+
+	return (
+		[head, stamped, rest]
+			.filter((part) => part.trim() !== '')
+			.join('\n\n')
+			.replace(/\n{3,}/g, '\n\n')
+			.replace(/\s+$/, '') + '\n'
+	);
+}
+
+/** Drops leading and trailing blank lines while keeping interior structure. */
+function trimBlankEdges(lines: string[]): string[] {
+	let first = 0;
+	let last = lines.length - 1;
+	while (first <= last && lines[first].trim() === '') first++;
+	while (last >= first && lines[last].trim() === '') last--;
+	return lines.slice(first, last + 1);
+}

--- a/src/lib/version/index.ts
+++ b/src/lib/version/index.ts
@@ -1,0 +1,2 @@
+export { computeRelease, nextVersion, stampChangelog } from './calver';
+export type { Release, ReleaseInput } from './calver';

--- a/src/routes/(app)/navigation-mobile.svelte
+++ b/src/routes/(app)/navigation-mobile.svelte
@@ -7,6 +7,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Drawer from '$lib/components/ui/drawer';
 	import { Logo } from '$lib/components/ui/logo';
+	import { VersionLabel } from '$lib/components/ui/version-label';
 	import { m } from '$lib/paraglide/messages';
 	import { getAccounts } from '$lib/remote-functions/account.remote';
 	import { signout } from '$lib/remote-functions/auth.remote';
@@ -62,10 +63,11 @@
 
 	<Drawer.Content class="@container/drawer-content">
 		<Drawer.Header>
-			<Drawer.Title class="mx-auto">
+			<Drawer.Title class="mx-auto flex items-end gap-2">
 				<a href={resolve('/')} class="w-fit">
 					<Logo class="h-10" />
 				</a>
+				<VersionLabel class="pb-1" />
 			</Drawer.Title>
 			<Drawer.Close
 				aria-label={m.dialog_close()}

--- a/src/routes/(app)/navigation.svelte
+++ b/src/routes/(app)/navigation.svelte
@@ -6,6 +6,7 @@
 	import { page } from '$app/state';
 	import { SideMenu } from '$lib/components/features/side-menu';
 	import { Logo } from '$lib/components/ui/logo';
+	import { VersionLabel } from '$lib/components/ui/version-label';
 	import { m } from '$lib/paraglide/messages';
 	import { signout } from '$lib/remote-functions/auth.remote';
 	import { getUser } from '$lib/remote-functions/user.remote';
@@ -60,9 +61,12 @@
 {/snippet}
 
 <nav class="sticky top-8 hidden w-full max-w-72 flex-col self-start p-4 @7xl/main:flex">
-	<a href={resolve('/')} class="w-fit">
-		<Logo class="h-12" />
-	</a>
+	<div class="flex items-end gap-2">
+		<a href={resolve('/')} class="w-fit">
+			<Logo class="h-12" />
+		</a>
+		<VersionLabel class="pb-1" />
+	</div>
 
 	{@render invitations?.()}
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,14 @@
 import adapter from '@sveltejs/adapter-node';
+import { readFileSync } from 'node:fs';
 import { relative, sep } from 'node:path';
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+
+// Version surfaced to the app via `$app/environment`. Prod (version-tag) builds
+// leave BUILD_SHA unset and show the clean CalVer; stage (main-push) builds pass
+// the short SHA and show a dev-flavoured `<version>-dev+<sha>` (ADR-0012).
+const buildSha = process.env.BUILD_SHA;
+const versionName = buildSha ? `${version}-dev+${buildSha}` : version;
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -27,6 +36,10 @@ const config = {
 
 		experimental: {
 			remoteFunctions: true
+		},
+
+		version: {
+			name: versionName
 		}
 	}
 };


### PR DESCRIPTION
Closes #125.

Ceremony-free versioning plus a stage-deploy lane, per the decision in #99. Hard pre-flip gate for going public (#116).

## What's here

- **`src/lib/version/`** — pure, unit-tested CalVer + Keep-a-Changelog module (`nextVersion`, `stampChangelog`, `computeRelease`). No git/fs/clock inside; date and tags are inputs. `calver.test.ts` covers first release, micro increment/reset, current-month derivation, zero-padding, changelog stamping, and empty-`[Unreleased]` rejection.
- **`npm run release`** — thin adapter (`scripts/release.ts`) run via Node type-stripping so it shares the exact tested module. Computes next CalVer, stamps `CHANGELOG.md`, bumps `package.json`, commits, tags. Guards a dirty tree and an empty release.
- **`.github/workflows/publish.yml`** — paths-filter gated. `main` push → ghcr `:stage` + `:sha-<short>`; version tag → `:<version>` + `:latest`. `ci.yml` untouched, GHCR auth via built-in `GITHUB_TOKEN`, no test rerun.
- **Version label** — muted `VersionLabel` beside the logo (desktop + mobile). `kit.version.name` reads `package.json` and appends `-dev+<sha>` when `BUILD_SHA` is set; the `Dockerfile` passes `BUILD_SHA` only for stage builds → `<version>-dev+<sha>` on stage, clean CalVer on prod.
- **Docs** — `CHANGELOG.md`, ADR-0012, CLAUDE.md changelog ground-rule, README deploy section (GHCR image table, one-time Pi `docker login`, stage/prod compose stacks).

## Note on ADR numbering

The issue named "ADR 0010", but 0010 (dark mode) and 0011 (account deletion) were already taken — this uses **ADR-0012** and records the renumbering in the ADR itself.

## Verification

`npm run check` (0 errors), `npm run lint` (clean), full unit suite (552 passed + 1 expected-fail, 15 new), and `DATABASE_URL=:memory: npm run build`. The publish workflow, Dockerfile, image-tag scheme, and Pi pull are proven by a real stage deploy rather than automated tests (per #99's testing decisions).