### PR TITLE
feat: iOS MVP HTTP API — 12 endpoints over user-context (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and dependency bumps get no entry.
 
 ### Added
 
+- An HTTP API for native clients (the upcoming iOS app), served under
+  `/api/v1` by the same instance as the web app and authenticated with a
+  personal access token (`Authorization: Bearer`). It exposes the month
+  envelope view, budget/account/category lists, the transaction register, and
+  endpoints to capture, edit, and delete transactions, move money between
+  accounts, and set or reassign category budgets. Every write returns the
+  server-recomputed envelope and affected account balances in its own
+  response, so a client never recomputes budget math locally. The web app and
+  its behaviour are unchanged.
+
 - Personal access tokens for API clients (the upcoming iOS app): the settings
   page gains an "API Tokens" section where you create a named token (with an
   optional expiry date), reveal it exactly once — as plaintext with a copy

--- a/src/lib/server/api/endpoints.test.ts
+++ b/src/lib/server/api/endpoints.test.ts
@@ -1,0 +1,290 @@
+/**
+ * The referee for ticket #195: every native-endpoint response is assembled
+ * from real `user-context` output and decoded against the *published* contract
+ * schemas (`docs/api/openapi.yaml`, built here via `buildOpenApiDocument`).
+ * The pipeline ticket (#194) guards the envelope family; this file exercises
+ * the entity, register, write-result, and transfer schemas as their endpoints
+ * land, and asserts the fat-response bookkeeping (affected categories and
+ * account balances) the contract requires.
+ */
+
+import { createDatabase, tables } from '$db';
+import { createUserCtx } from '$db/user-context';
+import { type Month, parseMonth } from '$lib/utils/month';
+import addFormats from 'ajv-formats';
+import Ajv2020, { type ValidateFunction } from 'ajv/dist/2020';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createBudgetWithUser } from '../../../test/fixtures';
+import {
+	createTransaction,
+	createTransfer,
+	deleteTransaction,
+	editTransaction,
+	editTransfer,
+	getEnvelopeView,
+	listAccounts,
+	listBudgets,
+	listCategories,
+	listTransactions,
+	reassign,
+	setAssignment
+} from './endpoints';
+import { buildOpenApiDocument, type OpenApiDocument } from './openapi';
+
+const doc = buildOpenApiDocument() as OpenApiDocument;
+const month = parseMonth(202501) as Month;
+
+/** JSON round-trip: what the HTTP layer actually puts on the wire. */
+function onTheWire<T>(value: T): unknown {
+	return JSON.parse(JSON.stringify(value));
+}
+
+const validators = new Map<string, ValidateFunction>();
+function decode(schemaName: string, value: unknown) {
+	let validate = validators.get(schemaName);
+	if (!validate) {
+		const ajv = new Ajv2020({ allErrors: true, strict: false });
+		addFormats(ajv);
+		validate = ajv.compile({
+			$ref: `#/components/schemas/${schemaName}`,
+			components: doc.components
+		});
+		validators.set(schemaName, validate);
+	}
+	const wire = onTheWire(value);
+	expect(validate(wire), JSON.stringify(validate.errors, null, 2)).toBe(true);
+	return wire;
+}
+
+function seed() {
+	const db = createDatabase(':memory:');
+	const { budget, user } = createBudgetWithUser(db);
+	const ctx = createUserCtx(user.id, db);
+
+	const groceries = db
+		.insert(tables.categories)
+		.values({ budgetId: budget.id, name: 'Groceries', notes: 'weekly', targetBalance: 40000 })
+		.returning()
+		.get();
+	const fun = db
+		.insert(tables.categories)
+		.values({ budgetId: budget.id, name: 'Fun' })
+		.returning()
+		.get();
+	const checking = db
+		.insert(tables.accounts)
+		.values({ budgetId: budget.id, name: 'Checking' })
+		.returning()
+		.get();
+	const savings = db
+		.insert(tables.accounts)
+		.values({ budgetId: budget.id, name: 'Savings' })
+		.returning()
+		.get();
+
+	// 1000.00 income, 200.00 assigned to Groceries, 50.00 spent from Groceries.
+	db.insert(tables.transactions)
+		.values({ accountId: checking.id, amount: 100000, budgetId: budget.id, date: '2025-01-02' })
+		.run();
+	db.insert(tables.budgetAssignments)
+		.values({ amount: 20000, budgetId: budget.id, categoryId: groceries.id, month: 202501 })
+		.run();
+	const spend = db
+		.insert(tables.transactions)
+		.values({
+			accountId: checking.id,
+			amount: -5000,
+			budgetId: budget.id,
+			categoryId: groceries.id,
+			date: '2025-01-15'
+		})
+		.returning()
+		.get();
+
+	return { budget, checking, ctx, fun, groceries, savings, spend, user };
+}
+
+let s: ReturnType<typeof seed>;
+beforeEach(() => {
+	s = seed();
+});
+
+describe('reference + envelope reads', () => {
+	it('listBudgets rows decode against Budget', () => {
+		const budgets = listBudgets(s.ctx);
+		expect(budgets.length).toBe(1);
+		for (const budget of budgets) decode('Budget', budget);
+	});
+
+	it('listAccounts rows decode against AccountSummary and carry balances', () => {
+		const accounts = listAccounts(s.ctx, s.budget.id);
+		for (const account of accounts) decode('AccountSummary', account);
+		const checking = accounts.find((a) => a.id === s.checking.id);
+		expect(checking?.balance).toBe(95000); // 100000 income − 5000 spend
+	});
+
+	it('listCategories rows decode against Category', () => {
+		for (const category of listCategories(s.ctx, s.budget.id)) decode('Category', category);
+	});
+
+	it('getEnvelopeView decodes against EnvelopeView', () => {
+		decode('EnvelopeView', getEnvelopeView(s.ctx, s.budget.id, month));
+	});
+
+	it('a read against an inaccessible budget is a 404', () => {
+		expect(() => listAccounts(s.ctx, 'budget_missing')).toThrowError(
+			expect.objectContaining({ status: 404 })
+		);
+		expect(() => getEnvelopeView(s.ctx, 'budget_missing', month)).toThrowError(
+			expect.objectContaining({ status: 404 })
+		);
+	});
+});
+
+describe('transaction writes carry a fat response', () => {
+	it('a categorised capture returns the affected category and account', () => {
+		const result = createTransaction(
+			s.ctx,
+			s.user.id,
+			{
+				accountId: s.checking.id,
+				amount: -2000,
+				budgetId: s.budget.id,
+				categoryId: s.fun.id,
+				validated: false
+			},
+			month
+		);
+		decode('TransactionWriteResult', result);
+		expect(result.envelope.categories.map((c) => c.categoryId)).toEqual([s.fun.id]);
+		expect(result.accounts).toEqual([{ accountId: s.checking.id, balance: 93000 }]);
+	});
+
+	it('an income capture (no category) leaves envelope.categories empty', () => {
+		const result = createTransaction(
+			s.ctx,
+			s.user.id,
+			{ accountId: s.savings.id, amount: 5000, budgetId: s.budget.id, validated: false },
+			month
+		);
+		decode('TransactionWriteResult', result);
+		expect(result.envelope.categories).toEqual([]);
+		expect(result.transaction.categoryId).toBeNull();
+	});
+
+	it('an edit that moves a transaction between categories reports both', () => {
+		const result = editTransaction(
+			s.ctx,
+			s.spend.id,
+			{ categoryId: s.fun.id, validated: false },
+			month
+		);
+		decode('TransactionWriteResult', result);
+		expect(new Set(result.envelope.categories.map((c) => c.categoryId))).toEqual(
+			new Set([s.fun.id, s.groceries.id])
+		);
+	});
+
+	it('a delete returns the removed id and recomputed aggregates', () => {
+		const result = deleteTransaction(s.ctx, s.spend.id, month);
+		decode('TransactionDeleteResult', result);
+		expect(result.deletedIds).toEqual([s.spend.id]);
+	});
+
+	it('deleting a transfer leg removes both legs', () => {
+		const { from } = createTransfer(s.ctx, {
+			amount: 3000,
+			budgetId: s.budget.id,
+			fromAccountId: s.checking.id,
+			toAccountId: s.savings.id
+		});
+		const result = deleteTransaction(s.ctx, from.id, month);
+		decode('TransactionDeleteResult', result);
+		expect(result.deletedIds.length).toBe(2);
+	});
+});
+
+describe('assignments', () => {
+	it('setAssignment returns an EnvelopeDelta for the affected category', () => {
+		const delta = setAssignment(s.ctx, {
+			amount: 30000,
+			budgetId: s.budget.id,
+			categoryId: s.fun.id,
+			month
+		});
+		decode('EnvelopeDelta', delta);
+		expect(delta.categories.map((c) => c.categoryId)).toEqual([s.fun.id]);
+		expect(delta.categories[0].assigned).toBe(30000);
+	});
+
+	it('reassign to another category reports both; to Unassigned reports one', () => {
+		const moved = reassign(s.ctx, {
+			amount: 5000,
+			budgetId: s.budget.id,
+			month,
+			sourceCategoryId: s.groceries.id,
+			targetCategoryId: s.fun.id
+		});
+		decode('EnvelopeDelta', moved);
+		expect(new Set(moved.categories.map((c) => c.categoryId))).toEqual(
+			new Set([s.fun.id, s.groceries.id])
+		);
+
+		const returned = reassign(s.ctx, {
+			amount: 5000,
+			budgetId: s.budget.id,
+			month,
+			sourceCategoryId: s.groceries.id,
+			targetCategoryId: null
+		});
+		decode('EnvelopeDelta', returned);
+		expect(returned.categories.map((c) => c.categoryId)).toEqual([s.groceries.id]);
+	});
+});
+
+describe('transfers', () => {
+	it('createTransfer returns both legs and two account balances', () => {
+		const result = createTransfer(s.ctx, {
+			amount: 3000,
+			budgetId: s.budget.id,
+			fromAccountId: s.checking.id,
+			toAccountId: s.savings.id
+		});
+		decode('TransferResult', result);
+		expect(result.from.amount).toBe(-3000);
+		expect(result.to.amount).toBe(3000);
+		expect(result.accounts).toEqual([
+			{ accountId: s.checking.id, balance: 92000 }, // 95000 − 3000
+			{ accountId: s.savings.id, balance: 3000 }
+		]);
+	});
+
+	it('editTransfer keeps both legs consistent and decodes against TransferResult', () => {
+		const { from } = createTransfer(s.ctx, {
+			amount: 3000,
+			budgetId: s.budget.id,
+			fromAccountId: s.checking.id,
+			toAccountId: s.savings.id
+		});
+		const result = editTransfer(s.ctx, from.transferId!, { amount: 4000 });
+		decode('TransferResult', result);
+		expect(result.from.amount).toBe(-4000);
+		expect(result.to.amount).toBe(4000);
+	});
+});
+
+describe('register', () => {
+	it('listTransactions decodes against TransactionPage and TransactionListItem', () => {
+		const page = listTransactions(s.ctx, { accountId: s.checking.id, page: 1, pageSize: 15 });
+		decode('TransactionPage', page);
+		for (const row of page.rows) decode('TransactionListItem', row);
+		expect(page.total).toBe(2);
+	});
+
+	it('the register of an inaccessible account is a 404', () => {
+		expect(() =>
+			listTransactions(s.ctx, { accountId: 'account_missing', page: 1, pageSize: 15 })
+		).toThrowError(expect.objectContaining({ status: 404 }));
+	});
+});

--- a/src/lib/server/api/endpoints.ts
+++ b/src/lib/server/api/endpoints.ts
@@ -1,0 +1,301 @@
+/**
+ * Response assembly for the native-client API (map #190, ticket #195).
+ *
+ * Each function is a thin adapter over a `UserCtx`: it calls the same domain
+ * commands/queries the web app uses and shapes the result into a contract
+ * response (`src/lib/server/api/contract.ts`). All access control, validation,
+ * and persistence rules live in `user-context` — these functions add only the
+ * "fat write" bookkeeping the contract requires (map decision 5): the
+ * server-recomputed `EnvelopeDelta` and affected account balances returned
+ * inside each write's own response, so a native client never recomputes
+ * envelope math locally.
+ *
+ * `ctx` is injected rather than built here so the assembly can be unit-tested
+ * against an isolated in-memory database; the `+server.ts` routes supply the
+ * real, request-scoped context.
+ */
+
+import type { UserCtx } from '$db/user-context';
+import type { ListTransaction, TransactionSortParam } from '$db/user-context/transaction';
+import type { Month } from '$lib/utils/month';
+
+import { error } from '@sveltejs/kit';
+
+export type AssignmentBody = { amount: number; budgetId: string; categoryId: string; month: Month };
+export type ListTransactionsParams = {
+	accountId: string;
+	categoryId?: null | string[];
+	notes?: null | string;
+	page: number;
+	pageSize: number;
+	sortAccount?: 'asc' | 'desc' | null;
+	sortAmount?: 'asc' | 'desc' | null;
+	sortCategory?: 'asc' | 'desc' | null;
+	sortDate?: 'asc' | 'desc' | null;
+	sortValidated?: 'asc' | 'desc' | null;
+};
+
+export type ReassignmentBody = {
+	amount: number;
+	budgetId: string;
+	month: Month;
+	sourceCategoryId: string;
+	targetCategoryId: null | string;
+};
+
+export type TransactionCreateBody = {
+	accountId: string;
+	amount: number;
+	budgetId: string;
+	categoryId?: string;
+	date?: string;
+	notes?: string;
+	validated: boolean;
+};
+
+export type TransactionEditBody = {
+	accountId?: string;
+	amount?: number;
+	categoryId?: string;
+	date?: string;
+	notes?: string;
+	validated: boolean;
+};
+
+export type TransferCreateBody = {
+	amount: number;
+	budgetId: string;
+	date?: string;
+	fromAccountId: string;
+	notes?: string;
+	toAccountId: string;
+};
+
+export type TransferEditBody = {
+	amount?: number;
+	date?: string;
+	fromAccountId?: string;
+	notes?: null | string;
+	toAccountId?: string;
+};
+
+type AccountBalance = { accountId: string; balance: number };
+
+type CategoryBalance = {
+	activity: number;
+	assigned: number;
+	categoryId: string;
+	remaining: number;
+};
+
+export function createTransaction(
+	ctx: UserCtx,
+	userId: string,
+	body: TransactionCreateBody,
+	month: Month
+) {
+	const transaction = ctx.transaction.create({
+		accountId: body.accountId,
+		amount: body.amount,
+		budgetId: body.budgetId,
+		categoryId: body.categoryId || null,
+		createdBy: userId,
+		date: body.date,
+		notes: body.notes || null,
+		validated: body.validated
+	});
+
+	return {
+		accounts: accountBalances(ctx, [transaction.accountId]),
+		envelope: envelopeDelta(ctx, transaction.budgetId, month, [transaction.categoryId]),
+		transaction
+	};
+}
+
+export function createTransfer(ctx: UserCtx, body: TransferCreateBody) {
+	const { from, to } = ctx.transaction.transfer({
+		amount: body.amount,
+		budgetId: body.budgetId,
+		date: body.date,
+		fromAccountId: body.fromAccountId,
+		notes: body.notes ?? null,
+		toAccountId: body.toAccountId
+	});
+
+	return { accounts: accountBalances(ctx, [from.accountId, to.accountId]), from, to };
+}
+
+export function deleteTransaction(ctx: UserCtx, transactionId: string, month: Month) {
+	// Deleting a transfer leg removes both legs (ADR-0015), so more than one
+	// row can come back — an empty result means unknown/inaccessible id.
+	const deleted = ctx.transaction.delete([transactionId]);
+	if (deleted.length === 0) error(404);
+
+	return {
+		accounts: accountBalances(
+			ctx,
+			deleted.map((transaction) => transaction.accountId)
+		),
+		deletedIds: deleted.map((transaction) => transaction.id),
+		envelope: envelopeDelta(
+			ctx,
+			deleted[0].budgetId,
+			month,
+			deleted.map((transaction) => transaction.categoryId)
+		)
+	};
+}
+
+export function editTransaction(
+	ctx: UserCtx,
+	transactionId: string,
+	body: TransactionEditBody,
+	month: Month
+) {
+	// Read the pre-edit row so a category or account move can surface both
+	// sides in the fat response (the contract's "up to two" affected sets).
+	const before = ctx.transaction.byId(transactionId);
+
+	const transaction = ctx.transaction.edit(transactionId, {
+		accountId: body.accountId,
+		amount: body.amount,
+		categoryId: body.categoryId === undefined ? undefined : body.categoryId || null,
+		date: body.date,
+		notes: body.notes === undefined ? undefined : body.notes || null,
+		validated: body.validated
+	});
+
+	return {
+		accounts: accountBalances(ctx, [before.accountId, transaction.accountId]),
+		envelope: envelopeDelta(ctx, transaction.budgetId, month, [
+			before.categoryId,
+			transaction.categoryId
+		]),
+		transaction
+	};
+}
+
+export function editTransfer(ctx: UserCtx, transferId: string, body: TransferEditBody) {
+	const { from, to } = ctx.transaction.editTransfer(transferId, {
+		amount: body.amount,
+		date: body.date,
+		fromAccountId: body.fromAccountId,
+		notes: body.notes,
+		toAccountId: body.toAccountId
+	});
+
+	return { accounts: accountBalances(ctx, [from.accountId, to.accountId]), from, to };
+}
+
+export function getEnvelopeView(ctx: UserCtx, budgetId: string, month: Month) {
+	ctx.budget.byId(budgetId); // 404 for an unknown or inaccessible budget.
+	return {
+		categories: ctx.budget.monthly(budgetId, month),
+		month,
+		unassigned: ctx.budget.unassigned(budgetId, month)
+	};
+}
+
+export function listAccounts(ctx: UserCtx, budgetId: string) {
+	ctx.budget.byId(budgetId); // 404 for an unknown or inaccessible budget.
+	return ctx.account.all(budgetId);
+}
+
+export function listBudgets(ctx: UserCtx) {
+	return ctx.budget.all();
+}
+
+export function listCategories(ctx: UserCtx, budgetId: string) {
+	ctx.budget.byId(budgetId); // 404 for an unknown or inaccessible budget.
+	return ctx.category.all(budgetId);
+}
+
+export function listTransactions(ctx: UserCtx, params: ListTransactionsParams) {
+	ctx.account.byId(params.accountId); // 404 for an unknown or inaccessible account.
+
+	const filter = {
+		accountId: params.accountId,
+		...(params.categoryId?.length ? { categoryId: params.categoryId } : {}),
+		...(params.notes ? { notes: params.notes } : {})
+	};
+
+	const sort: TransactionSortParam = {
+		...(params.sortCategory ? { category: params.sortCategory } : {}),
+		...(params.sortAccount ? { account: params.sortAccount } : {}),
+		...(params.sortDate ? { date: params.sortDate } : {}),
+		...(params.sortAmount ? { amount: params.sortAmount } : {}),
+		...(params.sortValidated ? { validated: params.sortValidated } : {})
+	};
+
+	// The API paginates from page 1; the domain query is zero-based.
+	const { rows, total } = ctx.transaction.page(filter, sort, {
+		page: params.page - 1,
+		pageSize: params.pageSize
+	});
+
+	return { rows, total };
+}
+
+export function reassign(ctx: UserCtx, body: ReassignmentBody) {
+	ctx.budget.reassignment({
+		amount: body.amount,
+		budgetId: body.budgetId,
+		month: body.month,
+		sourceCategoryId: body.sourceCategoryId,
+		targetCategoryId: body.targetCategoryId
+	});
+	return envelopeDelta(ctx, body.budgetId, body.month, [
+		body.sourceCategoryId,
+		body.targetCategoryId
+	]);
+}
+
+export function setAssignment(ctx: UserCtx, body: AssignmentBody) {
+	ctx.budget.assignment({
+		amount: body.amount,
+		budgetId: body.budgetId,
+		categoryId: body.categoryId,
+		month: body.month
+	});
+	return envelopeDelta(ctx, body.budgetId, body.month, [body.categoryId]);
+}
+
+/** Recomputed all-time balances of the given accounts (deduplicated). */
+function accountBalances(ctx: UserCtx, accountIds: string[]): AccountBalance[] {
+	return [...new Set(accountIds)].map((id) => {
+		const account = ctx.account.byId(id);
+		return { accountId: account.id, balance: account.balance };
+	});
+}
+
+/**
+ * The `EnvelopeDelta` every write carries: `unassigned` recomputed for the
+ * client's viewed month, plus the month-scoped balances of the affected
+ * categories only (nulls — income legs — drop out, leaving `categories` empty
+ * for a pure income write).
+ */
+function envelopeDelta(
+	ctx: UserCtx,
+	budgetId: string,
+	month: Month,
+	affectedCategoryIds: (null | string)[]
+) {
+	const affected = new Set(affectedCategoryIds.filter((id): id is string => id !== null));
+
+	const categories: CategoryBalance[] = affected.size
+		? ctx.budget
+				.monthly(budgetId, month)
+				.filter((category) => affected.has(category.id))
+				.map((category) => ({
+					activity: category.activity,
+					assigned: category.assigned,
+					categoryId: category.id,
+					remaining: category.remaining
+				}))
+		: [];
+
+	return { categories, month, unassigned: ctx.budget.unassigned(budgetId, month) };
+}
+
+/** Re-exported for tests that assert against the register row shape. */
+export type { ListTransaction };

--- a/src/lib/server/api/guard.test.ts
+++ b/src/lib/server/api/guard.test.ts
@@ -1,0 +1,44 @@
+import type { RequestEvent } from '@sveltejs/kit';
+
+import { error } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+
+import { withApi } from './guard';
+
+/** A minimal event carrying only what `withApi` reads. */
+function makeEvent(options: { header?: string; user?: null | { id: string } } = {}): RequestEvent {
+	const headers = new Headers();
+	if (options.header) headers.set('x-genug-client', options.header);
+	return {
+		locals: { user: options.user ?? null },
+		request: new Request('http://localhost/api/v1/budgets', { headers })
+	} as unknown as RequestEvent;
+}
+
+describe('withApi', () => {
+	it('rejects a request without a valid token as 401 unauthorized', async () => {
+		const handler = withApi(async () => ({ body: { ok: true }, status: 200 }));
+		const response = await handler(makeEvent({ user: null }));
+		expect(response.status).toBe(401);
+		expect(((await response.json()) as { code: string }).code).toBe('unauthorized');
+	});
+
+	it('runs the handler and serialises its body for an authenticated request', async () => {
+		const handler = withApi(async ({ user }) => ({ body: { userId: user.id }, status: 200 }));
+		const response = await handler(makeEvent({ user: { id: 'user_1' } }));
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ userId: 'user_1' });
+	});
+
+	it('translates a thrown domain error into the contract error envelope', async () => {
+		const handler = withApi(async () => {
+			error(404, 'nope');
+		});
+		const response = await handler(makeEvent({ user: { id: 'user_1' } }));
+		expect(response.status).toBe(404);
+		expect((await response.json()) as { code: string; message: string }).toEqual({
+			code: 'not_found',
+			message: 'nope'
+		});
+	});
+});

--- a/src/lib/server/api/guard.ts
+++ b/src/lib/server/api/guard.ts
@@ -1,0 +1,44 @@
+/**
+ * Auth, client-version, and error boundary shared by every native-client
+ * route (map #190, ticket #195). Wrapping a handler in `withApi` keeps the
+ * `+server.ts` files thin: they parse their params and body, then return a
+ * status + body; this wrapper owns everything cross-cutting.
+ *
+ * Authentication is the `Bearer` path `hooks.server.ts` already populates —
+ * a valid PAT sets `locals.user` (with `locals.session === null`); a missing
+ * or invalid token leaves it null and earns a 401 here. Access control below
+ * the user is still enforced inside `user-context` by `accessGuard()` /
+ * `ownerGuard()`, exactly as for the web app.
+ */
+
+import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+
+import { database } from '$db';
+import { createUserCtx, type UserCtx } from '$db/user-context';
+import { json } from '@sveltejs/kit';
+
+import { apiError, clientVersionIssue, toErrorResponse } from './respond';
+
+type ApiHandler = (args: {
+	ctx: UserCtx;
+	event: RequestEvent;
+	user: NonNullable<App.Locals['user']>;
+}) => Promise<{ body: unknown; status: number }>;
+
+export function withApi(handler: ApiHandler): RequestHandler {
+	return async (event) => {
+		const versionIssue = clientVersionIssue(event.request.headers.get('x-genug-client'));
+		if (versionIssue) return apiError(426, 'client_upgrade_required', versionIssue);
+
+		const user = event.locals.user;
+		if (!user) return apiError(401, 'unauthorized', 'Missing, invalid, expired, or revoked token.');
+
+		try {
+			const ctx = createUserCtx(user.id, database);
+			const { body, status } = await handler({ ctx, event, user });
+			return json(body, { status });
+		} catch (err) {
+			return toErrorResponse(err, event.locals.logger);
+		}
+	};
+}

--- a/src/lib/server/api/respond.test.ts
+++ b/src/lib/server/api/respond.test.ts
@@ -1,0 +1,100 @@
+import { m } from '$lib/paraglide/messages';
+import { error, isHttpError } from '@sveltejs/kit';
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+
+import { clientVersionIssue, parseMonthOrThrow, toErrorResponse } from './respond';
+
+describe('clientVersionIssue', () => {
+	it('allows a missing header (the gate is optional)', () => {
+		expect(clientVersionIssue(null)).toBeNull();
+		expect(clientVersionIssue('')).toBeNull();
+	});
+
+	it('allows any well-formed version when no minimum is configured', () => {
+		expect(clientVersionIssue('ios/2026.7.0', {})).toBeNull();
+	});
+
+	it('rejects a version below its platform minimum', () => {
+		expect(clientVersionIssue('ios/1.0.0', { ios: '2.0.0' })).toContain('below');
+	});
+
+	it('allows a version at or above the minimum', () => {
+		expect(clientVersionIssue('ios/2.0.0', { ios: '2.0.0' })).toBeNull();
+		expect(clientVersionIssue('ios/2.1', { ios: '2.0.0' })).toBeNull();
+	});
+
+	it('ignores an unknown platform and a malformed header', () => {
+		expect(clientVersionIssue('android/1.0.0', { ios: '2.0.0' })).toBeNull();
+		expect(clientVersionIssue('garbage', { ios: '2.0.0' })).toBeNull();
+	});
+});
+
+describe('toErrorResponse', () => {
+	async function bodyOf(err: unknown) {
+		const response = toErrorResponse(err);
+		return { body: (await response.json()) as { code: string; message: string }, response };
+	}
+
+	it('maps a valibot failure to a 400 validation_error', async () => {
+		let err: unknown;
+		try {
+			v.parse(v.string(), 123);
+		} catch (thrown) {
+			err = thrown;
+		}
+		expect(v.isValiError(err)).toBe(true);
+		const { body, response } = await bodyOf(err);
+		expect(response.status).toBe(400);
+		expect(body.code).toBe('validation_error');
+	});
+
+	it('keeps an HttpError status and derives a status-based code', async () => {
+		let thrown: unknown;
+		try {
+			error(404);
+		} catch (err) {
+			thrown = err;
+		}
+		expect(isHttpError(thrown)).toBe(true);
+		const { body, response } = await bodyOf(thrown);
+		expect(response.status).toBe(404);
+		expect(body.code).toBe('not_found');
+	});
+
+	it('maps the named domain rules to their stable codes', async () => {
+		let archived: unknown;
+		try {
+			error(400, m.error_account_archived());
+		} catch (err) {
+			archived = err;
+		}
+		expect((await bodyOf(archived)).body.code).toBe('account_archived');
+
+		let transferLeg: unknown;
+		try {
+			error(400, m.error_transaction_is_transfer_leg());
+		} catch (err) {
+			transferLeg = err;
+		}
+		expect((await bodyOf(transferLeg)).body.code).toBe('transaction_is_transfer_leg');
+	});
+
+	it('wraps an unexpected error as a 500 internal_error', async () => {
+		const { body, response } = await bodyOf(new Error('boom'));
+		expect(response.status).toBe(500);
+		expect(body.code).toBe('internal_error');
+	});
+});
+
+describe('parseMonthOrThrow', () => {
+	it('parses a valid YYYYMM', () => {
+		expect(parseMonthOrThrow('202501')).toBe(202501);
+	});
+
+	it('rejects a missing or out-of-range month with a 400', () => {
+		expect(() => parseMonthOrThrow(null)).toThrow();
+		expect(() => parseMonthOrThrow('202513')).toThrow();
+		expect(() => parseMonthOrThrow('nope')).toThrow();
+	});
+});

--- a/src/lib/server/api/respond.ts
+++ b/src/lib/server/api/respond.ts
@@ -1,0 +1,129 @@
+/**
+ * HTTP plumbing for the additive native-client API (map #190, ticket #195).
+ *
+ * The web app answers through remote functions; this surface is a parallel
+ * transport of `+server.ts` routes over the same `user-context`. Everything
+ * these helpers do is presentation: the error envelope the contract promises
+ * (`{ code, message }`), the optional client-version gate, and the `Month`
+ * query/path parsing shared across the write endpoints. No business rules
+ * live here — those stay in `user-context`.
+ */
+
+import type { Logger } from 'pino';
+
+import { m } from '$lib/paraglide/messages';
+import { type Month, parseMonth } from '$lib/utils/month';
+import { error, isHttpError, json } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+/** The contract's `Error` schema (`src/lib/server/api/contract.ts`). */
+export type ErrorEnvelope = { code: string; message: string };
+
+/**
+ * Minimum supported client version per platform (`X-Genug-Client` value's
+ * `<platform>` half). Empty until a native client actually ships and an old
+ * build needs locking out; the 426 mechanism exists now so the contract's
+ * `client_upgrade_required` path is real and testable (map decision 15).
+ */
+export const MINIMUM_CLIENT_VERSIONS: Record<string, string> = {};
+
+export function apiError(status: number, code: string, message: string): Response {
+	return json({ code, message } satisfies ErrorEnvelope, { status });
+}
+
+export const ok = (body: unknown) => ({ body, status: 200 });
+export const created = (body: unknown) => ({ body, status: 201 });
+
+/**
+ * The `X-Genug-Client` gate. The header is optional (generated clients inject
+ * it via middleware, older callers may omit it), so a missing or malformed
+ * value passes; only a present, well-formed version below its platform's
+ * minimum is rejected. Returns the 426 message, or `null` to allow.
+ */
+export function clientVersionIssue(
+	header: null | string,
+	minimums: Record<string, string> = MINIMUM_CLIENT_VERSIONS
+): null | string {
+	if (!header) return null;
+
+	const match = /^([a-z-]+)\/([0-9][A-Za-z0-9.-]*)$/.exec(header);
+	if (!match) return null;
+
+	const [, platform, version] = match;
+	const minimum = minimums[platform];
+	if (minimum && compareVersions(version, minimum) < 0) {
+		return `Client ${header} is below the supported minimum ${platform}/${minimum}.`;
+	}
+	return null;
+}
+
+/**
+ * Parse a `Month` from a path or query value, rejecting anything outside the
+ * `YYYYMM` range with a 400 — the domain queries assume a valid `Month`.
+ */
+export function parseMonthOrThrow(value: null | string): Month {
+	const month = value === null ? null : parseMonth(value);
+	if (month === null) error(400, 'Invalid or missing month; expected YYYYMM.');
+	return month;
+}
+
+/**
+ * Translate a thrown error into the contract's `{ code, message }` envelope.
+ * Valibot failures are 400s; SvelteKit `HttpError`s keep their status and
+ * message and gain a stable `code`; anything else is a logged 500.
+ */
+export function toErrorResponse(err: unknown, logger?: Logger): Response {
+	if (v.isValiError(err)) {
+		return apiError(400, 'validation_error', err.issues[0]?.message ?? 'Invalid request body.');
+	}
+
+	if (isHttpError(err)) {
+		const message =
+			err.body && typeof err.body === 'object' && 'message' in err.body
+				? String(err.body.message)
+				: String(err.body);
+		return apiError(err.status, codeForHttpError(err.status, message), message);
+	}
+
+	logger?.error({ err }, 'unhandled api error');
+	return apiError(500, 'internal_error', 'An unexpected error occurred.');
+}
+
+/**
+ * Map a domain error to a stable machine code. The two rules the contract
+ * names explicitly (`account_archived`, `transaction_is_transfer_leg`) are
+ * matched by their rendered message — the throw and this catch run in the
+ * same request, hence the same Paraglide locale, so the strings are equal.
+ * Everything else falls back to a status-derived code.
+ */
+function codeForHttpError(status: number, message: string): string {
+	if (message === m.error_account_archived()) return 'account_archived';
+	if (message === m.error_transaction_is_transfer_leg()) return 'transaction_is_transfer_leg';
+
+	switch (status) {
+		case 400:
+			return 'bad_request';
+		case 401:
+			return 'unauthorized';
+		case 403:
+			return 'forbidden';
+		case 404:
+			return 'not_found';
+		case 426:
+			return 'client_upgrade_required';
+		default:
+			return 'error';
+	}
+}
+
+/** Numeric dot-segment comparison; missing segments read as 0. */
+function compareVersions(a: string, b: string): number {
+	const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+	const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+	const len = Math.max(pa.length, pb.length);
+	for (let i = 0; i < len; i++) {
+		const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+		if (diff !== 0) return diff > 0 ? 1 : -1;
+	}
+	return 0;
+}

--- a/src/routes/api/v1/api.integration.test.ts
+++ b/src/routes/api/v1/api.integration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * End-to-end wiring for the native API (ticket #195): a real PAT is issued and
+ * validated exactly as `hooks.server.ts` does, then fed to the `+server.ts`
+ * handlers to prove the Bearer path reaches `user-context` and serialises a
+ * contract response. The per-endpoint response shapes are covered against the
+ * published schemas in `src/lib/server/api/endpoints.test.ts`; this asserts the
+ * glue — auth, params, status codes, and the JSON body.
+ */
+
+import type { RequestEvent, RequestHandler } from '@sveltejs/kit';
+
+import { database, tables } from '$db';
+import { createApiToken, validateApiToken } from '$db/auth/api-tokens';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { GET as getBudgets } from './budgets/+server';
+import { POST as postTransactions } from './transactions/+server';
+
+async function call(
+	handler: RequestHandler,
+	request: Request,
+	user: NonNullable<App.Locals['user']> | null
+) {
+	const event = {
+		locals: { user },
+		params: {},
+		request,
+		url: new URL(request.url)
+	} as unknown as RequestEvent;
+	return handler(event);
+}
+
+let user: NonNullable<App.Locals['user']>;
+let budgetId: string;
+let accountId: string;
+
+beforeAll(async () => {
+	const seededUser = database
+		.insert(tables.users)
+		.values({ passwordHash: 'hash', username: 'api-integration' })
+		.returning()
+		.get();
+	const budget = database.insert(tables.budgets).values({ name: 'Wallet' }).returning().get();
+	database
+		.insert(tables.usersToBudgets)
+		.values({ budgetId: budget.id, role: 'OWNER', userId: seededUser.id })
+		.run();
+	const account = database
+		.insert(tables.accounts)
+		.values({ budgetId: budget.id, name: 'Checking' })
+		.returning()
+		.get();
+
+	budgetId = budget.id;
+	accountId = account.id;
+
+	const { token } = createApiToken({ db: database, name: 'ios', userId: seededUser.id });
+	const validated = await validateApiToken({ db: database, token });
+	expect(validated?.id).toBe(seededUser.id);
+	user = validated!;
+});
+
+describe('native API routes over the Bearer path', () => {
+	it('GET /budgets returns 401 without a token', async () => {
+		const response = await call(getBudgets, new Request('http://localhost/api/v1/budgets'), null);
+		expect(response.status).toBe(401);
+	});
+
+	it('GET /budgets lists the token user’s budgets', async () => {
+		const response = await call(getBudgets, new Request('http://localhost/api/v1/budgets'), user);
+		expect(response.status).toBe(200);
+		const budgets = (await response.json()) as { id: string; name: string }[];
+		expect(budgets.map((b) => b.id)).toContain(budgetId);
+	});
+
+	it('POST /transactions?month= captures and returns the fat write result', async () => {
+		const request = new Request('http://localhost/api/v1/transactions?month=202501', {
+			body: JSON.stringify({ accountId, amount: 100000, budgetId }),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		});
+		const response = await call(postTransactions, request, user);
+		expect(response.status).toBe(201);
+		const result = (await response.json()) as {
+			accounts: { accountId: string; balance: number }[];
+			transaction: { amount: number; categoryId: null | string };
+		};
+		expect(result.transaction.amount).toBe(100000);
+		expect(result.accounts).toEqual([{ accountId, balance: 100000 }]);
+	});
+
+	it('POST /transactions rejects a malformed month with 400', async () => {
+		const request = new Request('http://localhost/api/v1/transactions?month=nope', {
+			body: JSON.stringify({ accountId, amount: 100, budgetId }),
+			headers: { 'content-type': 'application/json' },
+			method: 'POST'
+		});
+		const response = await call(postTransactions, request, user);
+		expect(response.status).toBe(400);
+	});
+});

--- a/src/routes/api/v1/assignments/+server.ts
+++ b/src/routes/api/v1/assignments/+server.ts
@@ -1,0 +1,10 @@
+import { AssignmentSchema } from '$lib/schemas/budget';
+import { setAssignment } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+import * as v from 'valibot';
+
+export const POST = withApi(async ({ ctx, event }) => {
+	const body = v.parse(AssignmentSchema, await event.request.json());
+	return ok(setAssignment(ctx, body));
+});

--- a/src/routes/api/v1/budgets/+server.ts
+++ b/src/routes/api/v1/budgets/+server.ts
@@ -1,0 +1,5 @@
+import { listBudgets } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+
+export const GET = withApi(async ({ ctx }) => ok(listBudgets(ctx)));

--- a/src/routes/api/v1/budgets/[budgetId]/accounts/+server.ts
+++ b/src/routes/api/v1/budgets/[budgetId]/accounts/+server.ts
@@ -1,0 +1,5 @@
+import { listAccounts } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+
+export const GET = withApi(async ({ ctx, event }) => ok(listAccounts(ctx, event.params.budgetId!)));

--- a/src/routes/api/v1/budgets/[budgetId]/categories/+server.ts
+++ b/src/routes/api/v1/budgets/[budgetId]/categories/+server.ts
@@ -1,0 +1,7 @@
+import { listCategories } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+
+export const GET = withApi(async ({ ctx, event }) =>
+	ok(listCategories(ctx, event.params.budgetId!))
+);

--- a/src/routes/api/v1/budgets/[budgetId]/months/[month]/envelope/+server.ts
+++ b/src/routes/api/v1/budgets/[budgetId]/months/[month]/envelope/+server.ts
@@ -1,0 +1,8 @@
+import { getEnvelopeView } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok, parseMonthOrThrow } from '$server/api/respond';
+
+export const GET = withApi(async ({ ctx, event }) => {
+	const month = parseMonthOrThrow(event.params.month ?? null);
+	return ok(getEnvelopeView(ctx, event.params.budgetId!, month));
+});

--- a/src/routes/api/v1/reassignments/+server.ts
+++ b/src/routes/api/v1/reassignments/+server.ts
@@ -1,0 +1,10 @@
+import { ApiReassignmentSchema } from '$lib/schemas/api';
+import { reassign } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+import * as v from 'valibot';
+
+export const POST = withApi(async ({ ctx, event }) => {
+	const body = v.parse(ApiReassignmentSchema, await event.request.json());
+	return ok(reassign(ctx, body));
+});

--- a/src/routes/api/v1/transactions/+server.ts
+++ b/src/routes/api/v1/transactions/+server.ts
@@ -1,0 +1,29 @@
+import { ListTransactionsSchema, TransactionCreateSchema } from '$lib/schemas/transaction';
+import { createTransaction, listTransactions } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { created, ok, parseMonthOrThrow } from '$server/api/respond';
+import * as v from 'valibot';
+
+export const GET = withApi(async ({ ctx, event }) => {
+	const search = event.url.searchParams;
+	const params = v.parse(ListTransactionsSchema, {
+		accountId: search.get('accountId') ?? undefined,
+		categoryId: search.getAll('categoryId'),
+		notes: search.get('notes') ?? undefined,
+		page: search.get('page') ?? undefined,
+		pageSize: search.get('pageSize') ?? undefined,
+		sortAccount: search.get('sortAccount') ?? undefined,
+		sortAmount: search.get('sortAmount') ?? undefined,
+		sortCategory: search.get('sortCategory') ?? undefined,
+		sortDate: search.get('sortDate') ?? undefined,
+		sortValidated: search.get('sortValidated') ?? undefined
+	});
+
+	return ok(listTransactions(ctx, params));
+});
+
+export const POST = withApi(async ({ ctx, event, user }) => {
+	const month = parseMonthOrThrow(event.url.searchParams.get('month'));
+	const body = v.parse(TransactionCreateSchema, await event.request.json());
+	return created(createTransaction(ctx, user.id, body, month));
+});

--- a/src/routes/api/v1/transactions/[transactionId]/+server.ts
+++ b/src/routes/api/v1/transactions/[transactionId]/+server.ts
@@ -1,0 +1,20 @@
+import { TransactionEditSchema } from '$lib/schemas/transaction';
+import { deleteTransaction, editTransaction } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok, parseMonthOrThrow } from '$server/api/respond';
+import * as v from 'valibot';
+
+// The transaction id travels in the path, not the body (matches the derived
+// `TransactionEdit` request schema in the OpenAPI contract).
+const EditBodySchema = v.omit(TransactionEditSchema, ['transactionId']);
+
+export const PATCH = withApi(async ({ ctx, event }) => {
+	const month = parseMonthOrThrow(event.url.searchParams.get('month'));
+	const body = v.parse(EditBodySchema, await event.request.json());
+	return ok(editTransaction(ctx, event.params.transactionId!, body, month));
+});
+
+export const DELETE = withApi(async ({ ctx, event }) => {
+	const month = parseMonthOrThrow(event.url.searchParams.get('month'));
+	return ok(deleteTransaction(ctx, event.params.transactionId!, month));
+});

--- a/src/routes/api/v1/transfers/+server.ts
+++ b/src/routes/api/v1/transfers/+server.ts
@@ -1,0 +1,10 @@
+import { ApiTransferCreateSchema } from '$lib/schemas/api';
+import { createTransfer } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { created } from '$server/api/respond';
+import * as v from 'valibot';
+
+export const POST = withApi(async ({ ctx, event }) => {
+	const body = v.parse(ApiTransferCreateSchema, await event.request.json());
+	return created(createTransfer(ctx, body));
+});

--- a/src/routes/api/v1/transfers/[transferId]/+server.ts
+++ b/src/routes/api/v1/transfers/[transferId]/+server.ts
@@ -1,0 +1,10 @@
+import { ApiTransferEditSchema } from '$lib/schemas/api';
+import { editTransfer } from '$server/api/endpoints';
+import { withApi } from '$server/api/guard';
+import { ok } from '$server/api/respond';
+import * as v from 'valibot';
+
+export const PATCH = withApi(async ({ ctx, event }) => {
+	const body = v.parse(ApiTransferEditSchema, await event.request.json());
+	return ok(editTransfer(ctx, event.params.transferId!, body));
+});


### PR DESCRIPTION
Closes #195. Part of the additive-API map (#190), Phase 1.

Implements the iOS MVP HTTP API as `+server.ts` routes under `/api/v1` — a
second transport over the same `createUserCtx(userId)` the web app already
uses. The web app and its remote functions are untouched; this is additive
(map decision 3). Using `+server.ts` here deliberately breaks the repo's
remote-functions-first rule for the cross-client surface, as sanctioned by the
map's CLAUDE.md-override note.

## Surface (12 operations, per `docs/api/openapi.yaml`)

- `GET /budgets`, `/budgets/{id}/accounts`, `/budgets/{id}/categories`
- `GET /budgets/{id}/months/{month}/envelope`
- `GET /transactions` — paged, filtered, sorted register
- `POST` / `PATCH` / `DELETE /transactions/{id}`
- `POST /transfers`, `PATCH /transfers/{id}`
- `POST /assignments`, `POST /reassignments`

## Design

- **Thin routes.** Each `+server.ts` parses its params/body, validates against
  the existing valibot schemas (the same ones the OpenAPI request bodies derive
  from, so requests can't drift from server validation), and delegates to a
  `ctx`-injected assembly layer (`endpoints.ts`) that is unit-testable against
  an isolated in-memory DB. Business rules, `accessGuard`/`ownerGuard`, and
  persistence stay in `user-context`.
- **Fat writes (map decision 5).** Every write returns the server-recomputed
  `EnvelopeDelta` for the client's `?month=` plus the affected account
  balances, so a native client never recomputes envelope math locally.
  Transfers carry balances only — budget-neutral, no envelope (ADR-0015).
- **Cross-cutting `withApi` wrapper.** PAT `Bearer` auth (401), the optional
  `X-Genug-Client` version gate (the 426 mechanism exists; no minimums are
  configured until a client ships), and a `{ code, message }` error envelope
  that maps domain `HttpError`s and valibot failures to stable codes.

## Testing

- `endpoints.test.ts` — assembly responses assembled from real `user-context`
  output and decoded against the **published contract schemas** (the referee
  named in #195): entity, register, write-result, transfer, and envelope
  families.
- `respond.test.ts` / `guard.test.ts` — version gate, error mapping, auth.
- `api.integration.test.ts` — a route-level pass through the real PAT
  validation path with `Bearer` tokens.

Full unit suite green; `npm run check` and `npm run lint` clean.
