### PR TITLE
fix: declare single-flight updates at every requested()-backed submit site (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and dependency bumps get no entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- Deleting a category from the detail view on a narrow (phone) viewport now
+  removes the row from the budget table immediately; previously the deleted
+  category could linger until a page reload. The same fix hardens account
+  deletion, category creation, and transaction delete/validate against stale
+  lists after submit.
+
 ### Added
 
 - Money can now be moved between two accounts of the same budget as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@ and dependency bumps get no entry.
 
 ### Fixed
 
-- Deleting a category from the detail view on a narrow (phone) viewport now
-  removes the row from the budget table immediately; previously the deleted
-  category could linger until a page reload. The same fix hardens account
-  deletion, category creation, and transaction delete/validate against stale
-  lists after submit.
+- Deleting a category or account from the detail view on a narrow (phone)
+  viewport now removes the row from the budget table immediately; previously
+  the deleted entry could linger until a page reload.
 
 ### Added
 

--- a/docs/adr/0013-modals-cap-to-the-viewport-and-scroll-behind-a-body-seam.md
+++ b/docs/adr/0013-modals-cap-to-the-viewport-and-scroll-behind-a-body-seam.md
@@ -81,3 +81,11 @@ scrollable, which is what made it overflow-proof.
   still drops query refreshes for forms confirmed through a nested alert dialog.
   Revisiting the touch-drawer switch depends on resolving that vaul × remote-form
   interaction.
+- **Resolved (#147):** the dropped refresh was not a vaul × bits-ui layer
+  problem. The delete form never chained `.updates(...)`, so the server's
+  `requested(...).refreshAll()` was a silent no-op and the client fell back to
+  `invalidateAll()` — which re-fetched the deleted category's own detail
+  queries (404) and raced the drawer teardown, discarding the table update.
+  With `.updates(...)` declared at the submit site the refresh arrives in the
+  form response itself and the drawer path is reliable; the touch-drawer
+  switch is no longer blocked by this defect.

--- a/docs/remote-functions.md
+++ b/docs/remote-functions.md
@@ -61,6 +61,12 @@ The canonical rule is **one pattern, awaited at component top level**
 ### Mutations and cache refresh
 
 - Default: single-flight refresh via `await form.submit().updates(query, ...)`.
+- **Every submit site of a form whose server function calls `requested(...)`
+  must chain `.updates(...)` declaring (at least) the same query functions.**
+  `requested()` only sees instances the client declared; without `.updates()`
+  it is a silent no-op and the client falls back to `invalidateAll()`, which
+  refreshes every cached query — including ones whose entity the mutation just
+  deleted (404s) — and can drop the visible update entirely (#147).
 - Optimistic updates (`.updates(query.withOverride(...))`) are opt-in for
   hot paths only: rapid repeated interactions where the round-trip is felt
   (assigning money to categories, toggling transaction validation). Anything

--- a/src/lib/components/features/account/account-delete.svelte
+++ b/src/lib/components/features/account/account-delete.svelte
@@ -6,7 +6,8 @@
 	import {
 		deleteAccount,
 		getAccount,
-		getAccountDeletability
+		getAccountDeletability,
+		getAccounts
 	} from '$lib/remote-functions/account.remote';
 	import TrashIcon from '~icons/ph/trash';
 
@@ -43,7 +44,7 @@
 		</div>
 	{/if}
 
-	<AlertDialogForm form={deleteAccount} onSuccess={() => onDeleted()}>
+	<AlertDialogForm form={deleteAccount} onSuccess={() => onDeleted()} updates={() => [getAccounts]}>
 		{#snippet trigger(props)}
 			<Button
 				{...props}

--- a/src/lib/components/features/category/category-create.svelte
+++ b/src/lib/components/features/category/category-create.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
 	import { getMonthly } from '$lib/remote-functions/budget.remote';
-	import { createCategory } from '$lib/remote-functions/category.remote';
+	import { createCategory, getCategories } from '$lib/remote-functions/category.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 
 	import { Button } from '../../ui/button';
@@ -16,7 +16,7 @@
 
 <FormBody
 	{...createCategory.enhance(async (form) => {
-		if (await form.submit().updates(getMonthly)) {
+		if (await form.submit().updates(getCategories, getMonthly)) {
 			form.element.reset();
 			onSuccess?.();
 		}

--- a/src/lib/components/features/category/category-delete.svelte
+++ b/src/lib/components/features/category/category-delete.svelte
@@ -3,8 +3,10 @@
 	import { AlertDialogForm } from '$lib/components/ui/alert-dialog-form';
 	import { Button } from '$lib/components/ui/button';
 	import { m } from '$lib/paraglide/messages';
+	import { getMonthly } from '$lib/remote-functions/budget.remote';
 	import {
 		deleteCategory,
+		getCategories,
 		getCategoryById,
 		getCategoryDeletability
 	} from '$lib/remote-functions/category.remote';
@@ -70,7 +72,11 @@
 		</div>
 	{/if}
 
-	<AlertDialogForm form={deleteCategory} onSuccess={() => onDeleted()}>
+	<AlertDialogForm
+		form={deleteCategory}
+		onSuccess={() => onDeleted()}
+		updates={() => [getCategories, getMonthly]}
+	>
 		{#snippet trigger(props)}
 			<Button
 				{...props}

--- a/src/lib/components/features/transaction/transaction-edit-modal.svelte
+++ b/src/lib/components/features/transaction/transaction-edit-modal.svelte
@@ -64,7 +64,8 @@
 		onSuccess: () => {
 			open = false;
 		},
-		toast: {}
+		toast: {},
+		updates: () => [listTransactions]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -54,7 +54,10 @@
 
 	// No client-side update chain: the server refreshes the transaction list,
 	// and the refreshed list unmounts this row — that is the success signal.
-	const deleteSubmit = createFormSubmit(() => deleteForm, { toast: {} });
+	const deleteSubmit = createFormSubmit(() => deleteForm, {
+		toast: {},
+		updates: () => [listTransactions]
+	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);
 

--- a/src/lib/components/features/transaction/transaction-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-edit.svelte
@@ -52,8 +52,8 @@
 		updates: () => [listTransactions]
 	});
 
-	// No client-side update chain: the server refreshes the transaction list,
-	// and the refreshed list unmounts this row — that is the success signal.
+	// No onSuccess: the refreshed list unmounts this row — that is the
+	// success signal.
 	const deleteSubmit = createFormSubmit(() => deleteForm, {
 		toast: {},
 		updates: () => [listTransactions]

--- a/src/lib/components/features/transaction/transaction-validate-toggle.svelte
+++ b/src/lib/components/features/transaction/transaction-validate-toggle.svelte
@@ -3,7 +3,10 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { m } from '$lib/paraglide/messages';
-	import { batchValidateTransactions } from '$lib/remote-functions/transaction.remote';
+	import {
+		batchValidateTransactions,
+		listTransactions
+	} from '$lib/remote-functions/transaction.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import { cn } from 'tailwind-variants';
 	import SealIcon from '~icons/ph/seal';
@@ -26,7 +29,10 @@
 
 	// Row-scoped micro-form (ADR-0009): the seal icon flipping with the
 	// refreshed list is the success signal; thrown errors go to the toast.
-	const submit = createFormSubmit(() => form, { toast: {} });
+	const submit = createFormSubmit(() => form, {
+		toast: {},
+		updates: () => [listTransactions]
+	});
 </script>
 
 <!-- Centering via flex + auto margins (not grid place-content) so a caller's

--- a/src/lib/components/features/transaction/transfer-edit-modal.svelte
+++ b/src/lib/components/features/transaction/transfer-edit-modal.svelte
@@ -65,7 +65,8 @@
 		onSuccess: () => {
 			open = false;
 		},
-		toast: {}
+		toast: {},
+		updates: () => [listTransactions]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/components/features/transaction/transfer-table-row-edit.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-edit.svelte
@@ -56,7 +56,10 @@
 
 	// Deleting either leg removes the whole transfer server-side (ADR-0015); the
 	// refreshed list unmounts this row — that is the success signal.
-	const deleteSubmit = createFormSubmit(() => deleteForm, { toast: {} });
+	const deleteSubmit = createFormSubmit(() => deleteForm, {
+		toast: {},
+		updates: () => [listTransactions]
+	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);
 

--- a/src/routes/(app)/[budgetId=id]/categories/new/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/new/+page.svelte
@@ -7,7 +7,8 @@
 	import { Input } from '$lib/components/ui/input';
 	import * as Page from '$lib/components/ui/page';
 	import { m } from '$lib/paraglide/messages';
-	import { createCategory } from '$lib/remote-functions/category.remote';
+	import { getMonthly } from '$lib/remote-functions/budget.remote';
+	import { createCategory, getCategories } from '$lib/remote-functions/category.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import PhStack from '~icons/ph/stack';
 
@@ -19,7 +20,8 @@
 		onSuccess: () => {
 			goto(resolve('/(app)/[budgetId=id]', { budgetId }));
 		},
-		toast: {}
+		toast: {},
+		updates: () => [getCategories, getMonthly]
 	});
 </script>
 

--- a/tests/playwright/category-responsive.spec.ts
+++ b/tests/playwright/category-responsive.spec.ts
@@ -53,6 +53,28 @@ test('Category detail reopens for the same category after closing', async ({ pag
 	await expect(page.locator('[data-slot="dialog-content"]')).toBeVisible();
 });
 
+test('Deleting a category from the drawer refreshes the budget table', async ({ page, pages }) => {
+	const categoryName = await seedCategory(pages);
+
+	await page.setViewportSize({ height: 720, width: 390 });
+	await pages.category.openDetail(categoryName);
+
+	const drawer = page.locator('[data-slot="drawer-content"]');
+	await expect(drawer).toBeVisible();
+
+	// Delete through the nested alert-dialog confirm (#147: this path used to
+	// drop the post-submit query refresh, leaving a stale row until reload).
+	await drawer.getByRole('button', { exact: true, name: 'Delete' }).click();
+	const confirm = page.getByRole('alertdialog');
+	await expect(
+		confirm.getByRole('heading', { name: 'Delete category permanently?' })
+	).toBeVisible();
+	await confirm.getByRole('button', { exact: true, name: 'Delete' }).click();
+
+	await expect(drawer).not.toBeVisible();
+	await expect(page.getByRole('row').filter({ hasText: categoryName })).not.toBeVisible();
+});
+
 test('Category detail opens as a bottom drawer on narrow viewports', async ({ page, pages }) => {
 	const categoryName = await seedCategory(pages);
 


### PR DESCRIPTION
## Problem

Deleting a category from the detail drawer (narrow viewports) left a stale row in the budget table until reload (#147). The failure was flaky but frequent (~4 of 6 stress runs red on `main`).

## Root cause

Not a vaul × bits-ui layering problem. Verified with network traces:

1. `deleteCategory` refreshes queries server-side via `requested(...).refreshAll()`, but `requested()` only iterates instances the **client declares** by chaining `.updates(...)` onto the submission. `category-delete.svelte` never did — the server refresh was a **silent no-op** (the form response carried no refresh payload, on desktop too).
2. The client then falls back to `invalidateAll()`, which re-fetches every cached query — including the just-deleted category's own detail queries, which 404.
3. Those rejections race the drawer teardown and discard the pending table update. The desktop dialog only passed by luck (near-empty query cache at that moment).

## Fix

Declare `.updates(...)` at every submit site whose server function uses `requested()` — the form response then carries the fresh query data itself and the `invalidateAll` fallback (and its 404 storm) never runs.

An audit found the same latent defect at seven more sites, all wired here:

- category delete (the #147 repro)
- account delete (the issue predicted this one)
- category create — both surfaces; the quick-action form also silently omitted `getCategories` (declared `updates`, but a partial list suppresses the fallback too)
- transaction/transfer delete (4 sites)
- transaction validate toggle

Also:

- Drawer-mode delete regression test (was ~4/6 red on `main`, 30/30 green under stress after the fix)
- Rule documented in `docs/remote-functions.md`
- ADR-0013 follow-up marked resolved — the bottom-drawer-on-iPad switch is no longer blocked by this defect
- CHANGELOG entry

## Verification

- `npm run check`, lint: clean
- Unit tests: 592 passed
- Playwright: full suite 88/88 on both projects; new regression test stress-run 15× per project

Fixes #147