### PR TITLE
docs: correctness fixes for ADR links, password recovery, version location

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ git push --follow-tags
 ```
 
 Versions are CalVer (`YYYY.0M.MICRO`) and the changelog is hand-curated under
-`## [Unreleased]`; see [ADR-0012](docs/dev/adr/0012-calver-releases-and-stage-deploy.md).
+`## [Unreleased]`.
 
 ## Contributing
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -16,8 +16,7 @@ database server.
 ## Container images
 
 Prebuilt images are published to the GitHub Container Registry at
-`ghcr.io/lj-n/genug-da` (see
-[ADR-0012](dev/adr/0012-calver-releases-and-stage-deploy.md)):
+`ghcr.io/lj-n/genug-da`:
 
 | Tag           | Built from      | Use                                                                         |
 | ------------- | --------------- | --------------------------------------------------------------------------- |
@@ -26,7 +25,7 @@ Prebuilt images are published to the GitHub Container Registry at
 | `stage`       | tip of `main`   | Testing — rolling build ahead of the last release.                          |
 | `sha-<short>` | a `main` commit | Testing — immutable pin to an exact commit.                                 |
 
-Stage builds show a dev-flavoured version beside the logo
+Stage builds show a dev-flavoured version in the navigation footer
 (`2026.07.0-dev+a1b2c3d`); release builds show the clean CalVer.
 
 While the repository (and image) is private, authenticate the host once with
@@ -81,27 +80,6 @@ URL users type into the browser (scheme and host, e.g.
 `https://budget.example.com`). SvelteKit checks form submissions against
 this origin for CSRF protection — with `ORIGIN` unset or wrong, logins and
 every other form fail.
-
-### Stage stack (optional)
-
-A second stack pulling `:stage` lets you try the tip of `main` before
-promoting it to production. Give it its own data volume, port, and origin so
-it never touches production data.
-
-```yml
-services:
-  genug-da-stage:
-    container_name: genug-da-stage
-    image: ghcr.io/lj-n/genug-da:stage
-    restart: unless-stopped
-    ports:
-      - '3003:3000'
-    volumes:
-      - ./data-stage:/app/data:rw
-    environment:
-      DATABASE_URL: '/app/data/genug.db'
-      ORIGIN: 'https://stage.your.domain'
-```
 
 ## Environment variables
 
@@ -170,10 +148,20 @@ across a migration.
 
 ## Password recovery
 
-There is no forgot-password flow and none is needed: recovery runs from the
-server shell. The reset CLI is bundled into every build as
+There is no self-service forgot-password flow, and none is needed. There are
+two ways to recover an account.
+
+**From the admin UI.** An administrator can reset any other user's password
+from the admin page: each user row has a reset action that generates a fresh
+random password and shows it once. Hand that password to the user; they log in
+and change it under Settings. This covers everyday resets without touching the
+server shell.
+
+**From the server shell.** The reset CLI is bundled into every build as
 `build/reset-password.js` (ADR-0015), so it is available inside the deployed
-container without a source checkout, email, or SMTP configuration.
+container without a source checkout, email, or SMTP configuration. Use it when
+no admin can reach the UI — including to reset the sole administrator's own
+password, which the admin UI deliberately cannot do.
 
 Reset any user's password by username:
 


### PR DESCRIPTION
## What

Mechanical correctness fixes across the user-facing docs, following up from the README proofread (#219). No design decisions.

## Changes

- **README** — the "Releasing" section drops the ADR-0012 link; the brief inline CalVer note stays.
- **`docs/self-hosting.md`** — the container-images intro drops the ADR-0012 link.
- **`docs/self-hosting.md`** — "Password recovery" now documents the admin-UI reset path (each user row on the admin page has a reset action that shows a fresh password once) alongside the bundled reset CLI. Notes that the admin UI deliberately cannot reset the sole administrator's own account, which is what the CLI covers.
- **`docs/self-hosting.md`** — the version-location claim is corrected: the dev-flavoured version renders in the navigation footer, not beside the logo (verified against the app — `VersionLabel` is rendered at the bottom of the desktop and mobile navigation).
- **`docs/self-hosting.md`** — the optional "Stage stack" section is removed. The `stage` image tag stays documented in the container-images table.

## Acceptance criteria

- [x] No ADR links remain in README or `self-hosting.md`.
- [x] "Password recovery" documents the admin-UI reset path.
- [x] Version-location statement verified against the app and corrected.
- [x] Stage-stack section removed.
- [x] Docs still render; no broken links introduced (`prettier --check` clean, no dangling anchors).

Docs-only change — no CHANGELOG entry per repo rule.

Closes #224
