### PR TITLE
ci(publish): build arm64 natively instead of under QEMU

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ name: Publish
 #
 #   push to main        → ghcr.io/lj-n/genug-da:stage + :sha-<short>
 #   push a version tag  → ghcr.io/lj-n/genug-da:<version> + :latest
+#                          + a GitHub Release whose notes are the CHANGELOG section
 on:
   push:
     branches: [main]
@@ -160,3 +161,41 @@ jobs:
 
       - name: Inspect image
         run: docker buildx imagetools inspect "${{ env.IMAGE }}:${{ steps.meta.outputs.version }}"
+
+  # On version tags, publish a GitHub Release using this version's CHANGELOG
+  # section as the body, so the release notes mirror the changelog verbatim.
+  release:
+    needs: [merge]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog section
+        run: |
+          # Print the lines between this version's '## [x.y.z]' heading and the
+          # next '## ' heading (sub-headings like '### Added' are kept).
+          awk -v ver="$TAG" '
+            index($0, "## [" ver "]") == 1 { grab = 1; next }
+            grab && /^## / { exit }
+            grab { print }
+          ' CHANGELOG.md > notes.md
+          if [ ! -s notes.md ]; then
+            echo "No CHANGELOG section found for $TAG" >&2
+            exit 1
+          fi
+        env:
+          TAG: ${{ github.ref_name }}
+
+      - name: Publish GitHub Release
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file notes.md
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file notes.md --verify-tag
+          fi
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,19 +54,82 @@ jobs:
             echo "Docs-only push to main — skipping image build."
           fi
 
-  publish:
+  # Each platform builds natively on its own runner — no QEMU. arm64 uses the
+  # ubuntu-24.04-arm standard runner (counts against included Actions minutes),
+  # so better-sqlite3 compiles per arch at native speed instead of emulated.
+  # Each job pushes an untagged, digest-only image; the merge job stitches them
+  # into a single multi-arch tag.
+  build:
     needs: [gate]
     if: needs.gate.outputs.publish == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
       - id: sha
         run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
 
-      # QEMU emulates arm64 on the amd64 runner so the image runs natively on
-      # ARM self-host targets (better-sqlite3 compiles from source per arch).
-      - uses: docker/setup-qemu-action@v3
+      - id: prep
+        run: echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Labels only here; tags are applied once on the merged manifest below.
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+
+      - uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Only stage (branch) builds carry the SHA; prod (tag) builds stay clean.
+          build-args: |
+            BUILD_SHA=${{ github.ref_type == 'branch' && steps.sha.outputs.short || '' }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Stitches the per-arch digests into one multi-arch tag list and pushes it.
+  merge:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -86,13 +149,14 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ github.ref_type == 'tag' }}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Only stage (branch) builds carry the SHA; prod (tag) builds stay clean.
-          build-args: |
-            BUILD_SHA=${{ github.ref_type == 'branch' && steps.sha.outputs.short || '' }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Word-splitting on the two $(...) is intentional: one expands to the
+          # -t tag flags, the other to the per-arch digest references.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${{ env.IMAGE }}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
## Problem

The multi-arch publish added in #142 builds both platforms on a single amd64 runner, emulating arm64 via QEMU. Because `better-sqlite3` compiles from source per arch, the emulated arm64 layer dominates: the `2026.07.1` tag publish ran **36+ minutes** and was still going when cancelled; the `main` runs finished only after 11–23 min. Functionally it publishes, but it's too slow to be usable as a release path.

## Fix

Build each platform natively, no emulation:

- Split the `publish` job into a per-platform `build` matrix — `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64). arm64 standard runners are available on private repos and count against the plan's included Actions minutes, so this stays free on the current plan.
- Each job pushes a **tag-less, digest-only** image (`push-by-digest=true`).
- A `merge` job stitches the per-arch digests into one multi-arch tag list via `docker buildx imagetools create`, preserving the existing tag logic (`stage` + `sha-<short>` on branch, `<version>` + `latest` on tag) and the `BUILD_SHA` build-arg.

## GitHub Release notes

Previously nothing created a GitHub Release, so the changelog never surfaced anywhere but `CHANGELOG.md`. Added a `release` job (tag pushes only, `contents: write` scoped to that job) that extracts the matching `CHANGELOG.md` section and publishes it as the GitHub Release body. Idempotent across re-runs.

The `gate` job and its docs-only skip are unchanged.

## Verification

- `actionlint` clean, YAML validates.
- Changelog-extraction `awk` tested locally against the current `CHANGELOG.md`.
- The workflow only triggers on `main`/tags, so the native build + release job can't run from this branch — they need to be exercised on the next push to `main` / next tag after merge.

Expectation: ~2–3 min per arch built natively, versus the 30+ min QEMU path.