### PR TITLE
ci(publish): build multi-arch images (amd64 + arm64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,10 @@ jobs:
       - id: sha
         run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
+      # QEMU emulates arm64 on the amd64 runner so the image runs natively on
+      # ARM self-host targets (better-sqlite3 compiles from source per arch).
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -86,6 +90,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only stage (branch) builds carry the SHA; prod (tag) builds stay clean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and dependency bumps get no entry.
 
 ## [Unreleased]
 
+### Added
+
+- Multi-architecture container images (`linux/amd64` and `linux/arm64`), so the
+  published images run natively on ARM64 hosts.
+
 ## [2026.07.0] - 2026-07-14
 
 ### Added


### PR DESCRIPTION
Follow-up to #141.

The publish workflow built without a `platforms:` list, so it emitted only `linux/amd64` (the runner's architecture). ARM self-host targets can't pull the resulting `:latest` / `:stage` — `docker pull` fails with `no matching manifest for linux/arm64`. Previously the image was built on the ARM host itself, so this never surfaced; pulling a prebuilt GHCR image does.

## Fix

- Add `docker/setup-qemu-action@v3` so the amd64 runner can emulate arm64.
- Build `platforms: linux/amd64,linux/arm64` so `:stage` and `:latest` run natively on ARM.

`better-sqlite3` compiles from source per architecture using the build tools already present in the `Dockerfile` (`python3 make g++`), so no Dockerfile change is needed. The arm64 leg builds under emulation and is slower, but correct.

No changelog entry — CI-only change per the repo ground rule.

## Note

This covers `arm64` (64-bit Pi OS). A 32-bit OS would need `linux/arm/v7` added to the platforms list; left out since the target is arm64.