### PR TITLE
chore: commit .env dev default so DATABASE_URL isn't needed on every command

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Committed shared defaults — non-secret values only.
+# Machine-specific overrides and secrets belong in .env.local (gitignored, wins over this file).
+DATABASE_URL=local.db

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,9 +21,10 @@ prior, agreed-upon issue may be closed without review.
 ## Development setup
 
 See the [Development section of the README](../README.md#development) for
-setup and the test/lint commands. In short: Node.js 22+, `npm install`, and
-run everything with `DATABASE_URL=:memory:` — `npm run dev`, `npm run check`,
-`npm run lint`, `npm run test:unit`, `npm run test:e2e`.
+setup and the test/lint commands. In short: Node.js 22+, `npm install`, then
+`npm run dev`, `npm run check`, `npm run lint`, `npm run test:unit`,
+`npm run test:e2e`. A committed `.env` provides the `DATABASE_URL` default, so
+no prefix is needed.
 
 ## Conduct
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,5 +16,5 @@ Closes #
 
 - [ ] A maintainer agreed to this change in the linked issue
 - [ ] `npm run lint` and `npm run check` pass
-- [ ] `DATABASE_URL=:memory: npm run test:unit` passes
+- [ ] `npm run test:unit` passes
 - [ ] User-visible changes have a `CHANGELOG.md` entry under `## [Unreleased]`

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ node_modules
 Thumbs.db
 
 # Env
-.env
+# .env is committed (non-secret shared defaults). Machine-specific overrides
+# and secrets go in .env.local / .env.*, which stay ignored.
 .env.*
 !.env.example
 !.env.test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,11 @@ SvelteKit 2 + Svelte 5 runes, `@sveltejs/adapter-node`, Tailwind 4, Drizzle ORM 
 
 ## Build, Test, and Lint Commands
 
-Set `DATABASE_URL` for builds and DB-backed tests. For local runs, `:memory:` is the common value.
+A committed `.env` provides `DATABASE_URL=local.db`, so a fresh clone runs these commands with no prefix. Override machine-specific values in `.env.local` (gitignored, wins over `.env`). Unit tests force `:memory:` automatically.
 
 ```bash
 # development
-DATABASE_URL=:memory: npm run dev
+npm run dev
 
 # type/svelte checks
 npm run check
@@ -30,13 +30,13 @@ npm run lint:fix
 npm run format
 
 # production build / preview
-DATABASE_URL=:memory: npm run build
-DATABASE_URL=:memory: npm run preview
+npm run build
+npm run preview
 
 # unit tests
-DATABASE_URL=:memory: npm run test:unit
-DATABASE_URL=:memory: npm run test:unit -- src/lib/server/db/auth/auth.test.ts
-DATABASE_URL=:memory: npm run test:unit -- src/lib/server/db/auth/auth.test.ts -t "authenticateUser - returns user on valid credentials"
+npm run test:unit
+npm run test:unit -- src/lib/server/db/auth/auth.test.ts
+npm run test:unit -- src/lib/server/db/auth/auth.test.ts -t "authenticateUser - returns user on valid credentials"
 
 # Playwright
 npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ keep my own data in: one SQLite file, no external services.
 
 ```sh
 npm install
-DATABASE_URL=:memory: npm run dev
+npm run dev
 ```
+
+A committed `.env` supplies a `DATABASE_URL=local.db` default, so no prefix is
+needed. Override it in `.env.local` (gitignored) if you want a different path.
 
 ```sh
 npm run test:unit       # Vitest

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -106,11 +106,15 @@ variables (`HOST`, `BODY_SIZE_LIMIT`, proxy-header handling, …) — see the
 
 ```sh
 npm install
-DATABASE_URL=:memory: npm run build
+npm run build
 DATABASE_URL=./data/genug.db \
   ORIGIN=http://localhost:3000 \
   NODE_ENV=production node build
 ```
+
+`node build` runs adapter-node's server, which does not read `.env` — pass
+`DATABASE_URL` explicitly, as shown. The build step picks up the committed
+`.env` default on its own.
 
 Migrations run automatically at startup.
 


### PR DESCRIPTION
Closes #229

Tracks a base `.env` holding a non-secret shared default (`DATABASE_URL=local.db`) so a fresh clone runs `npm run dev`, `build`, `preview`, and `db:migrations` without a `DATABASE_URL=` prefix. Vite and drizzle-kit auto-load `.env`; vitest already forces `:memory:` when `VITEST` is set.

## Changes

- `.gitignore`: track `.env` (committed shared defaults) while `.env.*` / `.env.local` stay ignored for machine-specific overrides and secrets. `local.db` stays covered by the existing `*.db` rule.
- New `.env` with a header comment: non-secret defaults only; secrets belong in `.env.local` (which wins over `.env`).
- Docs drop the now-redundant `DATABASE_URL=:memory:` prefixes and note `.env.local` as the override mechanism — `CLAUDE.md`, `README.md`, `.github/CONTRIBUTING.md`, `.github/pull_request_template.md`, `docs/self-hosting.md`.
- Bare-metal `node build` keeps an explicit `DATABASE_URL`, since adapter-node does not read `.env`.

No app-code fallback is added: `src/lib/server/db/index.ts` is unchanged and still throws when `DATABASE_URL` is unset, so the documented "no silent fallback paths" contract holds.

Not a user-visible change → no `CHANGELOG.md` entry.

## Verification

Fresh worktree, real `npm install`, all commands run **without** a `DATABASE_URL=` prefix:

- `npm run build` — passes (picks up `local.db` from `.env`)
- `npm run test:unit` — 663 passed, 1 expected fail
- `npm run check` — 0 errors
- `npm run lint` — passes
- `.env` is tracked; `.env.local` and `local.db` are correctly gitignored
- `npm run db:migrations` loads `.env` (no "DATABASE_URL not set" throw)
