### PR TITLE
chore: sweep internal genug-da references to genug (#246)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to genug-da
+# Contributing to genug
 
-Thanks for your interest in genug-da. The project is source-available and
+Thanks for your interest in genug. The project is source-available and
 maintained by a single person, so contributions work a little differently
 than in larger projects.
 
 ## Issues: welcome
 
 Bug reports and feature requests are welcome — please use the
-[issue templates](https://github.com/lj-n/genug-da/issues/new/choose).
+[issue templates](https://github.com/lj-n/genug/issues/new/choose).
 For suspected security vulnerabilities, do **not** open a public issue; see
 [SECURITY.md](SECURITY.md).
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Something in genug-da doesn't work as expected.
+description: Something in genug doesn't work as expected.
 labels: ['bug', 'needs-triage']
 body:
   - type: textarea
@@ -7,7 +7,7 @@ body:
     attributes:
       label: What happened?
       description: What went wrong, and what did you expect to happen instead?
-      placeholder: When I ..., genug-da ... — I expected ...
+      placeholder: When I ..., genug ... — I expected ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/lj-n/genug-da/security/advisories/new
+    url: https://github.com/lj-n/genug/security/advisories/new
     about: Please report security issues privately via GitHub's vulnerability reporting — never as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,12 @@
 name: Feature request
-description: Suggest an improvement or new capability for genug-da.
+description: Suggest an improvement or new capability for genug.
 labels: ['enhancement', 'needs-triage']
 body:
   - type: textarea
     id: problem
     attributes:
       label: What problem would this solve?
-      description: Describe the situation where genug-da currently falls short, rather than only the solution you have in mind.
+      description: Describe the situation where genug currently falls short, rather than only the solution you have in mind.
     validations:
       required: true
   - type: textarea

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a vulnerability
 
 Please report suspected vulnerabilities privately via
-[GitHub private vulnerability reporting](https://github.com/lj-n/genug-da/security/advisories/new)
+[GitHub private vulnerability reporting](https://github.com/lj-n/genug/security/advisories/new)
 ("Report a vulnerability" on the repository's Security tab).
 
 Do **not** open a public issue for security problems — public issues are

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ name: Publish
 # gate is untouched. main is already green via the PR gate, so this workflow only
 # builds and pushes — it does not re-run the test suite.
 #
-#   push to main        → ghcr.io/lj-n/genug-da:stage + :sha-<short>
-#   push a version tag  → ghcr.io/lj-n/genug-da:<version> + :latest
+#   push to main        → ghcr.io/lj-n/genug:stage + :sha-<short>
+#   push a version tag  → ghcr.io/lj-n/genug:<version> + :latest
 #                          + a GitHub Release whose notes are the CHANGELOG section
 on:
   push:
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  IMAGE: ghcr.io/lj-n/genug-da
+  IMAGE: ghcr.io/lj-n/genug
 
 jobs:
   # Tag pushes always publish. main pushes skip when only docs/markdown changed,

--- a/.vscode/sveltekit-page.code-snippets
+++ b/.vscode/sveltekit-page.code-snippets
@@ -1,5 +1,5 @@
 {
-	// Place your genug-da workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+	// Place your genug workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
 	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
 	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
 	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- The project moved from `lj-n/genug-da` to `lj-n/genug`. Container images are
+  now published to `ghcr.io/lj-n/genug`; self-hosters should update their
+  `image:` reference, as new versions will no longer appear under the old
+  name. The in-app source-code link now points to the new repository.
 - New app logo: a pixel-art mark with a "genug" wordmark next to it, shown in
   the navigation and on the login screens. In the navigation, the version
   number and source-code link moved from the footer to sit under the wordmark.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# genug-da — Agent Instructions
+# genug — Agent Instructions
 
 Persistent agent and workflow rules for this repository.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,4 +1,4 @@
-# genug-da
+# genug
 
 Envelope budgeting: money in a budget is assigned to categories month by month, and spending is tracked against those assignments.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/header-dark.svg">
-    <img src="docs/header-light.svg" width="360" alt="genug-da">
+    <img src="docs/header-light.svg" width="360" alt="genug">
   </picture>
 </p>
 
 <p align="center">
-  <a href="https://github.com/lj-n/genug-da/actions/workflows/ci.yml"><img src="https://github.com/lj-n/genug-da/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-  <a href="CHANGELOG.md"><img src="https://img.shields.io/github/v/tag/lj-n/genug-da?label=release" alt="Release"></a>
-  <a href="https://github.com/lj-n/genug-da/pkgs/container/genug-da"><img src="https://img.shields.io/badge/ghcr.io-lj--n%2Fgenug--da-blue?logo=docker&logoColor=white" alt="Container image"></a>
+  <a href="https://github.com/lj-n/genug/actions/workflows/ci.yml"><img src="https://github.com/lj-n/genug/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="CHANGELOG.md"><img src="https://img.shields.io/github/v/tag/lj-n/genug?label=release" alt="Release"></a>
+  <a href="https://github.com/lj-n/genug/pkgs/container/genug"><img src="https://img.shields.io/badge/ghcr.io-lj--n%2Fgenug-blue?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0--only-blue" alt="License: AGPL-3.0-only"></a>
 </p>
 
@@ -65,13 +65,13 @@ The name is german — "genug" means "enough".
 Runs as a single Node.js container against one SQLite file — no external
 database, cache, or services.
 
-Prebuilt images are published to `ghcr.io/lj-n/genug-da`. A minimal Docker
+Prebuilt images are published to `ghcr.io/lj-n/genug`. A minimal Docker
 Compose stack:
 
 ```yml
 services:
-  genug-da:
-    image: ghcr.io/lj-n/genug-da:latest
+  genug:
+    image: ghcr.io/lj-n/genug:latest
     restart: unless-stopped
     ports:
       - '3000:3000'
@@ -129,6 +129,6 @@ See [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 ## License
 
-genug-da is licensed under the [GNU Affero General Public License v3.0 only](LICENSE) (AGPL-3.0-only).
+genug is licensed under the [GNU Affero General Public License v3.0 only](LICENSE) (AGPL-3.0-only).
 
 Copyright (C) 2026 Linus Johannsen

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Entry point for genug-da's documentation, split into three audiences.
+Entry point for genug's documentation, split into three audiences.
 
 ## Guide
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,7 +1,7 @@
 # API contract (`openapi.yaml`)
 
 `openapi.yaml` is the published OpenAPI 3.1 contract for the additive HTTP API
-(map [#190](https://github.com/lj-n/genug-da/issues/190)). It is **generated** —
+(map [#190](https://github.com/lj-n/genug/issues/190)). It is **generated** —
 do not edit it by hand. It feeds `swift-openapi-generator` in the iOS repo and is
 verified against the live server by a decode-contract test.
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -597,7 +597,7 @@ info:
   license:
     identifier: AGPL-3.0-only
     name: AGPL-3.0-only
-  title: genug-da API
+  title: genug API
   version: 0.0.0-draft.1
 openapi: 3.1.0
 paths:

--- a/docs/dev/adr/0012-calver-releases-and-stage-deploy.md
+++ b/docs/dev/adr/0012-calver-releases-and-stage-deploy.md
@@ -5,7 +5,7 @@ Status: accepted
 
 ## Context
 
-genug-da is a self-hosted app. Until now there was no way to tell which build
+genug is a self-hosted app. Until now there was no way to tell which build
 was live: `package.json` was stuck at `0.0.1`, there were zero git tags,
 deployment was a manual pull of an untagged image straight from `main`, and
 there was no changelog. When something broke the exact shipped code could not be
@@ -48,7 +48,7 @@ deep module) and ADR-0004 (isolating fiddly math behind one internal seam).
 **A stage lane via image tags, not a branch (Model A).** One long-lived branch
 (`main`); "stage" and "prod" are image tags, not branches. A push to `main`
 publishes a rolling `:stage` plus an immutable `:sha-<short>` to
-`ghcr.io/lj-n/genug-da`; a version tag publishes the frozen `:<version>` plus a
+`ghcr.io/lj-n/genug`; a version tag publishes the frozen `:<version>` plus a
 moving `:latest`. A deploy host runs two Compose stacks pulling `:stage` and
 `:latest`; rollback is pinning prod to a prior `:<version>`. A new `publish.yml`
 handles this, separate from `ci.yml` so the PR gate is untouched; it

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,9 +1,9 @@
 # Self-Hosting
 
-Operational guidance for running your own genug-da instance. For what the
+Operational guidance for running your own genug instance. For what the
 app does and how to use it, see [usage.md](usage.md).
 
-genug-da is a single Node.js process backed by a single SQLite database
+genug is a single Node.js process backed by a single SQLite database
 file. There are no external services: no mail server, no cache, no separate
 database server.
 
@@ -16,7 +16,7 @@ database server.
 ## Container images
 
 Prebuilt images are published to the GitHub Container Registry at
-`ghcr.io/lj-n/genug-da`:
+`ghcr.io/lj-n/genug`:
 
 | Tag           | Built from      | Use                                                                         |
 | ------------- | --------------- | --------------------------------------------------------------------------- |
@@ -42,9 +42,9 @@ roll back.
 
 ```yml
 services:
-  genug-da:
-    container_name: genug-da
-    image: ghcr.io/lj-n/genug-da:latest
+  genug:
+    container_name: genug
+    image: ghcr.io/lj-n/genug:latest
     restart: unless-stopped
     ports:
       - '3000:3000'
@@ -154,7 +154,7 @@ docker compose pull && docker compose up -d
 ```
 
 Database migrations run automatically at startup. To roll back, pin the
-previous version tag (`image: ghcr.io/lj-n/genug-da:<version>`) — but note
+previous version tag (`image: ghcr.io/lj-n/genug:<version>`) — but note
 that a newer release may have migrated the database beyond what an older
 build expects, so restore the matching database backup when rolling back
 across a migration.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,9 @@
-# Using genug-da
+# Using genug
 
 A feature-oriented walkthrough of the app. For installing and operating an
 instance, see [self-hosting.md](self-hosting.md).
 
-genug-da is an [envelope budgeting](https://en.wikipedia.org/wiki/Envelope_system)
+genug is an [envelope budgeting](https://en.wikipedia.org/wiki/Envelope_system)
 app: money you receive lands in an unassigned pool, and you assign it to
 spending categories before you spend it. Each category's remaining balance
 tells you how much you can still spend in that area.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "genug-da",
+	"name": "genug",
 	"version": "2026.07.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "genug-da",
+			"name": "genug",
 			"version": "2026.07.4",
 			"license": "AGPL-3.0-only",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "genug-da",
+	"name": "genug",
 	"private": true,
 	"version": "2026.07.4",
 	"license": "AGPL-3.0-only",
@@ -28,7 +28,7 @@
 		"better-sqlite3": "^12.8.0",
 		"pino": "^10.3.1"
 	},
-	"//overrides": "Rationale and per-pin removal conditions: https://github.com/lj-n/genug-da/issues/213",
+	"//overrides": "Rationale and per-pin removal conditions: https://github.com/lj-n/genug/issues/213",
 	"overrides": {
 		"cookie": "^0.7.0",
 		"undici": "^7.28.0",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,4 +5,4 @@ export const UNASSIGNED = '__none__' as const;
 export const TRANSFER = '__transfer__' as const;
 
 /** Public source repository — linked in the UI to satisfy the AGPL §13 source offer. */
-export const SOURCE_REPOSITORY_URL = 'https://github.com/lj-n/genug-da';
+export const SOURCE_REPOSITORY_URL = 'https://github.com/lj-n/genug';

--- a/src/lib/server/api/contract.ts
+++ b/src/lib/server/api/contract.ts
@@ -1,5 +1,5 @@
 /**
- * Hand-authored base of the genug-da OpenAPI contract (map #190, settled in
+ * Hand-authored base of the genug OpenAPI contract (map #190, settled in
  * #191).
  *
  * This module owns everything a machine cannot derive: the paths, parameters,
@@ -420,7 +420,7 @@ export const contract: OpenApiDocument = {
 			'additive-only (map decision 14).'
 		].join(' '),
 		license: { identifier: 'AGPL-3.0-only', name: 'AGPL-3.0-only' },
-		title: 'genug-da API',
+		title: 'genug API',
 		version: '0.0.0-draft.1'
 	},
 


### PR DESCRIPTION
Closes #246

Sweeps every internal `genug-da` reference to `genug` after the repository rename to `lj-n/genug` (48 replacements across 21 files):

- `package.json` / `package-lock.json` — package name
- README badges, links, and the Docker Compose example
- `ghcr.io/lj-n/genug-da` → `ghcr.io/lj-n/genug` in `README.md`, `docs/self-hosting.md`, `.github/workflows/publish.yml` (unblocks CI publishing to the new namespace), and ADR-0012
- `SOURCE_REPOSITORY_URL` in `src/lib/constants.ts` (user-visible in-app source link)
- API contract + generated OpenAPI docs, GitHub issue templates, VS Code snippets, `CONTEXT.md`, `CLAUDE.md`
- New `## [Unreleased]` **Changed** CHANGELOG entry for self-hosters (image namespace + repo move)

Historical CHANGELOG entries are left untouched — they were accurate at the time.

Verified with `npm run check`, `npm run lint`, and the full unit suite (669 tests passing).