### PR TITLE
fix: refresh counterpart account register after creating a transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- Creating a transfer now updates the counterpart account's register right
+  away. After adding a transfer while viewing one account, switching to the
+  other account shows the new leg immediately, without a manual page reload.
+
 - The create-transaction and create-transfer forms no longer carry a
   half-typed draft across accounts. Switching to another account (in the same
   or a different budget) and reopening the create form now shows an empty form;

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -151,7 +151,6 @@
 						{budgetId}
 						class={colsClass}
 						interactOutsideIgnore={createTriggerGroup}
-						urlParams={tableState.params}
 					/>
 				{/snippet}
 
@@ -277,12 +276,7 @@
 	{currency}
 />
 
-<TransferCreateModal
-	bind:open={transferCreateModalOpen}
-	{accountId}
-	{budgetId}
-	urlParams={tableState.params}
-/>
+<TransferCreateModal bind:open={transferCreateModalOpen} {accountId} {budgetId} />
 
 <TransferEditModal
 	bind:open={transferEditModalOpen}

--- a/src/lib/components/features/transaction/transfer-create-modal.svelte
+++ b/src/lib/components/features/transaction/transfer-create-modal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { TransactionsURLParams } from '$lib/schemas/transaction';
 	import type { Attachment } from 'svelte/attachments';
 
 	import { Button } from '$lib/components/ui/button';
@@ -19,13 +18,11 @@
 	let {
 		accountId,
 		budgetId,
-		open = $bindable(false),
-		urlParams
+		open = $bindable(false)
 	}: {
 		accountId: string;
 		budgetId: string;
 		open?: boolean;
-		urlParams: TransactionsURLParams;
 	} = $props();
 
 	const accounts = $derived(await getAccounts(budgetId));
@@ -43,7 +40,10 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions({ accountId, ...urlParams })]
+		// A transfer writes a leg into each account, so refresh every live
+		// listTransactions instance (both legs' registers) rather than just the
+		// viewed account's — otherwise the counterpart stays stale until reload.
+		updates: () => [listTransactions]
 	});
 
 	// The draft is scoped to one account (carried as the hidden accountId), so it

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { TransactionsURLParams } from '$lib/schemas/transaction';
 	import type { Attachment } from 'svelte/attachments';
 
 	import { Button } from '$lib/components/ui/button';
@@ -23,8 +22,7 @@
 		budgetId,
 		class: className,
 		interactOutsideIgnore = null,
-		open = $bindable(false),
-		urlParams
+		open = $bindable(false)
 	}: {
 		accountId: string;
 		budgetId: string;
@@ -36,7 +34,6 @@
 		 */
 		interactOutsideIgnore?: HTMLElement | null;
 		open?: boolean;
-		urlParams: TransactionsURLParams;
 	} = $props();
 
 	const accounts = $derived(await getAccounts(budgetId));
@@ -55,7 +52,10 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions({ accountId, ...urlParams })]
+		// A transfer writes a leg into each account, so refresh every live
+		// listTransactions instance (both legs' registers) rather than just the
+		// viewed account's — otherwise the counterpart stays stale until reload.
+		updates: () => [listTransactions]
 	});
 
 	const submitWithKeyboard: Attachment<HTMLFormElement> = (node) => {

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -127,6 +127,40 @@ export class AccountPage extends BasePage {
 		}
 	}
 
+	/**
+	 * Creates a transfer from the currently-viewed account through the inline
+	 * transfer create row (desktop register). The viewed account is one leg by
+	 * definition; `counterpartAccount` is the other side, picked from the account
+	 * dropdown. A positive amount arrives in the viewed account, a negative one
+	 * leaves it — either way both legs are written.
+	 */
+	async createTransfer({
+		amount,
+		counterpartAccount,
+		notes
+	}: {
+		amount: string;
+		counterpartAccount: string;
+		notes?: string;
+	}) {
+		await this.page.getByRole('button', { exact: true, name: 'Transfer' }).click();
+
+		const createRow = this.page.getByRole('row', { exact: true, name: 'Transfer' });
+		await expect(createRow).toBeVisible();
+
+		await createRow.getByRole('button', { name: 'Open account dropdown' }).click();
+		await this.page.getByRole('option', { name: counterpartAccount }).click();
+
+		if (notes !== undefined) {
+			await createRow.getByRole('textbox', { name: 'Notes' }).fill(notes);
+		}
+
+		await createRow.getByRole('textbox', { name: 'Amount' }).fill(amount);
+
+		await createRow.getByRole('button', { exact: true, name: 'Save' }).click();
+		await expect(createRow).not.toBeVisible();
+	}
+
 	async deleteTransaction() {
 		const row = this.page
 			.getByRole('row')
@@ -291,6 +325,22 @@ export class AccountPage extends BasePage {
 		await this.page.getByRole('button', { name: 'Restore' }).click();
 
 		await expect(this.page.getByRole('button', { name: 'New Transaction' })).toBeVisible();
+	}
+
+	/**
+	 * Switches to another account through the desktop side-menu link. Unlike
+	 * `goto`, this is a client-side (SPA) navigation, so the target account's
+	 * cached transaction query is reused rather than refetched from a fresh
+	 * document — the path that exercises counterpart-leg cache invalidation.
+	 */
+	async switchToAccountViaSideMenu(accountName: string) {
+		// Scope to the navigation landmark: the same account name can also appear as
+		// a link elsewhere (e.g. the month view's setup tutorial card).
+		await this.page
+			.getByRole('navigation')
+			.getByRole('link', { exact: true, name: accountName })
+			.click();
+		await expect(this.page.getByRole('heading', { name: accountName })).toBeVisible();
 	}
 
 	async toggleValidated() {

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -99,6 +99,46 @@ test('Toggle Validated', async ({ pages }) => {
 	await pages.account.toggleValidated();
 });
 
+test("Transfer's counterpart leg shows in the other account without reload", async ({
+	page,
+	pages
+}) => {
+	// The desktop side menu (the cross-account switcher used below) only mounts at
+	// the wide breakpoint; pin a desktop viewport so this runs the same way under
+	// the tablet project.
+	await page.setViewportSize({ height: 900, width: 1440 });
+
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const accountA = uniqueName(faker.finance.accountName());
+	const accountB = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountA);
+	await pages.budget.createAccount(accountB);
+
+	// Visit account B first so its transaction query is cached client-side; the
+	// bug is that a transfer created from another account fails to invalidate
+	// this cached instance, so it stays stale.
+	await pages.account.switchToAccountViaSideMenu(accountB);
+	await expect(pages.account.transactionsEmptyState()).toBeVisible();
+
+	// Create the transfer while viewing account A; the counterpart leg lands in B.
+	await pages.account.switchToAccountViaSideMenu(accountA);
+	await pages.account.createTransfer({ amount: '25', counterpartAccount: accountB });
+
+	// Return to B via browser back, which restores B's cached query instance
+	// rather than refetching it (a fresh navigation would refetch and mask the
+	// bug). B's leg must show immediately — its category cell carries a transfer
+	// badge naming the counterpart account (A).
+	await page.goBack();
+	await expect(page.getByRole('heading', { name: accountB })).toBeVisible();
+	await expect(
+		page.getByRole('cell', { name: 'Edit category' }).filter({ hasText: accountA })
+	).toBeVisible();
+});
+
 test('Toggle and switch create rows from their trigger buttons', async ({ page, pages }) => {
 	await pages.auth.createUserAndLogin();
 


### PR DESCRIPTION
## What

A transfer writes a leg into each account. The two transfer-*create* submit sites declared `updates: () => [listTransactions({ accountId, ...urlParams })]`, which refreshes only the currently-viewed account's cached register. The counterpart account's cached (unmounted) query instance stayed stale, so its new leg did not appear until a manual page reload. (`transfer-edit-modal.svelte` already used the correct bare-function form — the reference pattern.)

## Change

- Switch both create sites to `updates: () => [listTransactions]` (all live instances), matching `transfer-edit-modal.svelte`.
- Drop the now-orphaned `urlParams` prop from both transfer components and their two call sites in `transaction-table.svelte` — it existed only to build the parameterized query the fix removes.
- Add a Playwright regression test: cache account B's register, create a transfer from account A, return to B via browser back (which restores B's cached instance rather than refetching), and assert the counterpart leg is present without a reload.
- `CHANGELOG.md` entry under `## [Unreleased]` → `Fixed`.

## Verification

- The regression test was confirmed to **fail on the pre-fix code** (B's cached instance restored stale, no counterpart leg) and **pass on the fix** — a genuine guard.
- `npm run check`, `npm run lint`, full unit suite (665 passed), and full Playwright suite all green (one unrelated pre-existing tablet flake in `a11y.spec.ts` passed on re-run).

Closes #240