### PR TITLE
Budget table: bold the Remaining amount when non-zero (#271)

### DIFF
--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -71,6 +71,7 @@
 			<div
 				class={cn(
 					'flex size-full items-center justify-end rounded-sm px-1',
+					remaining !== 0 && 'font-semibold',
 					remaining < 0 && 'text-error'
 				)}
 			>


### PR DESCRIPTION
Resolves #271 (child of the restyle map #254).

On the month-view budget table the Remaining cell read flat regardless of value once the tinted chips were dropped. This gives a non-zero remaining **weight**: `font-semibold` (600) lifts it off the regular-weight IBM Plex Mono baseline. Zero stays at the resting weight (and muted, via the disabled reassignment trigger). One-line change in `reassignment-popup.svelte`.

- Weight confirmed live with the map driver: **semibold**, not bold.
- Zero/non-zero boundary verified against **both palettes** — zero row (`€0.00`) muted+regular; positives semibold foreground; negative semibold + error color (red light / salmon dark).
- Quality bar green on the branch: `check` (0 errors), `lint`, unit (669), e2e (114).

No CHANGELOG entry per the map's working agreement (single entry consolidated at the final `restyle` → `main` PR).