### PR TITLE
fix: clear create-transaction/transfer draft when the account changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and dependency bumps get no entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- The create-transaction and create-transfer forms no longer carry a
+  half-typed draft across accounts. Switching to another account (in the same
+  or a different budget) and reopening the create form now shows an empty form;
+  a draft is only kept when you reopen the form on the same account.
+
 ## [2026.07.4] - 2026-07-19
 
 ### Added

--- a/src/lib/components/features/transaction/transaction-create-modal.svelte
+++ b/src/lib/components/features/transaction/transaction-create-modal.svelte
@@ -45,10 +45,17 @@
 		updates: () => [listTransactions({ accountId, ...urlParams })]
 	});
 
-	// The form mounts each time the sheet opens, so a mount-scoped attachment is
-	// the reliable reset point (bits-ui never fires onOpenChangeComplete(true)
-	// for static content, see transaction-table-row-create.svelte.test.ts).
-	const resetOnMount: Attachment<HTMLFormElement> = () => {
+	// The draft is scoped to one account (carried as the hidden accountId), so it
+	// is stale once the viewed account changes. Reset the fields when the form
+	// next mounts for a different account; reopening on the SAME account keeps the
+	// draft. This deliberately covers cross-budget and same-budget switches, and
+	// avoids the unreliable reset-on-open (bits-ui never fires
+	// onOpenChangeComplete(true) for static content).
+	let lastResetAccountId: string | undefined;
+
+	const resetOnAccountChange: Attachment<HTMLFormElement> = () => {
+		if (lastResetAccountId === accountId) return;
+		lastResetAccountId = accountId;
 		createTransaction.fields.set({
 			amount: 0,
 			categoryId: undefined,
@@ -74,7 +81,7 @@
 				aria-label={m.transactions_table_create_transaction()}
 				{...submit.attrs}
 				{@attach submit.anchor}
-				{@attach resetOnMount}
+				{@attach resetOnAccountChange}
 			>
 				<input {...createTransaction.fields.accountId.as('hidden', accountId)} />
 				<input {...createTransaction.fields.budgetId.as('hidden', budgetId)} />

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -71,7 +71,16 @@
 		return () => node.removeEventListener('keydown', handle);
 	};
 
-	const reset = () => {
+	// The draft is scoped to one account (carried as the hidden accountId), so it
+	// is stale once the viewed account changes. Reset the fields when the form
+	// next mounts for a different account; reopening on the SAME account keeps the
+	// draft. This replaces the old reset-on-open, which was dead code (bits-ui
+	// never fires onOpenChangeComplete(true) for static popover content).
+	let lastResetAccountId: string | undefined;
+
+	const resetOnAccountChange: Attachment<HTMLFormElement> = () => {
+		if (lastResetAccountId === accountId) return;
+		lastResetAccountId = accountId;
 		submitAndContinue = false;
 		createTransaction.fields.set({
 			amount: 0,
@@ -83,14 +92,7 @@
 	};
 </script>
 
-<Popover.Root
-	bind:open
-	onOpenChangeComplete={(isOpen) => {
-		if (isOpen) {
-			reset();
-		}
-	}}
->
+<Popover.Root bind:open>
 	<!-- Render the popover content ONTO the form via `child`: no wrapper div sits
 	     between the rowgroup and form[role="row"], so the table's a11y tree stays
 	     valid (a table/rowgroup may only own rows — an intermediate generic or
@@ -113,6 +115,7 @@
 				{...submit.attrs}
 				{@attach open && submitWithKeyboard}
 				{@attach submit.anchor}
+				{@attach resetOnAccountChange}
 			>
 				<input {...createTransaction.fields.accountId.as('hidden', accountId)} />
 				<input {...createTransaction.fields.budgetId.as('hidden', budgetId)} />

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
@@ -229,19 +229,36 @@ describe('TableRowCreate', () => {
 		expect(screen.queryByRole('row')).not.toBeInTheDocument();
 	});
 
-	// bits-ui 2.18.1 never fires onOpenChangeComplete(true) for Popover.ContentStatic — on
-	// open, its presence manager reads the content node before it is mounted and bails, so
-	// only the close direction fires (reproduced in real Chromium, not a jsdom artifact).
-	// The component's reset-on-open is therefore currently dead code in the app as well.
-	// This test states the intended behavior; when a bits-ui upgrade fixes the callback,
-	// vitest will report it as "expected to fail, but passed" — then remove the `.fails`.
-	it.fails('resets the form fields when the popover opens', async () => {
-		const { rerender } = await renderRow({ open: false });
+	// The draft is scoped to the viewed account: reopening on the SAME account
+	// keeps a half-typed draft, but switching accounts and reopening must clear
+	// it. The reset is keyed on the accountId change, not the popover open event
+	// (bits-ui never fires onOpenChangeComplete(true) for static popover content).
+	it('keeps the draft when reopened on the same account', async () => {
+		const { rerender } = await renderRow({ open: true });
+
+		// The fresh mount seeds the defaults once for this account.
+		await waitFor(() => expect(remote.setAllFields).toHaveBeenCalledTimes(1));
+		remote.setAllFields.mockClear();
+
+		// Close, then reopen on the same account: no reset, the draft survives.
+		await rerender({ ...baseProps, open: false });
+		await rerender({ ...baseProps, open: true });
+		await screen.findByRole('row');
 
 		expect(remote.setAllFields).not.toHaveBeenCalled();
+	});
 
-		await rerender({ open: true });
+	it('resets the draft when reopened on a different account', async () => {
+		const { rerender } = await renderRow({ open: true });
+
+		await waitFor(() => expect(remote.setAllFields).toHaveBeenCalledTimes(1));
+		remote.setAllFields.mockClear();
+
+		// Navigate to another account, then reopen the create form.
+		await rerender({ ...baseProps, accountId: 'account-2', open: false });
+		await rerender({ ...baseProps, accountId: 'account-2', open: true });
 		await screen.findByRole('row');
+
 		await waitFor(() => expect(remote.setAllFields).toHaveBeenCalledTimes(1));
 		const values = remote.fieldState();
 		expect(values.amount).toBe(0);

--- a/src/lib/components/features/transaction/transfer-create-modal.svelte
+++ b/src/lib/components/features/transaction/transfer-create-modal.svelte
@@ -46,10 +46,17 @@
 		updates: () => [listTransactions({ accountId, ...urlParams })]
 	});
 
-	// The form mounts each time the sheet opens, so a mount-scoped attachment is
-	// the reliable reset point (bits-ui never fires onOpenChangeComplete(true)
-	// for static content, see transaction-table-row-create.svelte.test.ts).
-	const resetOnMount: Attachment<HTMLFormElement> = () => {
+	// The draft is scoped to one account (carried as the hidden accountId), so it
+	// is stale once the viewed account changes. Reset the fields when the form
+	// next mounts for a different account; reopening on the SAME account keeps the
+	// draft. This deliberately covers cross-budget and same-budget switches, and
+	// avoids the unreliable reset-on-open (bits-ui never fires
+	// onOpenChangeComplete(true) for static content).
+	let lastResetAccountId: string | undefined;
+
+	const resetOnAccountChange: Attachment<HTMLFormElement> = () => {
+		if (lastResetAccountId === accountId) return;
+		lastResetAccountId = accountId;
 		createTransfer.fields.set({
 			amount: 0,
 			counterpartAccountId: '',
@@ -74,7 +81,7 @@
 				aria-label={m.transactions_table_create_transfer()}
 				{...submit.attrs}
 				{@attach submit.anchor}
-				{@attach resetOnMount}
+				{@attach resetOnAccountChange}
 			>
 				<input {...createTransfer.fields.accountId.as('hidden', accountId)} />
 				<input {...createTransfer.fields.budgetId.as('hidden', budgetId)} />

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -70,7 +70,16 @@
 		return () => node.removeEventListener('keydown', handle);
 	};
 
-	const reset = () => {
+	// The draft is scoped to one account (carried as the hidden accountId), so it
+	// is stale once the viewed account changes. Reset the fields when the form
+	// next mounts for a different account; reopening on the SAME account keeps the
+	// draft. This replaces the old reset-on-open, which was dead code (bits-ui
+	// never fires onOpenChangeComplete(true) for static popover content).
+	let lastResetAccountId: string | undefined;
+
+	const resetOnAccountChange: Attachment<HTMLFormElement> = () => {
+		if (lastResetAccountId === accountId) return;
+		lastResetAccountId = accountId;
 		createTransfer.fields.set({
 			amount: 0,
 			counterpartAccountId: '',
@@ -80,14 +89,7 @@
 	};
 </script>
 
-<Popover.Root
-	bind:open
-	onOpenChangeComplete={(isOpen) => {
-		if (isOpen) {
-			reset();
-		}
-	}}
->
+<Popover.Root bind:open>
 	<!-- Render the popover content ONTO the form via `child`: see
 	     transaction-table-row-create — no wrapper div between the rowgroup and
 	     form[role="row"], keeping the table's a11y tree valid. -->
@@ -109,6 +111,7 @@
 				{...submit.attrs}
 				{@attach open && submitWithKeyboard}
 				{@attach submit.anchor}
+				{@attach resetOnAccountChange}
 			>
 				<input {...createTransfer.fields.accountId.as('hidden', accountId)} />
 				<input {...createTransfer.fields.budgetId.as('hidden', budgetId)} />


### PR DESCRIPTION
Closes #238

## Problem

The four create surfaces — the transaction/transfer create modal (mobile drawer / desktop dialog) and the desktop inline-row create popover — share a module-level field singleton (`createTransaction.fields` / `createTransfer.fields`). A half-typed draft for one account survived closing the form and reappeared when the form was reopened on a **different** account.

## Fix

Reset the create form's fields when the active `accountId` changes, replacing the unreliable reset-on-open:

- the modals reset on *every* mount (which would clobber a same-account draft), and
- the inline-row popover's `onOpenChangeComplete(true)` reset was dead code — bits-ui never fires that callback for static popover content.

Each surface now resets via an `{@attach resetOnAccountChange}` attachment guarded by a `lastResetAccountId`: it resets the fields when the form next mounts for a **different** account, and keeps the draft when reopened on the **same** account. This covers both cross-budget and same-budget account switches.

## Tests

Replaced the `it.fails` placeholder in `transaction-table-row-create.svelte.test.ts` with two component tests — draft preserved on same-account reopen, and draft cleared on the navigate-then-reopen path.
