### PR TITLE
Restyle form-control primitives to the locked design language (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- All form controls now follow the new design language: buttons, inputs,
+  textareas, selects, the category picker, checkboxes, toggle groups, the
+  calendar and the date picker share flat surfaces, one border tone, and the
+  thin neutral hover outline. Selected states fill with ink (checked
+  checkboxes, the active toggle item, the picked calendar day) instead of
+  accent tints, and today is marked with a subtle frame. Invalid fields show
+  the red border plus a soft red halo on every control — and the halo now
+  steps aside while a field is focused so the gold focus ring stays visible.
+  Disabled controls consistently dim to half opacity.
 - The budget month view has a simplified, calmer look — the first screen on
   the new design language: categories render as compact separated rows
   without column lines, headers are small quiet labels, the Unallocated chip

--- a/docs/dev/design-language.md
+++ b/docs/dev/design-language.md
@@ -45,6 +45,34 @@ uppercase text-muted`, uniform — no loud bold header cells.
 - Match outline width and negative offset (1px ↔ `-outline-offset-1`) or the
   outline floats inside the edge.
 
+## Form-control family (#257)
+
+The primitives in `src/lib/components/ui` (button, button-group, input,
+input-group, input-money, input-password, textarea, label, checkbox, select,
+select-category, toggle-group, calendar, date-picker, form-field, form-body)
+apply the language as follows; reviewed control-by-control in both modes on
+a live gallery:
+
+- **Shared interaction constants** live in `src/lib/components/ui/focus-ring`:
+  `hoverOutline` (the P7 neutral hover outline, `not-disabled`-guarded) and
+  `invalidRing`/`invalidRingWithin` (error halo). Use these instead of
+  restating the classes.
+- **Selection is ink.** Checked/indeterminate checkboxes, the active
+  toggle-group item and the selected calendar day fill
+  `bg-foreground text-background`. Select/combobox item highlight is a
+  neutral `bg-muted/10` fill. Today in the calendar is a `border-muted/40`
+  frame.
+- **Buttons keep tinted variant fills at rest** (`bg-interactive/10` etc. —
+  the tint reads as affordance meaning under P1); hover adds only the
+  neutral outline, never a deeper tint. Ghost hovers `bg-muted/10`.
+- **Control chrome is flat**: `bg-surface` fill, `border-muted/20`, no
+  shadows (shadows stay overlay-only per P2).
+- **Focus beats the error halo.** Invalid controls always show
+  `border-error`; the soft `ring-3 ring-error/20` halo is suppressed while
+  the control (or, for wrapper chrome, its inner form control) is
+  focus-visible, so the gold ring stays unmistakable.
+- **Disabled is 50% opacity** everywhere; buttons also drop pointer events.
+
 ## Reference implementation
 
 The budget month view (`src/routes/(app)/[budgetId=id]/[month=month]/`) is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "genug",
-	"version": "2026.07.4",
+	"version": "2026.07.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "genug",
-			"version": "2026.07.4",
+			"version": "2026.07.5",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@node-rs/argon2": "^2.0.2",

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -5,8 +5,13 @@
 
 	import { cn, tv, type VariantProps } from 'tailwind-variants';
 
+	import { hoverOutline, invalidRing } from '../focus-ring';
+
 	export const variants = tv({
-		base: "hover:cursor-pointer aria-invalid:ring-error/20 aria-invalid:border-error rounded-md border border-transparent bg-clip-padding active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-2 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: [
+			"hover:cursor-pointer aria-invalid:border-error rounded-md border border-transparent bg-clip-padding active:not-aria-[haspopup]:translate-y-px [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+			invalidRing
+		],
 		defaultVariants: {
 			size: 'default',
 			variant: 'default'
@@ -26,12 +31,12 @@
 				xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3"
 			},
 			variant: {
-				default: 'bg-interactive/10 text-interactive hover:bg-interactive/15',
-				destructive: 'bg-error/10 text-error hover:bg-error/15',
-				ghost: 'hover:bg-muted/10 hover:text-foreground',
-				info: 'bg-info/10 text-info hover:bg-info/15',
+				default: ['bg-interactive/10 text-interactive', hoverOutline],
+				destructive: ['bg-error/10 text-error', hoverOutline],
+				ghost: ['hover:bg-muted/10 hover:text-foreground', hoverOutline],
+				info: ['bg-info/10 text-info', hoverOutline],
 				link: 'text-interactive underline-offset-3 hover:underline',
-				success: 'bg-success/10 text-success hover:bg-success/15'
+				success: ['bg-success/10 text-success', hoverOutline]
 			}
 		}
 	});

--- a/src/lib/components/ui/calendar/calendar-day.svelte
+++ b/src/lib/components/ui/calendar/calendar-day.svelte
@@ -14,9 +14,9 @@
 	class={cn(
 		'flex size-(--cell-size) flex-col items-center justify-center gap-1 rounded-(--cell-radius) p-0 leading-none font-normal whitespace-nowrap select-none',
 		'[&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
-		'not-data-selected:hover:bg-muted/10 not-data-selected:hover:text-foreground',
-		'[&[data-today]:not([data-selected])]:bg-muted/5 [&[data-today]:not([data-selected])]:text-foreground [&[data-today][data-disabled]]:text-muted',
-		'data-selected:bg-info/10 data-selected:text-info data-selected:hover:text-foreground',
+		'not-data-selected:hover:text-foreground not-data-selected:hover:outline-1 not-data-selected:hover:-outline-offset-1 not-data-selected:hover:outline-foreground/50',
+		'[&[data-today]:not([data-selected])]:border [&[data-today]:not([data-selected])]:border-muted/40 [&[data-today]:not([data-selected])]:text-foreground [&[data-today][data-disabled]]:text-muted',
+		'data-selected:bg-foreground data-selected:text-background',
 		'[&[data-outside-month]:not([data-selected])]:text-muted [&[data-outside-month]:not([data-selected])]:hover:text-foreground',
 		'data-disabled:pointer-events-none data-disabled:text-muted data-disabled:opacity-50',
 		'data-unavailable:text-muted data-unavailable:line-through',

--- a/src/lib/components/ui/calendar/calendar-month-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-month-select.svelte
@@ -14,12 +14,7 @@
 	}: WithoutChildrenOrChild<CalendarPrimitive.MonthSelectProps> = $props();
 </script>
 
-<span
-	class={cn(
-		`relative flex rounded-md border border-muted/20 shadow-xs ${focusRingWithin}`,
-		className
-	)}
->
+<span class={cn(`relative flex rounded-md border border-muted/20 ${focusRingWithin}`, className)}>
 	<CalendarPrimitive.MonthSelect
 		bind:ref
 		class="absolute inset-0 bg-background opacity-0"

--- a/src/lib/components/ui/calendar/calendar-year-select.svelte
+++ b/src/lib/components/ui/calendar/calendar-year-select.svelte
@@ -15,12 +15,7 @@
 	}: WithoutChildrenOrChild<CalendarPrimitive.YearSelectProps> = $props();
 </script>
 
-<span
-	class={cn(
-		`relative flex rounded-md border border-muted/20 shadow-xs ${focusRingWithin}`,
-		className
-	)}
->
+<span class={cn(`relative flex rounded-md border border-muted/20 ${focusRingWithin}`, className)}>
 	<CalendarPrimitive.YearSelect bind:ref class="absolute inset-0 opacity-0" {...restProps}>
 		{#snippet child({ props, selectedYearItem, yearItems })}
 			<select {...props} {value}>

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { hoverOutline, invalidRing } from '$lib/components/ui/focus-ring';
 	import { Checkbox as CheckboxPrimitive } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
 	import PhCheck from '~icons/ph/check';
@@ -17,7 +18,9 @@
 	bind:ref
 	data-slot="checkbox"
 	class={cn(
-		'peer relative flex size-4 shrink-0 items-center justify-center rounded-full border shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error aria-invalid:ring-3 aria-invalid:ring-error/20',
+		'peer relative flex size-4 shrink-0 items-center justify-center rounded-xs border bg-surface outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error data-[state=indeterminate]:border-foreground data-[state=indeterminate]:bg-foreground data-[state=indeterminate]:text-background data-checked:border-foreground data-checked:bg-foreground data-checked:text-background',
+		hoverOutline,
+		invalidRing,
 		className
 	)}
 	bind:checked

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -76,7 +76,7 @@
 				{disabled}
 				type="button"
 				class={cn(
-					'w-full justify-between border-muted/30 bg-surface/70 px-2 hover:cursor-text hover:bg-surface/70 aria-expanded:bg-surface/70 aria-expanded:ring-2 aria-expanded:ring-focus',
+					'w-full justify-between border-muted/20 bg-surface px-2 hover:cursor-text hover:bg-surface aria-expanded:outline-1 aria-expanded:-outline-offset-1 aria-expanded:outline-foreground/50',
 					className
 				)}
 				role="combobox"
@@ -106,7 +106,7 @@
 			{placeholder}
 			{locale}
 			onValueChange={closeAndFocusTrigger}
-			class="rounded-xl border border-muted/30 bg-surface-high shadow"
+			class="rounded-xl border border-muted/20 bg-surface-high shadow"
 		/>
 	</Popover.Content>
 </Popover.Root>

--- a/src/lib/components/ui/focus-ring/focus-ring.ts
+++ b/src/lib/components/ui/focus-ring/focus-ring.ts
@@ -5,6 +5,32 @@
  * Both flavors must express the same treatment; only the trigger differs.
  */
 
+/**
+ * Canonical hover feedback (design language P7): a crisp neutral 1px
+ * outline flush with the element edge. Gold stays reserved for keyboard
+ * focus. Guarded on `:not(:disabled)` for form controls that keep pointer
+ * events while disabled.
+ */
+export const hoverOutline =
+	'hover:not-disabled:outline-1 hover:not-disabled:-outline-offset-1 hover:not-disabled:outline-foreground/50';
+
+/**
+ * Error halo for invalid controls (the red border is separate and always
+ * shows). Suppressed while the control draws its focus ring — the ring
+ * utilities would otherwise override the base-layer gold ring, and gold
+ * must stay visible as "keyboard focus is here" (P7).
+ */
+export const invalidRing =
+	'aria-invalid:not-focus-visible:ring-3 aria-invalid:not-focus-visible:ring-error/20';
+
+/**
+ * Container flavor — for wrappers marked aria-invalid whose focus ring is
+ * driven by a wrapped form control (`focusRingWithin`), so the suppression
+ * must key off that child's focus-visible, not the wrapper's own.
+ */
+export const invalidRingWithin =
+	'aria-invalid:not-has-[:is(input,select,textarea):focus-visible]:ring-3 aria-invalid:not-has-[:is(input,select,textarea):focus-visible]:ring-error/20';
+
 /** `focus-visible:` flavor — for elements that receive focus directly. */
 export const focusRing = 'focus-visible:ring-2 focus-visible:ring-focus';
 

--- a/src/lib/components/ui/focus-ring/index.ts
+++ b/src/lib/components/ui/focus-ring/index.ts
@@ -1,1 +1,7 @@
-export { focusRing, focusRingWithin } from './focus-ring';
+export {
+	focusRing,
+	focusRingWithin,
+	hoverOutline,
+	invalidRing,
+	invalidRingWithin
+} from './focus-ring';

--- a/src/lib/components/ui/input-group/input-group.svelte
+++ b/src/lib/components/ui/input-group/input-group.svelte
@@ -4,7 +4,7 @@
 
 	import { cn } from 'tailwind-variants';
 
-	import { focusRingWithin } from '../focus-ring';
+	import { focusRingWithin, hoverOutline } from '../focus-ring';
 
 	let {
 		children,
@@ -19,7 +19,7 @@
 	data-slot="input-group"
 	role="group"
 	class={cn(
-		`group/input-group relative flex w-full min-w-0 items-center rounded-md border border-muted/30 bg-surface outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 ${focusRingWithin} has-[[data-slot][aria-invalid=true]]:border-error has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5`,
+		`group/input-group relative flex w-full min-w-0 items-center rounded-md border border-muted/20 bg-surface outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 ${hoverOutline} ${focusRingWithin} has-[[data-slot][aria-invalid=true]]:border-error has-[[data-slot][aria-invalid=true]]:not-has-[:is(input,select,textarea):focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:not-has-[:is(input,select,textarea):focus-visible]:ring-error/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5`,
 		className
 	)}
 	{...props}

--- a/src/lib/components/ui/input/input-variants.test.ts
+++ b/src/lib/components/ui/input/input-variants.test.ts
@@ -12,7 +12,7 @@ describe('inputVariants', () => {
 		const result = classList(inputVariants());
 
 		expect(result).toEqual(
-			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/30', 'bg-surface/70', 'h-9'])
+			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/20', 'bg-surface', 'h-9'])
 		);
 	});
 
@@ -69,7 +69,7 @@ describe('inputVariants', () => {
 		const result = classList(inputVariants({ variant: 'container' }));
 
 		expect(result).toEqual(
-			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/30', 'bg-surface/70', 'h-9'])
+			expect.arrayContaining(['rounded-lg', 'border', 'border-muted/20', 'bg-surface', 'h-9'])
 		);
 		expect(result.filter((cls) => /^p[xy]?-/.test(cls))).toEqual([]);
 	});

--- a/src/lib/components/ui/input/input-variants.ts
+++ b/src/lib/components/ui/input/input-variants.ts
@@ -1,9 +1,9 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
-import { focusRingWithin } from '../focus-ring';
+import { focusRingWithin, hoverOutline, invalidRing, invalidRingWithin } from '../focus-ring';
 
 export const inputVariants = tv({
-	base: 'w-full outline-none placeholder:text-muted aria-invalid:border-error',
+	base: 'w-full outline-none placeholder:text-muted disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error',
 	defaultVariants: {
 		multiline: false,
 		variant: 'default'
@@ -15,12 +15,17 @@ export const inputVariants = tv({
 		},
 		variant: {
 			container: [
-				'flex items-center rounded-lg border border-muted/30 bg-surface/70 focus-within:bg-surface/80',
-				focusRingWithin
+				'flex items-center rounded-lg border border-muted/20 bg-surface',
+				hoverOutline,
+				focusRingWithin,
+				invalidRingWithin
 			],
-			default:
-				'rounded-lg border border-muted/30 bg-surface/70 px-3 py-1 focus-visible:bg-surface/80',
-			ghost: 'px-3 py-1'
+			default: [
+				'rounded-lg border border-muted/20 bg-surface px-3 py-1',
+				hoverOutline,
+				invalidRing
+			],
+			ghost: ['px-3 py-1', invalidRing]
 		}
 	}
 });

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -77,7 +77,7 @@
 	<Combobox.Item
 		value={args.value}
 		label={args.label}
-		class="relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-info/5 data-highlighted:text-info data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+		class="relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-muted/10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 	>
 		{#snippet children({ selected })}
 			<span class="absolute inset-e-2 flex size-3.5 items-center justify-center">

--- a/src/lib/components/ui/select/select-item.svelte
+++ b/src/lib/components/ui/select/select-item.svelte
@@ -18,7 +18,7 @@
 	{value}
 	data-slot="select-item"
 	class={cn(
-		"relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-info/5 focus:text-info not-data-[variant=destructive]:focus:**:text-info data-highlighted:bg-info/5 data-highlighted:text-info data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+		"relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-muted/10 data-highlighted:bg-muted/10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/select/select-trigger.svelte
+++ b/src/lib/components/ui/select/select-trigger.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { WithoutChild } from 'bits-ui';
 
+	import { hoverOutline, invalidRing } from '$lib/components/ui/focus-ring';
 	import { Select as SelectPrimitive } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
 	import PhCaretDown from '~icons/ph/caret-down';
@@ -21,7 +22,9 @@
 	data-slot="select-trigger"
 	data-size={size}
 	class={cn(
-		"flex w-fit items-center justify-between gap-1.5 rounded-md border border-muted/20 bg-surface py-2 pr-2 pl-2.5 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error aria-invalid:ring-3 aria-invalid:ring-error/20 data-placeholder:text-muted data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		invalidRing,
+		"flex w-fit items-center justify-between gap-1.5 rounded-md border border-muted/20 bg-surface py-2 pr-2 pl-2.5 text-sm whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-error data-placeholder:text-muted data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		hoverOutline,
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/textarea/textarea.svelte
+++ b/src/lib/components/ui/textarea/textarea.svelte
@@ -17,11 +17,7 @@
 <textarea
 	bind:this={ref}
 	data-slot={dataSlot}
-	class={cn(
-		inputVariants({ multiline: true }),
-		'flex disabled:cursor-not-allowed disabled:opacity-50',
-		className
-	)}
+	class={cn(inputVariants({ multiline: true }), 'flex', className)}
 	bind:value
 	{...restProps}
 ></textarea>

--- a/src/lib/components/ui/toggle-group/toggle-group-item.svelte
+++ b/src/lib/components/ui/toggle-group/toggle-group-item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { focusRing } from '$lib/components/ui/focus-ring';
+	import { focusRing, hoverOutline } from '$lib/components/ui/focus-ring';
 	import { ToggleGroup as ToggleGroupPrimitive, type WithoutChild } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
 
@@ -16,7 +16,8 @@
 	data-slot="toggle-group-item"
 	class={cn(
 		focusRing,
-		"inline-flex items-center justify-center gap-1.5 rounded-sm px-3 py-1 text-sm font-medium whitespace-nowrap text-muted transition-colors outline-none select-none hover:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-interactive/10 data-[state=on]:text-interactive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		hoverOutline,
+		"inline-flex items-center justify-center gap-1.5 rounded-sm px-3 py-1 text-sm font-medium whitespace-nowrap text-muted transition-colors outline-none select-none hover:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-foreground data-[state=on]:text-background [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
Closes #257.

Applies the design language locked in #255 and the palette from #256 to the full form-control family in `src/lib/components/ui` (button, button-group, input, input-group, input-money, input-password, textarea, label, checkbox, select, select-category, toggle-group, calendar, date-picker, form-field, form-body). Reviewed live, control-by-control in light and dark, on a throwaway gallery route (deleted before this PR; the decisions are captured in a new **Form-control family** section of `docs/dev/design-language.md`).

## What changed

- **Flat chrome** — `bg-surface` fill and `border-muted/20` on all control borders; `shadow-xs` removed from in-page controls (shadows remain overlay-only).
- **Neutral hover, gold = keyboard** — the canonical 1px `outline-foreground/50` hover treatment is now a shared `hoverOutline` const in `focus-ring`, used across the family; ghost buttons hover `bg-muted/10` so the effect darkens rather than brightens in light mode.
- **Selection is ink** — checked/indeterminate checkbox (now square instead of the app's only circle), the active toggle-group item and the selected calendar day fill `bg-foreground text-background`; select/combobox highlight is a neutral `bg-muted/10`; today gets a `border-muted/40` frame.
- **Invalid states unified** — every control shows `border-error` plus the soft `ring-error/20` halo; the halo is suppressed while the control is focus-visible (shared `invalidRing`/`invalidRingWithin` consts) so the gold focus ring always stays visible.
- **Open date-picker** shows the neutral outline instead of a gold ring (gold stays exclusive to keyboard focus).
- **Disabled unified at 50% opacity** — real `disabled` buttons and single-line inputs previously had no dimming at all.

Also syncs the package-lock root version stamp with the 2026.07.5 release (2-line diff).

## Verification

- `npm run check` — 0 errors
- `npm run test:unit` — 669/669 (two `input-variants` class assertions updated to the new tokens)
- `npm run lint` — clean
- Every variant/state (hover, focus, disabled, error) reviewed in both themes on the live gallery, per the issue.