### PR TITLE
Docs: README front door, self-hosting ops guide, and usage manual (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # genug-da
 
+[![CI](https://github.com/lj-n/genug-da/actions/workflows/ci.yml/badge.svg)](https://github.com/lj-n/genug-da/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/tag/lj-n/genug-da?label=release)](CHANGELOG.md)
+[![License: AGPL-3.0-only](https://img.shields.io/badge/license-AGPL--3.0--only-blue)](LICENSE)
+
 A self-hosted [envelope budgeting](https://en.wikipedia.org/wiki/Envelope_system) app.
 
 ## What is genug-da?
@@ -28,7 +32,7 @@ each marked pending or validated.](docs/screenshots/transactions.png)
 - **Budget Plans** — Separate budgets for personal, business, etc. Each with
   its own accounts, categories, and transactions.
 - **Accounts** — Map your bank accounts and credit cards. Track validated vs.
-  pending balances.
+  pending balances. Transfer between accounts.
 - **Categories** — Organize spending areas. Archive unused ones. Set target
   balances.
 - **Transactions** — Inline editing of category, date, notes, amount. Toggle
@@ -51,116 +55,37 @@ SvelteKit, Svelte 5, and Drizzle ORM.
 Svelte 5 (runes), SvelteKit 2, Tailwind CSS 4, bits-ui, Drizzle ORM,
 better-sqlite3, valibot, @node-rs/argon2, Paraglide i18n, Vitest, Playwright.
 
-## Getting Started
+## Deploy
 
-### Prerequisites
-
-- Node.js 22+
-- Build tools for native addons (better-sqlite3 compiles from source)
-
-### Environment Variables
-
-`DATABASE_URL` — path to the SQLite database file, e.g.
-`file:./data/genug-da.db`. Required.
-
-`PORT` — port the server listens on (default: `3002`).
-
-`ORIGIN` — public URL of your instance, e.g. `https://budget.example.com`.
-Required for CSRF protection when running behind a reverse proxy.
-
-### Container images (GHCR)
-
-Prebuilt images are published to the GitHub Container Registry at
-`ghcr.io/lj-n/genug-da` (see [ADR-0012](docs/adr/0012-calver-releases-and-stage-deploy.md)):
-
-| Tag           | Built from      | Use                                                                         |
-| ------------- | --------------- | --------------------------------------------------------------------------- |
-| `latest`      | latest release  | Production — moving pointer to the newest release.                          |
-| `<version>`   | a release       | Production — immutable pin (`2026.07.0`); roll back by pinning a prior one. |
-| `stage`       | tip of `main`   | Testing — rolling build ahead of the last release.                          |
-| `sha-<short>` | a `main` commit | Testing — immutable pin to an exact commit.                                 |
-
-Stage builds show a dev-flavoured version beside the logo (`2026.07.0-dev+a1b2c3d`);
-release builds show the clean CalVer.
-
-While the repository (and image) is private, authenticate the host once with a
-personal access token that has `read:packages`:
-
-```sh
-echo "$GHCR_PAT" | docker login ghcr.io -u <github-username> --password-stdin
-```
-
-### Docker Compose (production)
-
-Pulls the released image; swap `latest` for a specific `<version>` to pin or
-roll back.
+Prebuilt images are published to `ghcr.io/lj-n/genug-da`. A minimal Docker
+Compose stack:
 
 ```yml
 services:
   genug-da:
-    container_name: genug-da
     image: ghcr.io/lj-n/genug-da:latest
     restart: unless-stopped
     ports:
       - '3002:3002'
     volumes:
       - ./data:/app/data:rw
-    logging:
-      driver: json-file
-      options:
-        max-size: '10m'
-        max-file: '5'
     environment:
       PORT: 3002
       DATABASE_URL: 'file:/app/data/genug.db'
       ORIGIN: 'https://your.domain'
-      NODE_ENV: 'production'
 ```
 
-Update with `docker compose pull && docker compose up -d`. To build locally
-instead of pulling, replace `image:` with `build: .`.
+The first login on a fresh instance creates the admin user.
 
-### Docker Compose (stage)
-
-A second stack pulling `:stage` lets you try the tip of `main` before promoting
-it to production. Give it its own data volume, port, and origin so it never
-touches production data.
-
-```yml
-services:
-  genug-da-stage:
-    container_name: genug-da-stage
-    image: ghcr.io/lj-n/genug-da:stage
-    restart: unless-stopped
-    ports:
-      - '3003:3002'
-    volumes:
-      - ./data-stage:/app/data:rw
-    environment:
-      PORT: 3002
-      DATABASE_URL: 'file:/app/data/genug.db'
-      ORIGIN: 'https://stage.your.domain'
-      NODE_ENV: 'production'
-```
-
-### Docker (standalone)
-
-```sh
-docker build -t genug-da .
-docker run -p 3002:3002 -v ./data:/app/data -e DATABASE_URL=file:./data/genug-da.db genug-da
-```
-
-### Manual
-
-```sh
-npm install
-DATABASE_URL=:memory: npm run build
-node build
-```
+For the full picture — image tags and rollback, reverse proxy and `ORIGIN`,
+all environment variables, running without Docker, backups, upgrades, and
+password recovery — see [docs/self-hosting.md](docs/self-hosting.md).
 
 ## Usage
 
-Detailed docs coming soon.
+[docs/usage.md](docs/usage.md) walks through the app feature by feature:
+first login, budget plans, accounts, categories, monthly assignment,
+transactions and transfers, multi-user, and settings.
 
 ## Development
 
@@ -188,6 +113,10 @@ git push --follow-tags
 
 Versions are CalVer (`YYYY.0M.MICRO`) and the changelog is hand-curated under
 `## [Unreleased]`; see [ADR-0012](docs/adr/0012-calver-releases-and-stage-deploy.md).
+
+## Contributing
+
+See [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,7 +1,174 @@
 # Self-Hosting
 
-Operational guidance for running your own genug-da instance. (This page is
-being built out — see issue #123 for env vars, backups, and deploy guidance.)
+Operational guidance for running your own genug-da instance. For what the
+app does and how to use it, see [usage.md](usage.md).
+
+genug-da is a single Node.js process backed by a single SQLite database
+file. There are no external services: no mail server, no cache, no separate
+database server.
+
+## Prerequisites
+
+- **Docker** for the container images below, or
+- **Node.js 22+** plus build tools for native addons (better-sqlite3
+  compiles from source) for a manual install.
+
+## Container images
+
+Prebuilt images are published to the GitHub Container Registry at
+`ghcr.io/lj-n/genug-da` (see
+[ADR-0012](adr/0012-calver-releases-and-stage-deploy.md)):
+
+| Tag           | Built from      | Use                                                                         |
+| ------------- | --------------- | --------------------------------------------------------------------------- |
+| `latest`      | latest release  | Production — moving pointer to the newest release.                          |
+| `<version>`   | a release       | Production — immutable pin (`2026.07.0`); roll back by pinning a prior one. |
+| `stage`       | tip of `main`   | Testing — rolling build ahead of the last release.                          |
+| `sha-<short>` | a `main` commit | Testing — immutable pin to an exact commit.                                 |
+
+Stage builds show a dev-flavoured version beside the logo
+(`2026.07.0-dev+a1b2c3d`); release builds show the clean CalVer.
+
+While the repository (and image) is private, authenticate the host once with
+a personal access token that has `read:packages`:
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u <github-username> --password-stdin
+```
+
+## Deploy with Docker Compose
+
+Pulls the released image; swap `latest` for a specific `<version>` to pin or
+roll back.
+
+```yml
+services:
+  genug-da:
+    container_name: genug-da
+    image: ghcr.io/lj-n/genug-da:latest
+    restart: unless-stopped
+    ports:
+      - '3002:3002'
+    volumes:
+      - ./data:/app/data:rw
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
+    environment:
+      PORT: 3002
+      DATABASE_URL: 'file:/app/data/genug.db'
+      ORIGIN: 'https://your.domain'
+```
+
+Update with `docker compose pull && docker compose up -d`. To build locally
+instead of pulling, replace `image:` with `build: .`.
+
+### First admin
+
+No seeding or bootstrap command is needed. When the app starts with an empty
+database, the first visit redirects to a create-admin screen and the first
+registered user becomes the administrator. That admin then creates all
+further user accounts in the app — there is no open registration and no
+email involved. Since anyone who reaches a fresh instance first would become
+admin, register the admin user right after the first start.
+
+### Reverse proxy and ORIGIN
+
+Run the app behind a reverse proxy that terminates TLS; the app itself
+serves plain HTTP. Whatever proxy you use, set `ORIGIN` to the exact public
+URL users type into the browser (scheme and host, e.g.
+`https://budget.example.com`). SvelteKit checks form submissions against
+this origin for CSRF protection — with `ORIGIN` unset or wrong, logins and
+every other form fail.
+
+### Stage stack (optional)
+
+A second stack pulling `:stage` lets you try the tip of `main` before
+promoting it to production. Give it its own data volume, port, and origin so
+it never touches production data.
+
+```yml
+services:
+  genug-da-stage:
+    container_name: genug-da-stage
+    image: ghcr.io/lj-n/genug-da:stage
+    restart: unless-stopped
+    ports:
+      - '3003:3002'
+    volumes:
+      - ./data-stage:/app/data:rw
+    environment:
+      PORT: 3002
+      DATABASE_URL: 'file:/app/data/genug.db'
+      ORIGIN: 'https://stage.your.domain'
+```
+
+## Environment variables
+
+| Variable       | Required            | Description                                                                                                            |
+| -------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL` | yes                 | Path to the SQLite database file, e.g. `file:/app/data/genug.db`. The app refuses to start without it.                 |
+| `ORIGIN`       | yes, behind a proxy | Public URL of the instance (`https://budget.example.com`). Used for CSRF protection; see above.                        |
+| `PORT`         | no                  | Port the server listens on. adapter-node defaults to `3000`; the compose examples set `3002`, which the image exposes. |
+| `LOG_LEVEL`    | no                  | Log verbosity ([pino](https://getpino.io) levels, e.g. `debug`, `info`, `warn`, `error`). Defaults to `info`.          |
+| `NODE_ENV`     | no                  | `production` switches logs to plain JSON. Already set in the container image; set it yourself for manual runs.         |
+
+The server is built with SvelteKit's adapter-node, which understands further
+variables (`HOST`, `BODY_SIZE_LIMIT`, proxy-header handling, …) — see the
+[adapter-node documentation](https://svelte.dev/docs/kit/adapter-node#Environment-variables).
+
+## Running without Docker
+
+```sh
+npm install
+DATABASE_URL=:memory: npm run build
+DATABASE_URL=file:./data/genug.db NODE_ENV=production node build
+```
+
+Migrations run automatically at startup.
+
+## Backup and restore
+
+All state lives in the single SQLite file at `DATABASE_URL`. The database
+runs in SQLite's default journal mode, so there are no `-wal`/`-shm`
+sidecar files to worry about — the one `.db` file is the whole backup.
+
+**Cold backup (recommended):** stop the container, copy the file, start
+again.
+
+```sh
+docker compose stop
+cp ./data/genug.db /your/backup/location/genug-$(date +%F).db
+docker compose start
+```
+
+**Hot alternative:** SQLite can produce a consistent copy while the app is
+running:
+
+```sh
+sqlite3 ./data/genug.db ".backup ./genug-backup.db"
+```
+
+**Restore:** stop the app, replace the database file with the backup, start
+the app.
+
+## Upgrades and releases
+
+Releases are CalVer-versioned (`YYYY.0M.MICRO`) and listed in
+[CHANGELOG.md](../CHANGELOG.md); only user-visible changes are recorded
+there. Upgrading is a pull:
+
+```sh
+docker compose pull && docker compose up -d
+```
+
+Database migrations run automatically at startup. To roll back, pin the
+previous version tag (`image: ghcr.io/lj-n/genug-da:<version>`) — but note
+that a newer release may have migrated the database beyond what an older
+build expects, so restore the matching database backup when rolling back
+across a migration.
 
 ## Password recovery
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,172 @@
+# Using genug-da
+
+A feature-oriented walkthrough of the app. For installing and operating an
+instance, see [self-hosting.md](self-hosting.md).
+
+genug-da is an [envelope budgeting](https://en.wikipedia.org/wiki/Envelope_system)
+app: money you receive lands in an unassigned pool, and you assign it to
+spending categories before you spend it. Each category's remaining balance
+tells you how much you can still spend in that area.
+
+## First login
+
+On a fresh instance, the first visit redirects to a "Create Admin" screen.
+The first registered user becomes the administrator. Keep these credentials
+safe — there is no email-based recovery (an operator can reset passwords from
+the server shell, see [self-hosting.md](self-hosting.md#password-recovery)).
+
+Every later visitor gets the regular login screen. Accounts are created by
+the administrator (see [Multi-user](#multi-user)); there is no open
+registration.
+
+After logging in for the first time you are asked to create your first
+budget plan.
+
+## Budget plans
+
+A budget plan is a self-contained budget with its own accounts, categories,
+and transactions — for example one for personal finances and one for a side
+business.
+
+- **Create** — choose a name and a currency (EUR, USD, GBP, CAD, AUD, JPY).
+- **Switch** — all your budgets are listed in the navigation; click one to
+  jump to its current month. Drag to reorder them.
+- **Edit** — the settings icon in the budget header opens the budget
+  settings, where you can rename the budget or change its currency.
+
+## Accounts
+
+Accounts mirror your real-world bank accounts and credit cards. Each account
+shows three balances:
+
+- **Validated** — the sum of all validated transactions; this should match
+  your bank statement.
+- **Pending** — the sum of transactions you have entered but not yet
+  confirmed against the bank.
+- **Balance** — validated plus pending.
+
+When creating an account you can enter a starting balance; it is recorded as
+an initial validated income transaction.
+
+An account can be **archived** once its balance is zero and all its
+transactions are validated. Archived accounts keep their history and appear
+on a separate archived-accounts page, from which they can be restored. An
+account can only be **deleted** while no transactions reference it — history
+is never silently discarded.
+
+## Categories
+
+Categories are the envelopes you assign money to.
+
+- **Create** — pick a name; optional notes are free text for your own
+  reference.
+- **Target balance** — optionally set a target amount for a category. The
+  category detail view shows how much of the target is reached. Targets are
+  a planning aid; they do not block spending.
+- **Archive** — a category can be archived once its remaining balance is
+  zero and all its transactions are validated. Archived categories disappear
+  from the budget view but keep their history and can be restored.
+- **Delete** — only possible while the category has a zero remaining
+  balance and no transactions reference it. This prevents past spending from
+  silently turning into uncategorized income.
+
+## The monthly budget view
+
+The month view is the heart of the app. It lists every category with three
+numbers for the selected month:
+
+- **Budget** — the amount you assigned to the category this month.
+- **Activity** — what happened in the category this month (spending or
+  refunds).
+- **Remaining** — what is left to spend: assignments minus spending,
+  carried across months.
+
+Use the month and year navigation to move between months; each month's
+assignments are independent.
+
+### Assigning money
+
+Click a category's budget amount to edit it in place. Money you assign comes
+out of the **Unassigned** pool shown at the top of the view.
+
+Unassigned is month-scoped: income counts from the month it arrives, and the
+pool shows what is still available to assign through the selected month. If
+you have already assigned money in future months, that reservation is
+reflected too — the breakdown popover shows income, allocations, and where a
+future bottleneck sits. A negative Unassigned value is a warning that you
+have assigned more than you have received so far, not a hard error.
+
+### Moving money and covering overspending
+
+Click a category's remaining value to move money without going through the
+pool:
+
+- A category with money left can **move** an amount to another category or
+  back to Unassigned.
+- An overspent category (negative remaining, shown in red) can **cover** the
+  deficit by drawing from another category.
+
+## Transactions
+
+Transactions live under an account. Each has a category (or none — a
+transaction without a category is income to the budget), a date, optional
+notes, an amount, and a validated flag.
+
+- **Add** — from an account, open the new-transaction form; new entries
+  default to pending.
+- **Edit inline** — click a row to edit category, notes, date, and amount in
+  place, or delete the transaction.
+- **Validate** — toggle the checkbox on a row once the transaction shows up
+  on your bank statement. This moves it from the pending balance to the
+  validated balance; budget math counts both.
+- **Filter and sort** — filter by category (including "without category" and
+  transfers) and search notes; sort by date, amount, category, or validated
+  state. Filters are kept in the URL, so a filtered view can be bookmarked.
+
+### Transfers between accounts
+
+A transfer moves money between two accounts of the same budget without
+counting as income or spending. It is stored as a linked pair — an outflow
+in the source account and an inflow in the destination — with no category on
+either side, so it never affects Unassigned or any category's remaining
+balance. Editing or deleting a transfer always applies to both sides;
+each side can be validated independently as it clears at the respective
+bank.
+
+## Multi-user
+
+The administrator creates user accounts on the admin page: enter a username
+and the app generates a one-time random password to hand to the new user.
+Users change their password themselves in their settings.
+
+Budgets can be shared. The budget owner opens the users dialog and invites
+another user by their exact username. The invited user sees the invitation
+on login and can accept (gaining full access to the budget) or decline.
+Roles per budget:
+
+- **Owner** — created the budget; can invite and remove users.
+- **Member** — accepted an invitation; works with the budget like the owner.
+- **Invitee** — invited, decision pending.
+
+The owner can remove a user from the budget at any time; the removed user
+loses access immediately.
+
+## Settings
+
+Personal settings cover:
+
+- **Display name** — change your username.
+- **Password** — change your password (requires the current one; signs you
+  out afterwards).
+- **Theme** — system, light, or dark.
+- **Language** — English or German, applied immediately.
+
+The budget's currency is a per-budget setting (see
+[Budget plans](#budget-plans)), not a personal one.
+
+## Administration
+
+The admin page (administrator only) lists all users, offers password resets
+(generating a new one-time password), user deletion, and a danger-zone
+instance reset that permanently deletes all users, budgets, accounts, and
+transactions.


### PR DESCRIPTION
Closes #123.

Executes the completeness bar from #114; the #99-gated parts (release badge, ghcr deploy + first-admin prose) are included since #99 landed.

## README
- Badge row: CI workflow, release tag, AGPL-3.0-only license.
- Deploy slimmed to a minimal Compose quickstart (`:latest`, three env vars) with the "first login creates the admin" one-liner; full ops detail moved to `docs/self-hosting.md`.
- "Docs coming soon" placeholder replaced with a Usage paragraph pointing to `docs/usage.md`; Contributing section links `.github/CONTRIBUTING.md`.

## docs/self-hosting.md
- Built out from the password-recovery stub: prerequisites, GHCR tag table + PAT login, prod/stage Compose stacks, first-admin bootstrap prose, reverse-proxy/`ORIGIN` rule (prose-only, no proxy named), core env-var reference with adapter-node linked for the rest, cold + `sqlite3 .backup` backup guidance, upgrades/rollback with a migration caveat.
- Fixes an inaccuracy from the old README: nothing defaults `PORT` to 3002 (adapter-node defaults to 3000; 3002 is the compose/EXPOSE convention).

## docs/usage.md (new)
- Text-only feature walkthrough in the spec's order: first login/admin, budget plans, accounts, categories, monthly assignment, transactions & transfers, multi-user, settings, administration. No new screenshots beyond #112.

No changelog entry (docs-only). Prettier/ESLint pass, all 592 unit tests pass, all relative doc links verified.