### PR TITLE
chore: enforce comment policy across the codebase (#217)

### DIFF
--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -13,7 +13,6 @@ import Root from './alert-dialog.svelte';
 
 export {
 	Action,
-	//
 	Root as AlertDialog,
 	Action as AlertDialogAction,
 	Cancel as AlertDialogCancel,

--- a/src/lib/components/ui/button-group/index.ts
+++ b/src/lib/components/ui/button-group/index.ts
@@ -3,7 +3,6 @@ import Text from './button-group-text.svelte';
 import Root, { type ButtonGroupOrientation, buttonGroupVariants } from './button-group.svelte';
 
 export {
-	//
 	Root as ButtonGroup,
 	type ButtonGroupOrientation,
 	Separator as ButtonGroupSeparator,

--- a/src/lib/components/ui/calendar/calendar-day.svelte
+++ b/src/lib/components/ui/calendar/calendar-day.svelte
@@ -17,15 +17,10 @@
 		'not-data-selected:hover:bg-muted/10 not-data-selected:hover:text-foreground',
 		'[&[data-today]:not([data-selected])]:bg-muted/5 [&[data-today]:not([data-selected])]:text-foreground [&[data-today][data-disabled]]:text-muted',
 		'data-selected:bg-info/10 data-selected:text-info data-selected:hover:text-foreground',
-		// Outside months
 		'[&[data-outside-month]:not([data-selected])]:text-muted [&[data-outside-month]:not([data-selected])]:hover:text-foreground',
-		// Disabled
 		'data-disabled:pointer-events-none data-disabled:text-muted data-disabled:opacity-50',
-		// Unavailable
 		'data-unavailable:text-muted data-unavailable:line-through',
-		// focus
 		'focus:relative',
-		// inner spans
 		'[&>span]:text-xs [&>span]:opacity-70',
 		className
 	)}

--- a/src/lib/components/ui/calendar/index.ts
+++ b/src/lib/components/ui/calendar/index.ts
@@ -18,7 +18,6 @@ import YearSelect from './calendar-year-select.svelte';
 import Root from './calendar.svelte';
 
 export {
-	//
 	Root as Calendar,
 	Caption,
 	Cell,

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,6 +1,2 @@
 import Root from './checkbox.svelte';
-export {
-	//
-	Root as Checkbox,
-	Root
-};
+export { Root as Checkbox, Root };

--- a/src/lib/components/ui/collapsible/index.ts
+++ b/src/lib/components/ui/collapsible/index.ts
@@ -3,7 +3,6 @@ import Trigger from './collapsible-trigger.svelte';
 import Root from './collapsible.svelte';
 
 export {
-	//
 	Root as Collapsible,
 	Content as CollapsibleContent,
 	Trigger as CollapsibleTrigger,

--- a/src/lib/components/ui/command/index.ts
+++ b/src/lib/components/ui/command/index.ts
@@ -11,7 +11,6 @@ import Shortcut from './command-shortcut.svelte';
 import Root from './command.svelte';
 
 export {
-	//
 	Root as Command,
 	Dialog as CommandDialog,
 	Empty as CommandEmpty,

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -15,7 +15,6 @@ export {
 	Close,
 	Content,
 	Description,
-	//
 	Root as Dialog,
 	Body as DialogBody,
 	Close as DialogClose,

--- a/src/lib/components/ui/drawer/index.ts
+++ b/src/lib/components/ui/drawer/index.ts
@@ -16,7 +16,6 @@ export {
 	Close,
 	Content,
 	Description,
-	//
 	Root as Drawer,
 	Body as DrawerBody,
 	Close as DrawerClose,

--- a/src/lib/components/ui/empty-state/index.ts
+++ b/src/lib/components/ui/empty-state/index.ts
@@ -1,7 +1,3 @@
 import Root from './empty-state.svelte';
 
-export {
-	Root as EmptyState,
-	//
-	Root
-};
+export { Root as EmptyState, Root };

--- a/src/lib/components/ui/input-group/index.ts
+++ b/src/lib/components/ui/input-group/index.ts
@@ -10,7 +10,6 @@ export {
 	Addon,
 	Button,
 	Input,
-	//
 	Root as InputGroup,
 	Addon as InputGroupAddon,
 	Button as InputGroupButton,

--- a/src/lib/components/ui/label/index.ts
+++ b/src/lib/components/ui/label/index.ts
@@ -1,7 +1,3 @@
 import Root from './label.svelte';
 
-export {
-	//
-	Root as Label,
-	Root
-};
+export { Root as Label, Root };

--- a/src/lib/components/ui/pagination/index.ts
+++ b/src/lib/components/ui/pagination/index.ts
@@ -11,15 +11,14 @@ export {
 	Ellipsis,
 	Item,
 	Link,
-	NextButton, // old
-	//
+	NextButton,
 	Root as Pagination,
 	Content as PaginationContent,
 	Ellipsis as PaginationEllipsis,
 	Item as PaginationItem,
 	Link as PaginationLink,
-	NextButton as PaginationNextButton, // old
-	PrevButton as PaginationPrevButton, // old
-	PrevButton, // old
+	NextButton as PaginationNextButton,
+	PrevButton as PaginationPrevButton,
+	PrevButton,
 	Root
 };

--- a/src/lib/components/ui/popover/index.ts
+++ b/src/lib/components/ui/popover/index.ts
@@ -12,7 +12,6 @@ export {
 	Content,
 	Description,
 	Header,
-	//
 	Root as Popover,
 	Close as PopoverClose,
 	Content as PopoverContent,

--- a/src/lib/components/ui/responsive-modal/index.ts
+++ b/src/lib/components/ui/responsive-modal/index.ts
@@ -19,7 +19,6 @@ export {
 	Header,
 	Overlay,
 	Portal,
-	//
 	Root as ResponsiveModal,
 	Body as ResponsiveModalBody,
 	Close as ResponsiveModalClose,

--- a/src/lib/components/ui/select/index.ts
+++ b/src/lib/components/ui/select/index.ts
@@ -20,7 +20,6 @@ export {
 	Root,
 	ScrollDownButton,
 	ScrollUpButton,
-	//
 	Root as Select,
 	Content as SelectContent,
 	Group as SelectGroup,

--- a/src/lib/components/ui/separator/index.ts
+++ b/src/lib/components/ui/separator/index.ts
@@ -1,7 +1,3 @@
 import Root from './separator.svelte';
 
-export {
-	Root,
-	//
-	Root as Separator
-};
+export { Root, Root as Separator };

--- a/src/lib/components/ui/table/index.ts
+++ b/src/lib/components/ui/table/index.ts
@@ -16,7 +16,6 @@ export {
 	Header,
 	Root,
 	Row,
-	//
 	Root as Table,
 	Body as TableBody,
 	Caption as TableCaption,

--- a/src/lib/components/ui/toggle-group/index.ts
+++ b/src/lib/components/ui/toggle-group/index.ts
@@ -1,10 +1,4 @@
 import Item from './toggle-group-item.svelte';
 import Root from './toggle-group.svelte';
 
-export {
-	Item,
-	Root,
-	//
-	Root as ToggleGroup,
-	Item as ToggleGroupItem
-};
+export { Item, Root, Root as ToggleGroup, Item as ToggleGroupItem };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/src/lib/server/api/contract.ts
+++ b/src/lib/server/api/contract.ts
@@ -192,7 +192,7 @@ export const contract: OpenApiDocument = {
 				type: 'object'
 			},
 
-			// ---- Hand-authored envelope response schemas (drift risk — see header) ----
+			// Hand-authored envelope response schemas (drift risk — see header)
 
 			EnvelopeDelta: {
 				description:
@@ -276,8 +276,6 @@ export const contract: OpenApiDocument = {
 				],
 				type: 'object'
 			},
-
-			// ---- Entity + result schemas ----
 
 			TransactionDeleteResult: {
 				properties: {

--- a/src/lib/server/db/auth/index.ts
+++ b/src/lib/server/db/auth/index.ts
@@ -77,7 +77,7 @@ export function refreshSession({ db = database, session }: { db?: Database; sess
 	}
 
 	if (shouldRefresh(session.expiresAt)) {
-		session.expiresAt = new Date(Date.now() + DAY_IN_MS * 15); // Extend session by 15 days
+		session.expiresAt = new Date(Date.now() + DAY_IN_MS * 15);
 		db.update(tables.sessions)
 			.set({ expiresAt: session.expiresAt })
 			.where(eq(tables.sessions.id, session.id))

--- a/src/lib/server/db/auth/utils.ts
+++ b/src/lib/server/db/auth/utils.ts
@@ -12,9 +12,6 @@ export function shouldRefresh(expiresAt: Date) {
 	return expiresAt.getTime() - DAY_IN_MS * 10 <= Date.now();
 }
 
-/**
- * 24 hours * 60 minutes * 60 seconds * 1000 milliseconds
- */
 export const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 /**

--- a/src/lib/server/db/tables/transactions.ts
+++ b/src/lib/server/db/tables/transactions.ts
@@ -51,7 +51,7 @@ export const transactions = sqliteTable(
 			columns: [t.categoryId, t.budgetId],
 			foreignColumns: [categories.id, categories.budgetId]
 		}),
-		check('date_format', sql`${t.date} LIKE '____-__-__'`), // YYYY-MM-DD
+		check('date_format', sql`${t.date} LIKE '____-__-__'`),
 		// Transfer legs carry no category — ever (ADR-0015). Pair-level
 		// invariants stay command-enforced per ADR-0001.
 		check('transfer_no_category', sql`${t.transferId} IS NULL OR ${t.categoryId} IS NULL`)
@@ -90,11 +90,11 @@ if (import.meta.vitest) {
 
 		await expect(
 			database.insert(transactions).values({
-				accountId: 'nonexistent_account', // invalid accountId
+				accountId: 'nonexistent_account',
 				amount: 1000,
 				budgetId: budget.id,
 				categoryId: category.id,
-				date: new Date().toISOString().split('T')[0] // format as YYYY-MM-DD
+				date: new Date().toISOString().split('T')[0]
 			})
 		).rejects.toThrow();
 
@@ -103,8 +103,8 @@ if (import.meta.vitest) {
 				accountId: account.id,
 				amount: 1000,
 				budgetId: budget.id,
-				categoryId: 'nonexistent_category', // invalid categoryId
-				date: new Date().toISOString().split('T')[0] // format as YYYY-MM-DD
+				categoryId: 'nonexistent_category',
+				date: new Date().toISOString().split('T')[0]
 			})
 		).rejects.toThrow();
 
@@ -119,9 +119,9 @@ if (import.meta.vitest) {
 			database.insert(transactions).values({
 				accountId: account.id,
 				amount: 1000,
-				budgetId: secondBudget.id, // mismatched budgetId - accountId
+				budgetId: secondBudget.id,
 				categoryId: category.id,
-				date: new Date().toISOString().split('T')[0] // format as YYYY-MM-DD
+				date: new Date().toISOString().split('T')[0]
 			})
 		).rejects.toThrow();
 	});
@@ -157,7 +157,7 @@ if (import.meta.vitest) {
 			amount: 1000,
 			budgetId: budget.id,
 			categoryId: category.id,
-			date: '2023-12-31' // valid date
+			date: '2023-12-31'
 		});
 
 		await expect(
@@ -166,7 +166,7 @@ if (import.meta.vitest) {
 				amount: 1000,
 				budgetId: budget.id,
 				categoryId: category.id,
-				date: '12/31/2023' // invalid date
+				date: '12/31/2023'
 			})
 		).rejects.toThrow();
 	});
@@ -203,7 +203,7 @@ if (import.meta.vitest) {
 			budgetId: budget.id,
 			categoryId: null,
 			date: '2023-12-31',
-			transferId: 'transfer1' // category-free transfer leg
+			transferId: 'transfer1'
 		});
 
 		await expect(
@@ -211,7 +211,7 @@ if (import.meta.vitest) {
 				accountId: account.id,
 				amount: 1000,
 				budgetId: budget.id,
-				categoryId: category.id, // categorized transfer leg
+				categoryId: category.id,
 				date: '2023-12-31',
 				transferId: 'transfer2'
 			})

--- a/src/lib/server/db/tables/users.ts
+++ b/src/lib/server/db/tables/users.ts
@@ -100,7 +100,7 @@ if (import.meta.vitest) {
 		await expect(
 			database.insert(users).values({
 				passwordHash: 'hash2',
-				username: 'user1' // same username
+				username: 'user1'
 			})
 		).rejects.toThrow();
 	});

--- a/src/lib/server/db/user-context/access.test.ts
+++ b/src/lib/server/db/user-context/access.test.ts
@@ -65,7 +65,6 @@ describe('hasAccess', () => {
 			.values({ budgetId: budget.id, role: 'INVITEE', userId: invitee.id })
 			.run();
 
-		// OWNER sees the budget via hasAccess
 		const ownerRows = db
 			.select({ id: tables.budgets.id })
 			.from(tables.budgets)
@@ -73,7 +72,6 @@ describe('hasAccess', () => {
 			.all();
 		expect(ownerRows).toHaveLength(1);
 
-		// INVITEE does not see it (filtered out by hasAccess)
 		const inviteeRows = db
 			.select({ id: tables.budgets.id })
 			.from(tables.budgets)
@@ -96,7 +94,6 @@ describe('isOwner', () => {
 			.values({ budgetId: budget.id, role: 'MEMBER', userId: member.id })
 			.run();
 
-		// OWNER sees the budget via isOwner
 		const ownerRows = db
 			.select({ id: tables.budgets.id })
 			.from(tables.budgets)
@@ -104,7 +101,6 @@ describe('isOwner', () => {
 			.all();
 		expect(ownerRows).toHaveLength(1);
 
-		// MEMBER does not see it via isOwner
 		const memberRows = db
 			.select({ id: tables.budgets.id })
 			.from(tables.budgets)

--- a/src/lib/server/db/user-context/budget.ts
+++ b/src/lib/server/db/user-context/budget.ts
@@ -282,7 +282,6 @@ export const commands = (userId: string, db: Database = database) => ({
 	}) => {
 		accessGuard(budgetId, userId, db);
 
-		// Validate that both categories belong to this budget
 		{
 			const categoryIds = [sourceCategoryId];
 			if (targetCategoryId !== null) categoryIds.push(targetCategoryId);

--- a/src/lib/server/utils/remote-guard.ts
+++ b/src/lib/server/utils/remote-guard.ts
@@ -51,7 +51,6 @@ export function guardedCommand<Schema extends StandardSchemaV1, Input, Output>(
 	schemaOrFn: ((input: Input, auth: GuardedAuth) => Promise<Output>) | Schema,
 	maybeFn?: (output: StandardSchemaV1.InferOutput<Schema>, auth: GuardedAuth) => Promise<Output>
 ) {
-	// Handle the case with schema parameter (first overload)
 	if (isStandardSchema(schemaOrFn) && typeof maybeFn === 'function') {
 		return command(schemaOrFn, async (output) => {
 			const event = getRequestEvent();
@@ -62,7 +61,6 @@ export function guardedCommand<Schema extends StandardSchemaV1, Input, Output>(
 		});
 	}
 
-	// Handle the case where there's no schema parameter (second overload)
 	if (typeof schemaOrFn === 'function' && !maybeFn) {
 		return command('unchecked', async (input: Input) => {
 			const event = getRequestEvent();
@@ -119,7 +117,6 @@ export function guardedForm<
 				}
 		  ) => Promise<Output>)
 ) {
-	// Handle the case with schema parameter (first overload)
 	if (isStandardSchema(schemaOrFn) && typeof maybeFn === 'function') {
 		const fn = maybeFn as (
 			output: StandardSchemaV1.InferOutput<Schema>,
@@ -136,7 +133,6 @@ export function guardedForm<
 		});
 	}
 
-	// Handle the case with unchecked schema parameter (second overload)
 	if (typeof schemaOrFn === 'string' && typeof maybeFn === 'function') {
 		const fn = maybeFn as (
 			input: Input,
@@ -153,7 +149,6 @@ export function guardedForm<
 		});
 	}
 
-	// Handle the case where there's no schema parameter (third overload)
 	if (typeof schemaOrFn === 'function' && !maybeFn) {
 		return form(async () => {
 			const event = getRequestEvent();
@@ -178,7 +173,6 @@ export function guardedQuery<Schema extends StandardSchemaV1, Output>(
 	schemaOrFn: ((auth: GuardedAuth) => Promise<Output>) | Schema,
 	maybeFn?: (output: StandardSchemaV1.InferOutput<Schema>, auth: GuardedAuth) => Promise<Output>
 ) {
-	// Handle the case with schema parameter (first overload)
 	if (isStandardSchema(schemaOrFn) && typeof maybeFn === 'function') {
 		return query(schemaOrFn, (output) => {
 			const event = getRequestEvent();
@@ -189,7 +183,6 @@ export function guardedQuery<Schema extends StandardSchemaV1, Output>(
 		});
 	}
 
-	// Handle the case where there's no schema parameter (second overload)
 	if (typeof schemaOrFn === 'function' && !maybeFn) {
 		return query(() => {
 			const event = getRequestEvent();

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
@@ -30,7 +30,7 @@
 
 	// Archived categories are managed through the archived list's restore flow,
 	// not this page. Archiving here trips the same redirect: the submit
-	// refreshes getCategoryById, which now carries archivedAt.
+	// refreshes getCategoryById, populating archivedAt.
 	$effect(() => {
 		if (category.archivedAt !== null) {
 			goto(resolve('/(app)/[budgetId=id]/categories/archived', { budgetId: budgetId() }));


### PR DESCRIPTION
Closes #217.

Retroactively enforces the existing `docs/code-style.md` comment policy in a single **comment-only** pass across `src/`, config, and scripts. Markdown docs, ADRs, and `CONTEXT.md` were left untouched.

## What changed
- Removed comment noise: narration of the next line, change-log markers (`// old`), empty `//` placeholders, ASCII-art dividers, and redundant overload/utility narration.
- Kept load-bearing why/constraint comments, ADR references, sparing JSDoc, and test-fixture annotations that give meaning to otherwise-opaque values.
- 29 files touched. The feature-component and server layers were already clean (ADR-referenced why-comments), so the noise was concentrated in barrels, test fixtures, and a few utilities.

## Safety rail — comment/whitespace-only
Every changed `.ts`/`.svelte` file was compiled with comments stripped (esbuild for TS, the Svelte compiler for components) and asserted **byte-identical** to before. No logic changed, nothing was reordered or renamed.

**One whitespace call-out (per the issue's safety rail):** removing the empty `//` placeholders inside five barrel `export { … }` blocks (checkbox, empty-state, label, separator, toggle-group) let prettier collapse them from multi-line to a single line. This is a whitespace-only reformat — the exported symbols are identical.

## Debug leftovers
No stray `console.log`/debug found. The two surviving `console.*` calls are intentional and kept: a `dev`-gated diagnostic in `anchored-toast.svelte.ts` and a deliberate non-swallowing catch in the `copyToClipboard` browser util (per `docs/code-style.md`).

## Checks
`npm run check`, `npm run lint`, `npm run test:unit` (663 passed), and `npm run test:e2e` (112 passed) all green. No `CHANGELOG.md` entry — comment cleanup is not user-visible.
