### PR TITLE
fix: carry API error code on the throw body; drop deprecated toThrowError

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,6 +5,8 @@ declare global {
 		type Database = import('$db').Database;
 
 		interface Error {
+			/** Stable machine code for the native-client API envelope (`src/lib/server/api/respond.ts`). */
+			code?: string;
 			logId?: string;
 			message: string;
 		}

--- a/src/lib/server/api/endpoints.test.ts
+++ b/src/lib/server/api/endpoints.test.ts
@@ -133,10 +133,10 @@ describe('reference + envelope reads', () => {
 	});
 
 	it('a read against an inaccessible budget is a 404', () => {
-		expect(() => listAccounts(s.ctx, 'budget_missing')).toThrowError(
+		expect(() => listAccounts(s.ctx, 'budget_missing')).toThrow(
 			expect.objectContaining({ status: 404 })
 		);
-		expect(() => getEnvelopeView(s.ctx, 'budget_missing', month)).toThrowError(
+		expect(() => getEnvelopeView(s.ctx, 'budget_missing', month)).toThrow(
 			expect.objectContaining({ status: 404 })
 		);
 	});
@@ -285,6 +285,6 @@ describe('register', () => {
 	it('the register of an inaccessible account is a 404', () => {
 		expect(() =>
 			listTransactions(s.ctx, { accountId: 'account_missing', page: 1, pageSize: 15 })
-		).toThrowError(expect.objectContaining({ status: 404 }));
+		).toThrow(expect.objectContaining({ status: 404 }));
 	});
 });

--- a/src/lib/server/api/respond.test.ts
+++ b/src/lib/server/api/respond.test.ts
@@ -62,22 +62,16 @@ describe('toErrorResponse', () => {
 		expect(body.code).toBe('not_found');
 	});
 
-	it('maps the named domain rules to their stable codes', async () => {
+	it('carries a stable code set on the error body through the envelope', async () => {
 		let archived: unknown;
 		try {
-			error(400, m.error_account_archived());
+			error(400, { code: 'account_archived', message: m.error_account_archived() });
 		} catch (err) {
 			archived = err;
 		}
-		expect((await bodyOf(archived)).body.code).toBe('account_archived');
-
-		let transferLeg: unknown;
-		try {
-			error(400, m.error_transaction_is_transfer_leg());
-		} catch (err) {
-			transferLeg = err;
-		}
-		expect((await bodyOf(transferLeg)).body.code).toBe('transaction_is_transfer_leg');
+		const { body } = await bodyOf(archived);
+		expect(body.code).toBe('account_archived');
+		expect(body.message).toBe(m.error_account_archived());
 	});
 
 	it('wraps an unexpected error as a 500 internal_error', async () => {

--- a/src/lib/server/api/respond.ts
+++ b/src/lib/server/api/respond.ts
@@ -11,7 +11,6 @@
 
 import type { Logger } from 'pino';
 
-import { m } from '$lib/paraglide/messages';
 import { type Month, parseMonth } from '$lib/utils/month';
 import { error, isHttpError, json } from '@sveltejs/kit';
 import * as v from 'valibot';
@@ -78,11 +77,14 @@ export function toErrorResponse(err: unknown, logger?: Logger): Response {
 	}
 
 	if (isHttpError(err)) {
-		const message =
-			err.body && typeof err.body === 'object' && 'message' in err.body
-				? String(err.body.message)
-				: String(err.body);
-		return apiError(err.status, codeForHttpError(err.status, message), message);
+		const body: unknown = err.body;
+		const hasObjectBody = typeof body === 'object' && body !== null;
+		const message = hasObjectBody && 'message' in body ? String(body.message) : String(err.body);
+		const code =
+			hasObjectBody && 'code' in body && typeof body.code === 'string'
+				? body.code
+				: codeForStatus(err.status);
+		return apiError(err.status, code, message);
 	}
 
 	logger?.error({ err }, 'unhandled api error');
@@ -90,16 +92,12 @@ export function toErrorResponse(err: unknown, logger?: Logger): Response {
 }
 
 /**
- * Map a domain error to a stable machine code. The two rules the contract
- * names explicitly (`account_archived`, `transaction_is_transfer_leg`) are
- * matched by their rendered message — the throw and this catch run in the
- * same request, hence the same Paraglide locale, so the strings are equal.
- * Everything else falls back to a status-derived code.
+ * Fallback machine code for an `HttpError` that didn't carry an explicit
+ * `code` on its body. Domain rules that need a stable code (e.g.
+ * `account_archived`, `transaction_is_transfer_leg`) set it at the throw site
+ * via `error(status, { code, message })`; everything else lands here.
  */
-function codeForHttpError(status: number, message: string): string {
-	if (message === m.error_account_archived()) return 'account_archived';
-	if (message === m.error_transaction_is_transfer_leg()) return 'transaction_is_transfer_leg';
-
+function codeForStatus(status: number): string {
 	switch (status) {
 		case 400:
 			return 'bad_request';

--- a/src/lib/server/db/user-context/transaction.ts
+++ b/src/lib/server/db/user-context/transaction.ts
@@ -169,7 +169,11 @@ export const commands = (userId: string, db: Database = database) => ({
 		if (!existing) error(404);
 		// Editing a single leg is ambiguous — transfers change through
 		// editTransfer, which keeps both legs consistent (ADR-0015).
-		if (existing.transferId) error(400, m.error_transaction_is_transfer_leg());
+		if (existing.transferId)
+			error(400, {
+				code: 'transaction_is_transfer_leg',
+				message: m.error_transaction_is_transfer_leg()
+			});
 
 		const data = { ...update, validated: update.validated ?? false };
 		const updated = db
@@ -324,7 +328,8 @@ function activeAccountGuard(db: Database, budgetId: string, accountId: string) {
 		.where(and(eq(tables.accounts.id, accountId), eq(tables.accounts.budgetId, budgetId)))
 		.get();
 	if (!account) error(404, m.error_account_not_found());
-	if (account.archivedAt) error(400, m.error_account_archived());
+	if (account.archivedAt)
+		error(400, { code: 'account_archived', message: m.error_account_archived() });
 }
 
 function escapeLikePattern(term: string) {


### PR DESCRIPTION
Post-merge review fixes for #209.

## Review points addressed

1. **`codeForHttpError` smelled** — it matched the two named domain rules by their *rendered i18n message* (`message === m.error_account_archived()`). That reverse-lookup is fragile: it silently breaks the moment a translation string is edited, and it couples the transport layer to the exact message text.

   Instead, the code is now set **at the throw site** on the SvelteKit error body:

   ```ts
   error(400, { code: 'account_archived', message: m.error_account_archived() });
   ```

   The transport reads `body.code` directly and falls back to a status-derived code (`codeForStatus`) for everything else. `App.Error` gains an optional `code` field. Behaviour is identical — the same codes come out — but the mapping is now driven by the semantic at the throw, not by string-matching a localized message.

2. **`toThrowError` is deprecated** — replaced with `toThrow` in `endpoints.test.ts` (3 call sites).

## Verification

- `npm run check` — 0 errors
- `npm run test:unit` (respond, endpoints, transaction suites) — all pass
- lint clean on touched files

No CHANGELOG entry: behaviour-preserving refactor + test-only deprecation fix.