### PR TITLE
fix: toggle create rows from their trigger buttons instead of flickering (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- The New Transaction and Transfer buttons now toggle their inline create row:
+  clicking the button again cleanly closes the open row instead of making it
+  flicker, and clicking the other button switches directly to the other row.
+
 - Deleting a category or account from the detail view on a narrow (phone)
   viewport now removes the row from the budget table immediately; previously
   the deleted entry could linger until a page reload.

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -23,12 +23,19 @@
 		accountId,
 		budgetId,
 		class: className,
+		interactOutsideIgnore = null,
 		open = $bindable(false),
 		urlParams
 	}: {
 		accountId: string;
 		budgetId: string;
 		class?: string;
+		/**
+		 * Outside interactions inside this element do not dismiss the row. The
+		 * table passes its trigger button group so the buttons can implement
+		 * toggle/switch semantics without the dismiss layer racing them.
+		 */
+		interactOutsideIgnore?: HTMLElement | null;
 		open?: boolean;
 		urlParams: TransactionsURLParams;
 	} = $props();
@@ -84,7 +91,11 @@
 		}
 	}}
 >
-	<Popover.ContentStatic>
+	<Popover.ContentStatic
+		onInteractOutside={(e) => {
+			if (interactOutsideIgnore?.contains(e.target as Node)) e.preventDefault();
+		}}
+	>
 		<form
 			class={cn(
 				className,

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -49,6 +49,12 @@
 	} = $props();
 
 	let openCreateRow = $state(false);
+	// The inline-row triggers are plain buttons, not popover triggers (the rows
+	// own their Popover.Root). Without this exclusion the dismiss layer treats a
+	// click on them as an outside interaction and closes the row on pointerdown,
+	// which the click handler then immediately reopens (#174). The rows ignore
+	// interactions inside this group; the buttons implement toggle/switch.
+	let createTriggerGroup = $state<HTMLDivElement | null>(null);
 	let createModalOpen = $state(false);
 	let editModalOpen = $state(false);
 	let editModalTransaction = $state<ListTransaction | null>(null);
@@ -68,15 +74,25 @@
 	>
 		<!-- One create group per affordance (ADR-0014): the inline popover rows at
 		     @3xl and up, the bottom sheets below. Only one group is ever visible. -->
-		<ButtonGroup.Root class="ml-auto hidden @3xl/main:flex">
-			<Button onclick={() => (openCreateRow = true)}>
+		<ButtonGroup.Root class="ml-auto hidden @3xl/main:flex" bind:ref={createTriggerGroup}>
+			<Button
+				aria-expanded={openCreateRow}
+				onclick={() => {
+					openTransferCreateRow = false;
+					openCreateRow = !openCreateRow;
+				}}
+			>
 				<PlusBoldIcon />
 				{m.transactions_table_create_transaction()}
 			</Button>
 			<Button
 				size="icon"
 				aria-label={m.transactions_table_create_transfer()}
-				onclick={() => (openTransferCreateRow = true)}
+				aria-expanded={openTransferCreateRow}
+				onclick={() => {
+					openCreateRow = false;
+					openTransferCreateRow = !openTransferCreateRow;
+				}}
 			>
 				<ArrowsLeftRightIcon />
 			</Button>
@@ -112,6 +128,7 @@
 					{accountId}
 					{budgetId}
 					class={colsClass}
+					interactOutsideIgnore={createTriggerGroup}
 					urlParams={tableState.params}
 				/>
 				<TransferTableRowCreate
@@ -119,6 +136,7 @@
 					{accountId}
 					{budgetId}
 					class={colsClass}
+					interactOutsideIgnore={createTriggerGroup}
 					urlParams={tableState.params}
 				/>
 			{/snippet}

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -22,12 +22,19 @@
 		accountId,
 		budgetId,
 		class: className,
+		interactOutsideIgnore = null,
 		open = $bindable(false),
 		urlParams
 	}: {
 		accountId: string;
 		budgetId: string;
 		class?: string;
+		/**
+		 * Outside interactions inside this element do not dismiss the row. The
+		 * table passes its trigger button group so the buttons can implement
+		 * toggle/switch semantics without the dismiss layer racing them.
+		 */
+		interactOutsideIgnore?: HTMLElement | null;
 		open?: boolean;
 		urlParams: TransactionsURLParams;
 	} = $props();
@@ -81,7 +88,11 @@
 		}
 	}}
 >
-	<Popover.ContentStatic>
+	<Popover.ContentStatic
+		onInteractOutside={(e) => {
+			if (interactOutsideIgnore?.contains(e.target as Node)) e.preventDefault();
+		}}
+	>
 		<form
 			class={cn(
 				className,

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -99,6 +99,74 @@ test('Toggle Validated', async ({ pages }) => {
 	await pages.account.toggleValidated();
 });
 
+test('Toggle and switch create rows from their trigger buttons', async ({ page, pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName);
+
+	await pages.account.goto(accountName);
+
+	const transactionButton = page.getByRole('button', { exact: true, name: 'New Transaction' });
+	const transferButton = page.getByRole('button', { exact: true, name: 'Transfer' });
+	const transactionRow = page.getByRole('row', { name: 'New Transaction' });
+	const transferRow = page.getByRole('row', { exact: true, name: 'Transfer' });
+
+	// A human-paced click: the popover's dismiss layer debounces outside
+	// pointerdowns by ~10ms, so a fast synthetic click can mask the
+	// close-on-pointerdown/reopen-on-click flicker this test guards against.
+	// Holding the button past the debounce window makes it observable.
+	const pacedClick = async (button: typeof transactionButton) => {
+		await button.hover();
+		await page.mouse.down();
+		await page.waitForTimeout(50);
+		await page.mouse.up();
+	};
+
+	// Second click on the trigger closes the row — no dismiss on pointerdown.
+	await pacedClick(transactionButton);
+	await expect(transactionRow).toBeVisible();
+	await transactionButton.hover();
+	await page.mouse.down();
+	await page.waitForTimeout(50);
+	await expect(transactionRow).toBeVisible();
+	await page.mouse.up();
+	await expect(transactionRow).toBeHidden();
+
+	// Same toggle for the transfer row.
+	await pacedClick(transferButton);
+	await expect(transferRow).toBeVisible();
+	await pacedClick(transferButton);
+	await expect(transferRow).toBeHidden();
+
+	// Clicking the other trigger while a row is open switches rows.
+	await pacedClick(transactionButton);
+	await expect(transactionRow).toBeVisible();
+	await pacedClick(transferButton);
+	await expect(transferRow).toBeVisible();
+	await expect(transactionRow).toBeHidden();
+	await pacedClick(transactionButton);
+	await expect(transactionRow).toBeVisible();
+	await expect(transferRow).toBeHidden();
+
+	// True outside clicks and Escape still dismiss the row.
+	await page.getByRole('heading', { name: accountName }).click();
+	await expect(transactionRow).toBeHidden();
+	await pacedClick(transactionButton);
+	await expect(transactionRow).toBeVisible();
+	await page.keyboard.press('Escape');
+	await expect(transactionRow).toBeHidden();
+
+	// Cancel still dismisses the row.
+	await pacedClick(transferButton);
+	await expect(transferRow).toBeVisible();
+	await transferRow.getByRole('button', { name: 'Cancel' }).click();
+	await expect(transferRow).toBeHidden();
+});
+
 test('Sort Transactions', async ({ page, pages }) => {
 	await pages.auth.createUserAndLogin();
 


### PR DESCRIPTION
Closes #174.

## Problem

With an inline create row open, clicking its trigger button again made the row flicker: the bits-ui dismiss layer closed the popover on pointerdown (the buttons are plain buttons, not popover triggers), then the button's click handler immediately reopened it. Same for the transfer button and row.

## Fix

- The desktop trigger `ButtonGroup` element is passed into both create-row components as `interactOutsideIgnore`; their `Popover.ContentStatic` prevents dismissal for outside interactions originating inside that group.
- The buttons implement explicit toggle/switch semantics: a second click closes the own row, clicking the other trigger closes the open row and opens the other one. They also carry `aria-expanded` now.
- Outside click, Cancel, and Escape dismiss as before.

## Tests

New Playwright test covering toggle (both rows), switch (both directions), and the outside-click/Escape/Cancel dismiss paths. It uses human-paced clicks (pointerdown, 50 ms hold, pointerup) because a fast synthetic click cannot cross the dismiss layer's ~10 ms debounce and would mask the flicker; the test was verified red against the unpatched code.

- `npm run check`, lint: clean
- transaction e2e spec: 14/14 on chromium and tablet
- unit suite: 592 passed (1 pre-existing expected fail)