### PR TITLE
docs(changelog): note automated GitHub Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and dependency bumps get no entry.
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Releases are now published automatically on each version tag, with the
+  matching changelog section as the release notes.
+
 ## [2026.07.1] - 2026-07-14
 
 ### Added


### PR DESCRIPTION
Adds an `## [Unreleased]` entry recording that GitHub Releases are now published automatically on each version tag (via the `release` job merged in #143). This also gives `npm run release` something to stamp, so the next tag exercises that job end-to-end.