### PR TITLE
docs: add community-health files (CONTRIBUTING, SECURITY, issue/PR templates)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to genug-da
+
+Thanks for your interest in genug-da. The project is source-available and
+maintained by a single person, so contributions work a little differently
+than in larger projects.
+
+## Issues: welcome
+
+Bug reports and feature requests are welcome — please use the
+[issue templates](https://github.com/lj-n/genug-da/issues/new/choose).
+For suspected security vulnerabilities, do **not** open a public issue; see
+[SECURITY.md](SECURITY.md).
+
+## Pull requests: open an issue first
+
+Please don't send unsolicited pull requests. Open an issue describing the bug
+or change first and wait for a maintainer response. This keeps review effort
+bounded and avoids work on changes that won't be merged. PRs without a
+prior, agreed-upon issue may be closed without review.
+
+## Development setup
+
+See the [Development section of the README](../README.md#development) for
+setup and the test/lint commands. In short: Node.js 22+, `npm install`, and
+run everything with `DATABASE_URL=:memory:` — `npm run dev`, `npm run check`,
+`npm run lint`, `npm run test:unit`, `npm run test:e2e`.
+
+## Conduct
+
+Be respectful. This project has no formal code of conduct or enforcement
+process; disrespectful behaviour in issues or PRs simply gets moderated at
+the maintainer's discretion.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Something in genug-da doesn't work as expected.
+labels: ['bug', 'needs-triage']
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect to happen instead?
+      placeholder: When I ..., genug-da ... — I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Shown next to the logo in the app, e.g. `2026.07.2` or `2026.07.2-dev+a1b2c3d`.
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Docker Compose (release image)
+        - Docker Compose (stage image)
+        - Docker (standalone)
+        - Manual (node build)
+        - Other / development
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Server logs around the time of the error, if available. Redact anything private.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/lj-n/genug-da/security/advisories/new
+    about: Please report security issues privately via GitHub's vulnerability reporting — never as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an improvement or new capability for genug-da.
+labels: ['enhancement', 'needs-triage']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the situation where genug-da currently falls short, rather than only the solution you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see, and how would it behave?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other ways this could be solved.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via
+[GitHub private vulnerability reporting](https://github.com/lj-n/genug-da/security/advisories/new)
+("Report a vulnerability" on the repository's Security tab).
+
+Do **not** open a public issue for security problems — public issues are
+visible immediately, before a fix exists.
+
+This is a solo-maintained project: reports are handled on a best-effort
+basis. You should normally hear back within a week.
+
+## Supported versions
+
+Only the latest release (and the container image tags derived from it,
+`latest` / the newest CalVer tag) receives security fixes. There are no
+backports to older versions — update by pulling the newest release.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+Please open an issue and get a maintainer response BEFORE sending a PR —
+see .github/CONTRIBUTING.md. PRs without a prior, agreed-upon issue may be
+closed without review.
+-->
+
+## Linked issue
+
+Closes #
+
+## What changed
+
+<!-- Short description of the change and why. -->
+
+## Checklist
+
+- [ ] A maintainer agreed to this change in the linked issue
+- [ ] `npm run lint` and `npm run check` pass
+- [ ] `DATABASE_URL=:memory: npm run test:unit` passes
+- [ ] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]`


### PR DESCRIPTION
Implements the posture decided in #106: issues welcome, PRs gated behind a prior issue, vulnerability reports via GitHub private advisories, no Code of Conduct. All files live under `.github/`.

- `CONTRIBUTING.md` — open-an-issue-first posture, pointer to the README dev setup, one-line conduct note
- `SECURITY.md` — GitHub Private Vulnerability Reporting as the channel, latest release only
- `ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml` — structured forms, labelled `needs-triage`
- `ISSUE_TEMPLATE/config.yml` — blank issues disabled, security reports routed to the private advisory form
- `pull_request_template.md` — linked, pre-discussed issue required

Note from the issue: enabling Private Vulnerability Reporting is a repo setting, tracked in the repo-settings issue — `SECURITY.md` is inert until then.

Closes #118