### PR TITLE
fix: hide account-dropdown archived link when nothing is archived (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- The account dropdown now hides the archived-accounts link when a budget has
+  no archived accounts, instead of showing a "0 archived" link to an empty
+  page. The link reappears once an account is archived.
+
 - Category details moved from a dialog to a dedicated page. On desktop,
   clicking a category in the budget table now shows a lightweight popover with
   the viewed month's stats and a Settings link to the new page; on mobile,

--- a/src/lib/components/features/account/account-dropdown.svelte
+++ b/src/lib/components/features/account/account-dropdown.svelte
@@ -74,17 +74,19 @@
 				{m.budget_account_list_add_account()}
 			</DropdownMenu.Item>
 
-			<DropdownMenu.Item>
-				{#snippet child({ props })}
-					<a
-						href={resolve('/(app)/[budgetId=id]/accounts/archived', { budgetId: budgetId() })}
-						{...props}
-					>
-						<ArchiveIcon />
-						{m.account_archived_link({ amount: archivedAccounts.length })}
-					</a>
-				{/snippet}
-			</DropdownMenu.Item>
+			{#if archivedAccounts.length > 0}
+				<DropdownMenu.Item>
+					{#snippet child({ props })}
+						<a
+							href={resolve('/(app)/[budgetId=id]/accounts/archived', { budgetId: budgetId() })}
+							{...props}
+						>
+							<ArchiveIcon />
+							{m.account_archived_link({ amount: archivedAccounts.length })}
+						</a>
+					{/snippet}
+				</DropdownMenu.Item>
+			{/if}
 		</DropdownMenu.Group>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/tests/playwright/empty-states.spec.ts
+++ b/tests/playwright/empty-states.spec.ts
@@ -57,6 +57,8 @@ test('Empty-state guidance — canonical first-run path', async ({ page, pages }
 	await page.getByRole('button', { name: 'Show Accounts' }).click();
 	await expect(page.getByRole('menuitem', { name: accountName })).toBeVisible();
 	await expect(page.getByText('No accounts yet — add one below.')).toHaveCount(0);
+	// With no archived accounts the dropdown omits the "0 archived" link (#171).
+	await expect(page.getByRole('menuitem', { name: '0 archived' })).toHaveCount(0);
 	await page.keyboard.press('Escape');
 
 	// The footer link — now carrying the account's name — leads to the


### PR DESCRIPTION
## Summary

The account dropdown rendered the archived-accounts link unconditionally, so a budget with **no** archived accounts showed a "0 archived" link that led to an empty page — noise with no value.

This wraps the link in `{#if archivedAccounts.length > 0}` so it only appears once an account is archived. `archivedAccounts` was already loaded in the component, so there is no data-layer change.

## Category-side check

Per the issue, I checked the category equivalent (`category-quick-actions.svelte`). It already guards on `archivedCategories.length > 0`, so it does **not** have this bug and needs no change.

## Testing

- Extended `tests/playwright/empty-states.spec.ts` with an assertion that the "0 archived" menuitem is absent from the dropdown when no accounts are archived.
- `npm run check`, `npm run lint`, and `npm run test:unit` pass; the relevant Playwright specs pass (two unrelated flakes in setup/clear-filters steps confirmed green on re-run).
- `CHANGELOG.md` gains a `Changed` entry.

Closes #171