### PR TITLE
docs(readme): fresh-eyes proofread

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Assign each month's money to categories — targets fill up, overspending shows
 in red.
 
 ![The budget month view: categories with their assigned budget, activity, and
-remaining balance, one category overspent.](docs/screenshots/budget.png)
+remaining balance, with one category overspent.](docs/screenshots/budget.png)
 
 Record transactions per account and edit category, date, notes, and amount
 inline; toggle each between pending and validated.


### PR DESCRIPTION
Closes #219.

Fresh-eyes proofread of `README.md` — the project's landing page.

## Change

Fixed one ambiguous alt text on the budget screenshot: `remaining balance, one category overspent` read as a fourth item in the preceding list (`assigned budget, activity, and remaining balance, …`), so `with` was added to mark it as the intended absolute phrase — mirroring the parallel second screenshot's alt text.

## Verification (no code changes needed)

Full read of the page confirmed:

- **Links** — all relative/asset targets resolve: `docs/self-hosting.md`, `docs/usage.md`, ADR-0012, `.github/CONTRIBUTING.md`, `LICENSE`, `CHANGELOG.md`, both screenshots, and the CI-badge workflow.
- **Content vs. app** — currency list, tech-stack dependencies, Docker Compose env vars (`DATABASE_URL`, `ORIGIN`), npm scripts, and the admin-first-login claim all still match the current app. No drift found.

## Notes

- No CHANGELOG entry (docs change).
- No repositioning or structural rewrite, per the issue scope.