### PR TITLE
fix: make the container default port a consistent 3000 (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and dependency bumps get no entry.
 - The Add-Account dialog now receives keyboard focus when it opens;
   previously focus stayed on the triggering button behind the overlay.
 
+- The container image now sets `PORT=3000` and exposes the same port. It
+  previously exposed 3002 while the server listened on 3000, so a plain
+  `docker run -p 3002:3002` served nothing without an explicit `PORT` env
+  var. The README and self-hosting docs now agree on 3000 and document how
+  to override the port and why `ORIGIN` is required.
+
+- The README's `DATABASE_URL` examples used a `file:` URI prefix that
+  better-sqlite3 does not support — copied verbatim, they crashed the
+  container with "unable to open database file". The examples now use plain
+  file paths.
+
 ## [2026.07.3] - 2026-07-17
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,13 @@ FROM node:22-alpine
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV PORT=3000
 
 COPY --from=builder /app/build build/
 COPY --from=builder /app/node_modules node_modules/
 COPY --from=builder /app/src/lib/server/db/migrations src/lib/server/db/migrations/
 COPY --from=builder /app/package.json ./
 
-EXPOSE 3002
+EXPOSE 3000
 
 CMD ["node", "build"]

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ better-sqlite3, valibot, @node-rs/argon2, Paraglide i18n, Vitest, Playwright.
 ### Environment Variables
 
 `DATABASE_URL` — path to the SQLite database file, e.g.
-`file:./data/genug-da.db`. Required.
+`./data/genug-da.db`. Required.
 
-`PORT` — port the server listens on (default: `3002`).
+`PORT` — port the server listens on (default: `3000`).
 
 `ORIGIN` — public URL of your instance, e.g. `https://budget.example.com`.
 Required for CSRF protection when running behind a reverse proxy.
@@ -102,7 +102,7 @@ services:
     image: ghcr.io/lj-n/genug-da:latest
     restart: unless-stopped
     ports:
-      - '3002:3002'
+      - '3000:3000'
     volumes:
       - ./data:/app/data:rw
     logging:
@@ -111,8 +111,7 @@ services:
         max-size: '10m'
         max-file: '5'
     environment:
-      PORT: 3002
-      DATABASE_URL: 'file:/app/data/genug.db'
+      DATABASE_URL: '/app/data/genug.db'
       ORIGIN: 'https://your.domain'
       NODE_ENV: 'production'
 ```
@@ -133,12 +132,11 @@ services:
     image: ghcr.io/lj-n/genug-da:stage
     restart: unless-stopped
     ports:
-      - '3003:3002'
+      - '3003:3000'
     volumes:
       - ./data-stage:/app/data:rw
     environment:
-      PORT: 3002
-      DATABASE_URL: 'file:/app/data/genug.db'
+      DATABASE_URL: '/app/data/genug.db'
       ORIGIN: 'https://stage.your.domain'
       NODE_ENV: 'production'
 ```
@@ -147,7 +145,7 @@ services:
 
 ```sh
 docker build -t genug-da .
-docker run -p 3002:3002 -v ./data:/app/data -e DATABASE_URL=file:./data/genug-da.db genug-da
+docker run -p 3000:3000 -v ./data:/app/data -e DATABASE_URL=/app/data/genug-da.db genug-da
 ```
 
 ### Manual

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -3,6 +3,35 @@
 Operational guidance for running your own genug-da instance. (This page is
 being built out — see issue #123 for env vars, backups, and deploy guidance.)
 
+## Port
+
+The server listens on port **3000** by default. The container image sets
+`ENV PORT=3000` and exposes the same port, so a plain port mapping works
+without extra configuration:
+
+```bash
+docker run -p 3000:3000 ...
+```
+
+To serve on a different host port, change only the host side of the mapping
+(`-p 8080:3000`). To make the server itself listen on a different port, set
+the `PORT` env var and map that port instead:
+
+```bash
+docker run -e PORT=8080 -p 8080:8080 ...
+```
+
+An explicitly set `PORT` always beats the image default.
+
+## ORIGIN
+
+Set `ORIGIN` to the public URL your users reach the instance at, e.g.
+`https://budget.example.com` (or `http://localhost:3000` for a local
+container). SvelteKit uses it for CSRF protection: it compares each form
+POST's `Origin` header against this value. Without it, logging in and every
+other form submission fail with a "Cross-site POST form submissions are
+forbidden" error (HTTP 403), even though GET pages render fine.
+
 ## Password recovery
 
 There is no forgot-password flow and none is needed: recovery runs from the


### PR DESCRIPTION
Closes #164.

## What

- **Dockerfile**: the final stage now sets `ENV PORT=3000` and `EXPOSE 3000`. Previously it exposed 3002 while adapter-node listened on its 3000 default, so a container started without an explicit `PORT` served nothing on the exposed port.
- **README**: env-var table states default 3000, the `docker run` example uses `-p 3000:3000`, both compose examples map to container port 3000 and drop the now-redundant `PORT` override.
- **docs/self-hosting.md**: new sections on the default port (and overriding it via `PORT` + port mapping) and on `ORIGIN` (CSRF purpose, 403 form-POST failure mode, example values).
- **CHANGELOG**: two `Fixed` entries.

## Also fixed: broken `DATABASE_URL` examples

Found while verifying the built image: every README `DATABASE_URL` example used a `file:` URI prefix, which better-sqlite3 does not support — the container crashed with "unable to open database file" regardless of the port. Since the acceptance criteria require the README `docker run` command to work verbatim, the examples now use plain paths. `createDatabase` is untouched; if the server should accept `file:` URLs instead, that deserves its own issue.

## Verification

Built the image and ran the README standalone command verbatim from a clean directory (no `PORT` env var): app serves on `http://localhost:3000` (307 → `/login`) and the SQLite file is created in the mounted `./data`. Confirmed inside the image that `file:` URIs fail while plain paths work. Prettier passes on the changed files; the diff contains no app code.