### PR TITLE
feat: PAT auth foundation — apiTokens table + Bearer path in hooks (#192)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 
 import * as auth from '$db/auth';
+import { validateApiToken } from '$db/auth/api-tokens';
 import { getTextDirection } from '$lib/paraglide/runtime';
 import { paraglideMiddleware } from '$lib/paraglide/server';
 import { logger } from '$lib/server/logger';
@@ -27,6 +28,15 @@ const handleLogging: Handle = async ({ event, resolve }) => {
 };
 
 const handleAuth: Handle = async ({ event, resolve }) => {
+	const authorization = event.request.headers.get('authorization');
+
+	// API clients authenticate with a bearer token; they never get a web session.
+	if (authorization?.startsWith('Bearer ')) {
+		event.locals.session = null;
+		event.locals.user = await validateApiToken({ token: authorization.slice('Bearer '.length) });
+		return resolve(event);
+	}
+
 	const sessionToken = auth.getSessionCookie(event);
 
 	if (!sessionToken) {

--- a/src/lib/server/db/auth/api-tokens.test.ts
+++ b/src/lib/server/db/auth/api-tokens.test.ts
@@ -1,0 +1,153 @@
+import { createDatabase, type Database } from '$db';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import {
+	createApiToken,
+	createApiTokenSecret,
+	deleteApiToken,
+	listApiTokens,
+	validateApiToken
+} from './api-tokens';
+import { hashPassword } from './index';
+import { createUser } from './user';
+import { DAY_IN_MS, type User } from './utils';
+
+async function createUserForTest(db: Database, username = 'testuser'): Promise<User> {
+	const passwordHash = await hashPassword({ password: 'password123' });
+	return createUser({ db, passwordHash, username });
+}
+
+it('createApiToken - stores only a hash of the token', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+
+	const { apiToken, token } = createApiToken({ db, name: 'iPhone', userId: user.id });
+	const stored = await db.query.apiTokens.findFirst({ where: { id: apiToken.id } });
+
+	expect(stored?.tokenHash).toBeDefined();
+	expect(stored?.tokenHash).not.toBe(token);
+	expect(stored?.expiresAt).toBeNull();
+});
+
+it('createApiToken - throws when userId does not exist', () => {
+	const db = createDatabase(':memory:');
+
+	expect(() => createApiToken({ db, name: 'iPhone', userId: 'non-existent-user-id' })).toThrow();
+});
+
+it('createApiTokenSecret - produces 44-char base64 token', () => {
+	const token = createApiTokenSecret();
+	expect(token).toHaveLength(44);
+	expect(token).toMatch(/^[A-Za-z0-9+/]+=*$/);
+});
+
+it('validateApiToken - valid token returns the user without passwordHash', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const { token } = createApiToken({ db, name: 'iPhone', userId: user.id });
+
+	const validated = await validateApiToken({ db, token });
+
+	expect(validated).toMatchObject({ id: user.id, username: user.username });
+	expect(validated).not.toHaveProperty('passwordHash');
+});
+
+it('validateApiToken - invalid token returns null', async () => {
+	const db = createDatabase(':memory:');
+
+	await expect(validateApiToken({ db, token: 'invalid-token' })).resolves.toBeNull();
+});
+
+it('validateApiToken - updates lastUsedAt', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const { apiToken, token } = createApiToken({ db, name: 'iPhone', userId: user.id });
+
+	expect(apiToken.lastUsedAt).toBeNull();
+
+	await validateApiToken({ db, token });
+	const stored = await db.query.apiTokens.findFirst({ where: { id: apiToken.id } });
+
+	expect(stored?.lastUsedAt?.getTime()).toBe(Date.now());
+});
+
+it('validateApiToken - token without expiry never expires', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const { token } = createApiToken({ db, name: 'iPhone', userId: user.id });
+
+	vi.setSystemTime(new Date(Date.now() + DAY_IN_MS * 365 * 10));
+
+	await expect(validateApiToken({ db, token })).resolves.toMatchObject({ id: user.id });
+});
+
+it('validateApiToken - expired token returns null and is deleted', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const expiresAt = new Date(Date.now() + DAY_IN_MS * 30);
+	const { apiToken, token } = createApiToken({ db, expiresAt, name: 'iPhone', userId: user.id });
+
+	vi.setSystemTime(expiresAt);
+
+	await expect(validateApiToken({ db, token })).resolves.toBeNull();
+	await expect(
+		db.query.apiTokens.findFirst({ where: { id: apiToken.id } })
+	).resolves.toBeUndefined();
+});
+
+it('validateApiToken - token before its expiry validates', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const expiresAt = new Date(Date.now() + DAY_IN_MS * 30);
+	const { token } = createApiToken({ db, expiresAt, name: 'iPhone', userId: user.id });
+
+	vi.setSystemTime(new Date(expiresAt.getTime() - 1));
+
+	await expect(validateApiToken({ db, token })).resolves.toMatchObject({ id: user.id });
+});
+
+it('deleteApiToken - revoked token no longer validates', async () => {
+	const db = createDatabase(':memory:');
+	const user = await createUserForTest(db);
+	const { apiToken, token } = createApiToken({ db, name: 'iPhone', userId: user.id });
+
+	deleteApiToken({ db, tokenId: apiToken.id, userId: user.id });
+
+	await expect(validateApiToken({ db, token })).resolves.toBeNull();
+});
+
+it('deleteApiToken - ignores tokens belonging to another user', async () => {
+	const db = createDatabase(':memory:');
+	const owner = await createUserForTest(db, 'owner');
+	const other = await createUserForTest(db, 'other');
+	const { apiToken, token } = createApiToken({ db, name: 'iPhone', userId: owner.id });
+
+	deleteApiToken({ db, tokenId: apiToken.id, userId: other.id });
+
+	await expect(validateApiToken({ db, token })).resolves.toMatchObject({ id: owner.id });
+});
+
+it('listApiTokens - returns only the user tokens, without tokenHash', async () => {
+	const db = createDatabase(':memory:');
+	const owner = await createUserForTest(db, 'owner');
+	const other = await createUserForTest(db, 'other');
+	createApiToken({ db, name: 'iPhone', userId: owner.id });
+	createApiToken({ db, name: 'iPad', userId: owner.id });
+	createApiToken({ db, name: 'Android', userId: other.id });
+
+	const tokens = await listApiTokens({ db, userId: owner.id });
+
+	expect(tokens).toHaveLength(2);
+	expect(tokens.map((t) => t.name).sort()).toEqual(['iPad', 'iPhone']);
+	for (const token of tokens) {
+		expect(token).not.toHaveProperty('tokenHash');
+	}
+});
+
+beforeEach(() => {
+	vi.useFakeTimers({ now: 0 });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});

--- a/src/lib/server/db/auth/api-tokens.ts
+++ b/src/lib/server/db/auth/api-tokens.ts
@@ -1,0 +1,84 @@
+import { database, type Database, tables } from '$db';
+import { sha256 } from '@oslojs/crypto/sha2';
+import { encodeBase64, encodeHexLowerCase } from '@oslojs/encoding';
+import { and, eq } from 'drizzle-orm';
+
+import { isExpired, type User } from './utils';
+
+export function createApiToken({
+	db = database,
+	expiresAt,
+	name,
+	userId
+}: {
+	db?: Database;
+	expiresAt?: Date;
+	name: string;
+	userId: string;
+}) {
+	const token = createApiTokenSecret();
+	const apiToken = db
+		.insert(tables.apiTokens)
+		.values({ expiresAt, name, tokenHash: hashApiToken(token), userId })
+		.returning()
+		.get();
+	return { apiToken, token };
+}
+
+export function createApiTokenSecret(): string {
+	const randomBytes = crypto.getRandomValues(new Uint8Array(32));
+	return encodeBase64(randomBytes);
+}
+
+export function deleteApiToken({
+	db = database,
+	tokenId,
+	userId
+}: {
+	db?: Database;
+	tokenId: string;
+	userId: string;
+}) {
+	db.delete(tables.apiTokens)
+		.where(and(eq(tables.apiTokens.id, tokenId), eq(tables.apiTokens.userId, userId)))
+		.run();
+}
+
+export function listApiTokens({ db = database, userId }: { db?: Database; userId: string }) {
+	return db.query.apiTokens.findMany({
+		columns: { tokenHash: false },
+		orderBy: { createdAt: 'desc' },
+		where: { userId }
+	});
+}
+
+export async function validateApiToken({
+	db = database,
+	token
+}: {
+	db?: Database;
+	token: string;
+}): Promise<null | User> {
+	const apiToken = await db.query.apiTokens.findFirst({
+		where: { tokenHash: hashApiToken(token) },
+		with: { user: { columns: { passwordHash: false } } }
+	});
+
+	if (!apiToken || !apiToken.user) return null;
+
+	if (apiToken.expiresAt && isExpired(apiToken.expiresAt)) {
+		db.delete(tables.apiTokens).where(eq(tables.apiTokens.id, apiToken.id)).run();
+		return null;
+	}
+
+	db.update(tables.apiTokens)
+		.set({ lastUsedAt: new Date() })
+		.where(eq(tables.apiTokens.id, apiToken.id))
+		.run();
+
+	return apiToken.user;
+}
+
+function hashApiToken(token: string): string {
+	return encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -10,6 +10,7 @@ const database = createDatabase(env.DATABASE_URL);
 export { createDatabase, type Database, database };
 
 export * from './auth';
+export * from './auth/api-tokens';
 export * from './auth/user';
 export * from './auth/utils';
 export * as tables from './tables';

--- a/src/lib/server/db/migrations/20260718215554_worthless_forge/migration.sql
+++ b/src/lib/server/db/migrations/20260718215554_worthless_forge/migration.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `api_tokens` (
+	`created_at` integer NOT NULL,
+	`expires_at` integer,
+	`id` text PRIMARY KEY,
+	`last_used_at` integer,
+	`name` text NOT NULL,
+	`token_hash` text NOT NULL UNIQUE,
+	`user_id` text NOT NULL,
+	CONSTRAINT `fk_api_tokens_user_id_users_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `api_token_user` ON `api_tokens` (`user_id`);

--- a/src/lib/server/db/migrations/20260718215554_worthless_forge/snapshot.json
+++ b/src/lib/server/db/migrations/20260718215554_worthless_forge/snapshot.json
@@ -1,0 +1,1078 @@
+{
+	"version": "7",
+	"dialect": "sqlite",
+	"id": "d66eaaf3-e903-438f-b3b9-e861e07c1db6",
+	"prevIds": ["9c23559f-e130-4195-ab1e-ed0185eed8df"],
+	"ddl": [
+		{
+			"name": "accounts",
+			"entityType": "tables"
+		},
+		{
+			"name": "budget_assignments",
+			"entityType": "tables"
+		},
+		{
+			"name": "budgets",
+			"entityType": "tables"
+		},
+		{
+			"name": "users_to_budgets",
+			"entityType": "tables"
+		},
+		{
+			"name": "categories",
+			"entityType": "tables"
+		},
+		{
+			"name": "transactions",
+			"entityType": "tables"
+		},
+		{
+			"name": "api_tokens",
+			"entityType": "tables"
+		},
+		{
+			"name": "sessions",
+			"entityType": "tables"
+		},
+		{
+			"name": "user_entity_order",
+			"entityType": "tables"
+		},
+		{
+			"name": "users",
+			"entityType": "tables"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "archived_at",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget_id",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "notes",
+			"entityType": "columns",
+			"table": "accounts"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "amount",
+			"entityType": "columns",
+			"table": "budget_assignments"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget_id",
+			"entityType": "columns",
+			"table": "budget_assignments"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "category_id",
+			"entityType": "columns",
+			"table": "budget_assignments"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "month",
+			"entityType": "columns",
+			"table": "budget_assignments"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "budgets"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "'EUR'",
+			"generated": null,
+			"name": "currency",
+			"entityType": "columns",
+			"table": "budgets"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "budgets"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "budgets"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget_id",
+			"entityType": "columns",
+			"table": "users_to_budgets"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "role",
+			"entityType": "columns",
+			"table": "users_to_budgets"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "users_to_budgets"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "archived_at",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget_id",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "notes",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "target_balance",
+			"entityType": "columns",
+			"table": "categories"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "account_id",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "amount",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "budget_id",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "category_id",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_by",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "date",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "notes",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "transfer_id",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "validated",
+			"entityType": "columns",
+			"table": "transactions"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "integer",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "last_used_at",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "name",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "token_hash",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "api_tokens"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "expires_at",
+			"entityType": "columns",
+			"table": "sessions"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "sessions"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "sessions"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "entity_id",
+			"entityType": "columns",
+			"table": "user_entity_order"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "entity_type",
+			"entityType": "columns",
+			"table": "user_entity_order"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "position",
+			"entityType": "columns",
+			"table": "user_entity_order"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "user_id",
+			"entityType": "columns",
+			"table": "user_entity_order"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "created_at",
+			"entityType": "columns",
+			"table": "users"
+		},
+		{
+			"type": "text",
+			"notNull": false,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "id",
+			"entityType": "columns",
+			"table": "users"
+		},
+		{
+			"type": "integer",
+			"notNull": true,
+			"autoincrement": false,
+			"default": "false",
+			"generated": null,
+			"name": "isAdmin",
+			"entityType": "columns",
+			"table": "users"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "password_hash",
+			"entityType": "columns",
+			"table": "users"
+		},
+		{
+			"type": "text",
+			"notNull": true,
+			"autoincrement": false,
+			"default": null,
+			"generated": null,
+			"name": "username",
+			"entityType": "columns",
+			"table": "users"
+		},
+		{
+			"columns": ["budget_id"],
+			"tableTo": "budgets",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_accounts_budget_id_budgets_id_fk",
+			"entityType": "fks",
+			"table": "accounts"
+		},
+		{
+			"columns": ["budget_id"],
+			"tableTo": "budgets",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_budget_assignments_budget_id_budgets_id_fk",
+			"entityType": "fks",
+			"table": "budget_assignments"
+		},
+		{
+			"columns": ["category_id"],
+			"tableTo": "categories",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_budget_assignments_category_id_categories_id_fk",
+			"entityType": "fks",
+			"table": "budget_assignments"
+		},
+		{
+			"columns": ["category_id", "budget_id"],
+			"tableTo": "categories",
+			"columnsTo": ["id", "budget_id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "NO ACTION",
+			"nameExplicit": false,
+			"name": "fk_budget_assignments_category_id_budget_id_categories_id_budget_id_fk",
+			"entityType": "fks",
+			"table": "budget_assignments"
+		},
+		{
+			"columns": ["budget_id"],
+			"tableTo": "budgets",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_users_to_budgets_budget_id_budgets_id_fk",
+			"entityType": "fks",
+			"table": "users_to_budgets"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_users_to_budgets_user_id_users_id_fk",
+			"entityType": "fks",
+			"table": "users_to_budgets"
+		},
+		{
+			"columns": ["budget_id"],
+			"tableTo": "budgets",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_categories_budget_id_budgets_id_fk",
+			"entityType": "fks",
+			"table": "categories"
+		},
+		{
+			"columns": ["account_id"],
+			"tableTo": "accounts",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_transactions_account_id_accounts_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["budget_id"],
+			"tableTo": "budgets",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_transactions_budget_id_budgets_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["category_id"],
+			"tableTo": "categories",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "SET NULL",
+			"nameExplicit": false,
+			"name": "fk_transactions_category_id_categories_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["created_by"],
+			"tableTo": "users",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "SET NULL",
+			"nameExplicit": false,
+			"name": "fk_transactions_created_by_users_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["account_id", "budget_id"],
+			"tableTo": "accounts",
+			"columnsTo": ["id", "budget_id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "NO ACTION",
+			"nameExplicit": false,
+			"name": "fk_transactions_account_id_budget_id_accounts_id_budget_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["category_id", "budget_id"],
+			"tableTo": "categories",
+			"columnsTo": ["id", "budget_id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "NO ACTION",
+			"nameExplicit": false,
+			"name": "fk_transactions_category_id_budget_id_categories_id_budget_id_fk",
+			"entityType": "fks",
+			"table": "transactions"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_api_tokens_user_id_users_id_fk",
+			"entityType": "fks",
+			"table": "api_tokens"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_sessions_user_id_users_id_fk",
+			"entityType": "fks",
+			"table": "sessions"
+		},
+		{
+			"columns": ["user_id"],
+			"tableTo": "users",
+			"columnsTo": ["id"],
+			"onUpdate": "NO ACTION",
+			"onDelete": "CASCADE",
+			"nameExplicit": false,
+			"name": "fk_user_entity_order_user_id_users_id_fk",
+			"entityType": "fks",
+			"table": "user_entity_order"
+		},
+		{
+			"columns": ["category_id", "month"],
+			"nameExplicit": false,
+			"name": "budget_assignments_pk",
+			"entityType": "pks",
+			"table": "budget_assignments"
+		},
+		{
+			"columns": ["user_id", "budget_id"],
+			"nameExplicit": false,
+			"name": "users_to_budgets_pk",
+			"entityType": "pks",
+			"table": "users_to_budgets"
+		},
+		{
+			"columns": ["user_id", "entity_type", "entity_id"],
+			"nameExplicit": false,
+			"name": "user_entity_order_pk",
+			"entityType": "pks",
+			"table": "user_entity_order"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "accounts_pk",
+			"table": "accounts",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "budgets_pk",
+			"table": "budgets",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "categories_pk",
+			"table": "categories",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "transactions_pk",
+			"table": "transactions",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "api_tokens_pk",
+			"table": "api_tokens",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "sessions_pk",
+			"table": "sessions",
+			"entityType": "pks"
+		},
+		{
+			"columns": ["id"],
+			"nameExplicit": false,
+			"name": "users_pk",
+			"table": "users",
+			"entityType": "pks"
+		},
+		{
+			"columns": [
+				{
+					"value": "budget_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": "\"accounts\".\"archived_at\" IS NULL",
+			"origin": "manual",
+			"name": "account_active",
+			"entityType": "indexes",
+			"table": "accounts"
+		},
+		{
+			"columns": [
+				{
+					"value": "budget_id",
+					"isExpression": false
+				},
+				{
+					"value": "month",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "budget_assignment_month",
+			"entityType": "indexes",
+			"table": "budget_assignments"
+		},
+		{
+			"columns": [
+				{
+					"value": "budget_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": "\"categories\".\"archived_at\" IS NULL",
+			"origin": "manual",
+			"name": "category_active",
+			"entityType": "indexes",
+			"table": "categories"
+		},
+		{
+			"columns": [
+				{
+					"value": "budget_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "transaction_budget",
+			"entityType": "indexes",
+			"table": "transactions"
+		},
+		{
+			"columns": [
+				{
+					"value": "account_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "transaction_account",
+			"entityType": "indexes",
+			"table": "transactions"
+		},
+		{
+			"columns": [
+				{
+					"value": "account_id",
+					"isExpression": false
+				},
+				{
+					"value": "date",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "transaction_account_date",
+			"entityType": "indexes",
+			"table": "transactions"
+		},
+		{
+			"columns": [
+				{
+					"value": "transfer_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "transaction_transfer",
+			"entityType": "indexes",
+			"table": "transactions"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "api_token_user",
+			"entityType": "indexes",
+			"table": "api_tokens"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "session_user",
+			"entityType": "indexes",
+			"table": "sessions"
+		},
+		{
+			"columns": [
+				{
+					"value": "user_id",
+					"isExpression": false
+				},
+				{
+					"value": "entity_type",
+					"isExpression": false
+				},
+				{
+					"value": "position",
+					"isExpression": false
+				}
+			],
+			"isUnique": false,
+			"where": null,
+			"origin": "manual",
+			"name": "user_entity_order_sort_idx",
+			"entityType": "indexes",
+			"table": "user_entity_order"
+		},
+		{
+			"columns": [
+				{
+					"value": "isAdmin",
+					"isExpression": false
+				}
+			],
+			"isUnique": true,
+			"where": "\"users\".\"isAdmin\" = 1",
+			"origin": "manual",
+			"name": "admin_unique",
+			"entityType": "indexes",
+			"table": "users"
+		},
+		{
+			"columns": ["name", "budget_id"],
+			"nameExplicit": true,
+			"name": "account_name_budget_unique",
+			"entityType": "uniques",
+			"table": "accounts"
+		},
+		{
+			"columns": ["id", "budget_id"],
+			"nameExplicit": true,
+			"name": "account_id_budget_unique",
+			"entityType": "uniques",
+			"table": "accounts"
+		},
+		{
+			"columns": ["name", "budget_id"],
+			"nameExplicit": true,
+			"name": "category_name_budget_unique",
+			"entityType": "uniques",
+			"table": "categories"
+		},
+		{
+			"columns": ["id", "budget_id"],
+			"nameExplicit": true,
+			"name": "category_id_budget_unique",
+			"entityType": "uniques",
+			"table": "categories"
+		},
+		{
+			"columns": ["username"],
+			"nameExplicit": true,
+			"name": "username_unique",
+			"entityType": "uniques",
+			"table": "users"
+		},
+		{
+			"columns": ["token_hash"],
+			"nameExplicit": false,
+			"name": "api_tokens_token_hash_unique",
+			"entityType": "uniques",
+			"table": "api_tokens"
+		},
+		{
+			"columns": ["username"],
+			"nameExplicit": false,
+			"name": "users_username_unique",
+			"entityType": "uniques",
+			"table": "users"
+		},
+		{
+			"value": "\"month\" between 190001 and 210012 AND \"month\" % 100 between 1 and 12",
+			"name": "date_format",
+			"entityType": "checks",
+			"table": "budget_assignments"
+		},
+		{
+			"value": "\"target_balance\" > 0",
+			"name": "target_balance_positive",
+			"entityType": "checks",
+			"table": "categories"
+		},
+		{
+			"value": "\"date\" LIKE '____-__-__'",
+			"name": "date_format",
+			"entityType": "checks",
+			"table": "transactions"
+		},
+		{
+			"value": "\"transfer_id\" IS NULL OR \"category_id\" IS NULL",
+			"name": "transfer_no_category",
+			"entityType": "checks",
+			"table": "transactions"
+		}
+	],
+	"renames": []
+}

--- a/src/lib/server/db/relations.ts
+++ b/src/lib/server/db/relations.ts
@@ -16,6 +16,14 @@ export const relations = defineRelations(tables, (r) => ({
 		})
 	},
 
+	apiTokens: {
+		user: r.one.users({
+			from: r.apiTokens.userId,
+			optional: false,
+			to: r.users.id
+		})
+	},
+
 	budgets: {
 		accounts: r.many.accounts({
 			from: r.budgets.id,

--- a/src/lib/server/db/tables/users.ts
+++ b/src/lib/server/db/tables/users.ts
@@ -6,6 +6,29 @@ import { createId } from '../../utils/create-id';
 
 export const entityOrderTypes = ['budget', 'account', 'category'] as const;
 
+export const apiTokens = sqliteTable(
+	'api_tokens',
+	(t) => ({
+		createdAt: t
+			.integer('created_at', { mode: 'timestamp' })
+			.$defaultFn(() => new Date())
+			.notNull(),
+		expiresAt: t.integer('expires_at', { mode: 'timestamp' }),
+		id: t
+			.text('id')
+			.primaryKey()
+			.$defaultFn(() => createId()),
+		lastUsedAt: t.integer('last_used_at', { mode: 'timestamp' }),
+		name: t.text('name').notNull(),
+		tokenHash: t.text('token_hash').notNull().unique(),
+		userId: t
+			.text('user_id')
+			.references(() => users.id, { onDelete: 'cascade' })
+			.notNull()
+	}),
+	(t) => [index('api_token_user').on(t.userId)]
+);
+
 export const sessions = sqliteTable(
 	'sessions',
 	(t) => ({


### PR DESCRIPTION
Closes #192 (wayfinder map #190, map decision 8).

## What

Server-side foundation for iOS API authentication: personal access tokens, hashed at rest, resolved from an `Authorization: Bearer` header — without touching the web's cookie sessions.

- **`api_tokens` table** (`src/lib/server/db/tables/users.ts` + generated Drizzle migration): `id`, `name`, `tokenHash` (unique, sha256 hex — plaintext exists only at issuance), `userId` (cascade), `createdAt`, `lastUsedAt`, and nullable `expiresAt` (optional expiry, defaulted off).
- **Token logic** in `src/lib/server/db/auth/api-tokens.ts`: `createApiToken` (returns plaintext once), `validateApiToken` (checks expiry, deletes expired rows, stamps `lastUsedAt`), `deleteApiToken` (scoped to the owning user), `listApiTokens` (never returns hashes). 44-char base64 secrets (32 random bytes).
- **Bearer branch in `hooks.server.ts`**: resolves the token to `event.locals.user` and leaves `locals.session = null` — API clients authenticate remote-function guards and the future `+server.ts` endpoints (which gate on `locals.user`) but never gain web-session semantics; session-gated web pages still redirect them to login.

## Verification

- 12 new unit tests in `api-tokens.test.ts`; full suite green (617 passed, 42 files), `npm run lint` clean. `npm run check` has 3 pre-existing errors in `tests/playwright/a11y.spec.ts` from `@axe-core/playwright` not being installed locally — unrelated.
- End-to-end with curl against a dev server: valid `Bearer` on the `getBudgets` remote query returns data; missing/invalid tokens get the login-redirect result; unauthenticated page loads still 307 to `/login`.

## Notes

- No `CHANGELOG.md` entry yet: tokens can't be issued through any user surface until the issuance/revocation UI (#193), which carries the user-facing entry.
- `npm run db:migrations` currently fails on this machine — drizzle-kit's bundled jiti resolves the `paths` inherited from `.svelte-kit/tsconfig.json` against the repo root instead of the `.svelte-kit` dir. Worked around with a temporary `paths` override in the root `tsconfig.json` (reverted after generating).