### PR TITLE
ci: make the README CI badge track main; add GHCR image badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
+# Runs on PRs (the merge gate) and on pushes to main. The main runs exist so
+# the README status badge reflects main itself rather than the latest PR branch.
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -11,7 +15,10 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # PR runs supersede each other. Pushes to main get a per-commit group so
+  # back-to-back merges never cancel a run — a cancelled run on main would
+  # surface as a red README badge.
+  group: ci-${{ github.ref }}${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: true
 
 # Runner routing: the CI_RUNNER repo variable overrides the runner label for
@@ -70,8 +77,9 @@ jobs:
         env:
           DATABASE_URL: ':memory:'
 
-  # Decide whether the (expensive) e2e suite should run for this PR.
-  # Skips drafts and changes that touch only docs/markdown.
+  # Decide whether the (expensive) e2e suite should run for this event.
+  # Skips draft PRs and changes that touch only docs/markdown. On pushes to
+  # main, paths-filter diffs against the commit before the push.
   gate:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/lj-n/genug-da/actions/workflows/ci.yml"><img src="https://github.com/lj-n/genug-da/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/lj-n/genug-da/actions/workflows/ci.yml"><img src="https://github.com/lj-n/genug-da/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="CHANGELOG.md"><img src="https://img.shields.io/github/v/tag/lj-n/genug-da?label=release" alt="Release"></a>
+  <a href="https://github.com/lj-n/genug-da/pkgs/container/genug-da"><img src="https://img.shields.io/badge/ghcr.io-lj--n%2Fgenug--da-blue?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0--only-blue" alt="License: AGPL-3.0-only"></a>
 </p>
 


### PR DESCRIPTION
## Why

The README CI badge points at `ci.yml`, which only triggers on `pull_request` — it has zero runs on `main`. With no runs on the default branch, GitHub's badge falls back to the workflow's most recent run on *any* branch, so the badge currently shows "failing" from an unrelated PR branch while `main` itself is fine.

## What

- `ci.yml` now also runs on pushes to `main`, and the README badge is pinned with `?branch=main`, so it reports the state of `main` itself.
- Pushes to `main` get a per-commit concurrency group; PR runs keep superseding each other. Without this, back-to-back merges would cancel the earlier run and the badge would report "cancelled".
- The `gate` job's paths-filter works unchanged on push events (diffs against the commit before the push), so docs-only merges still skip e2e.
- New shields.io badge linking to the GHCR container package (`ghcr.io/lj-n/genug-da`), so self-hosters can see a prebuilt image exists. Badge row is now CI · Release · Container · License.

No CHANGELOG entry: CI/docs-only change.