### PR TITLE
ci: route runners via CI_RUNNER/CI_RUNNER_ARM repo variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Runner routing: the CI_RUNNER repo variable overrides the runner label for
+# all jobs (e.g. ubicloud-standard-2). Unset it to fall back to GitHub-hosted.
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -30,7 +33,7 @@ jobs:
           DATABASE_URL: ':memory:'
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,7 +45,7 @@ jobs:
       - run: npm run check
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -54,7 +57,7 @@ jobs:
       - run: npm run lint
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -70,7 +73,7 @@ jobs:
   # Decide whether the (expensive) e2e suite should run for this PR.
   # Skips drafts and changes that touch only docs/markdown.
   gate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       run_e2e: ${{ steps.decide.outputs.run_e2e }}
     steps:
@@ -98,7 +101,7 @@ jobs:
   e2e-test:
     needs: [gate]
     if: needs.gate.outputs.run_e2e == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 8
     strategy:
       fail-fast: false
@@ -135,7 +138,7 @@ jobs:
     name: 🎉 E2E Tests Passed
     needs: [gate, e2e-test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - run: |
           if [ "${{ needs.gate.result }}" != "success" ]; then
@@ -156,7 +159,7 @@ jobs:
   e2e-merge:
     needs: [gate, e2e-test]
     if: always() && needs.gate.outputs.run_e2e == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
   # Tag pushes always publish. main pushes skip when only docs/markdown changed,
   # reusing ci.yml's paths-filter philosophy.
   gate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       publish: ${{ steps.decide.outputs.publish }}
     steps:
@@ -55,9 +55,10 @@ jobs:
             echo "Docs-only push to main — skipping image build."
           fi
 
-  # Each platform builds natively on its own runner — no QEMU. arm64 uses the
-  # ubuntu-24.04-arm standard runner (counts against included Actions minutes),
-  # so better-sqlite3 compiles per arch at native speed instead of emulated.
+  # Each platform builds natively on its own runner — no QEMU — so
+  # better-sqlite3 compiles per arch at native speed instead of emulated.
+  # The CI_RUNNER / CI_RUNNER_ARM repo variables override the labels (see
+  # ci.yml); unset they fall back to the GitHub-hosted standard runners.
   # Each job pushes an untagged, digest-only image; the merge job stitches them
   # into a single multi-arch tag.
   build:
@@ -69,9 +70,9 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+            runner: ${{ vars.CI_RUNNER_ARM || 'ubuntu-24.04-arm' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -124,7 +125,7 @@ jobs:
   # Stitches the per-arch digests into one multi-arch tag list and pushes it.
   merge:
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -167,7 +168,7 @@ jobs:
   release:
     needs: [merge]
     if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Makes the runner label for every job in `ci.yml` and `publish.yml` configurable via repo variables, so CI can be switched between GitHub-hosted and third-party runners (Ubicloud) without workflow changes:

- `runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}` on all x64 jobs
- `${{ vars.CI_RUNNER_ARM || 'ubuntu-24.04-arm' }}` for the arm64 image build in `publish.yml`

Unset variables fall back to the previous GitHub-hosted labels, so merging this alone changes nothing. To route to Ubicloud:

```sh
gh variable set CI_RUNNER --body ubicloud-standard-2
gh variable set CI_RUNNER_ARM --body ubicloud-standard-2-arm
```

Context: GitHub-hosted minutes for the month are exhausted; Ubicloud's free tier (~1,250 min/month) covers this repo. Once the repo is public, deleting both variables reverts to (then free) GitHub-hosted runners.