### PR TITLE
fix(deps): bump brace-expansion to 5.0.7 (Dependabot alert #10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3986,9 +3986,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #10](https://github.com/lj-n/genug/security/dependabot/10) — GHSA-3jxr-9vmj-r5cp / CVE-2026-13149: high-severity DoS in `brace-expansion` via exponential-time expansion of consecutive non-expanding `{}` groups.

- Transitive dev dependency: `eslint` → `minimatch@10.2.4` → `brace-expansion@5.0.6` (vulnerable range `>= 3.0.0, < 5.0.7`)
- Lockfile-only bump to the first patched version 5.0.7; `package.json` untouched (existing semver range `^5.0.2` already allows it)
- This was the only `brace-expansion` entry in the lockfile; `npm audit` reports 0 vulnerabilities after the bump

No CHANGELOG entry per repo convention (dependency bumps are exempt).

## Verification

- `npm run lint` — pass (ESLint is the dependency chain that pulls in brace-expansion)
- `npm run check` — 0 errors
- `npm run test:unit` — 669/669 tests pass