### PR TITLE
ci: add Renovate config — grouped weekly updates, auto-merge non-majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended", "group:allNonMajor", "schedule:weekly"],
+	"timezone": "Europe/Berlin",
+	"lockFileMaintenance": {
+		"enabled": true
+	},
+	"packageRules": [
+		{
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		}
+	]
+}


### PR DESCRIPTION
Pre-flip tasks of #119, implementing the policy decided in #107.

## Changes

- `renovate.json` extending `config:recommended` + `group:allNonMajor` + `schedule:weekly` (Monday morning, Europe/Berlin)
- `lockFileMaintenance` enabled to keep `package-lock.json` fresh
- Package rule auto-merging patch+minor via platform auto-merge (Renovate default), gated on required CI checks; majors fall through to separate, manual PRs
- GitHub Actions bumps covered by the `github-actions` manager, enabled by default in `config:recommended`

## Verification

- Renovate's official `renovate-config-validator`: passed
- `npm run lint`: passed
- Unit suite: 561 passed, 1 expected fail (clean baseline)

## Out of scope (post-flip, manual)

- Install the Mend Renovate GitHub app (at/after going public)
- Enable auto-merge only once required checks on `main` are confirmed (branch protection must require the unit gate + `🎉 E2E Tests Passed`)

Part of #119 — the issue stays open for the post-flip steps.