### PR TITLE
feat(budget): condense month-view header controls (#272)

### DIFF
--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -29,14 +29,14 @@
 	const month = $derived(parseMonth(params.month));
 
 	// Shared with the category table (same query, no extra round-trip): the
-	// month navigator, quick actions, and unassigned summary only appear once
-	// the budget has a category — before that the tutorial card and the
-	// table's empty state are the whole view.
+	// month navigator and unassigned summary only appear once the budget has a
+	// category — before that the tutorial card and the table's empty state are
+	// the whole view. Create + archived live in the table's Category header.
 	const categories = $derived(
 		await (month === null ? Promise.resolve([]) : getMonthly({ budgetId: budgetId(), month }))
 	);
-	// Already loaded by the quick actions (cached): with no active category
-	// left, the archived link must still be reachable below.
+	// With no active category left, the archived link must still be reachable
+	// below (the table — and its header actions — is replaced by an empty state).
 	const archivedCategories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
 </script>
 
@@ -63,11 +63,7 @@
 				<!-- Prominent-stack below @3xl (ADR-0014): navigator row first, then the
 				     unassigned summary as a full-width band. -->
 				<div class="flex flex-col gap-3 @3xl/main:flex-row @3xl/main:items-end">
-					<div class="flex flex-wrap items-end gap-3">
-						<MonthNavigator {month} />
-
-						<CategoryQuickActions />
-					</div>
+					<MonthNavigator {month} />
 
 					<UnassignedSummary {month} />
 				</div>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -8,13 +8,15 @@
 	import { EmptyState } from '$lib/components/ui/empty-state';
 	import { m } from '$lib/paraglide/messages';
 	import { getBudget, getMonthly } from '$lib/remote-functions/budget.remote';
-	import { reorderCategories } from '$lib/remote-functions/category.remote';
+	import { getArchivedCategories, reorderCategories } from '$lib/remote-functions/category.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { clamp } from '$lib/utils/clamp';
 	import { asMoney, formatMoney } from '$lib/utils/money';
 	import { createSortable } from '$lib/utils/sort-helper.svelte';
 	import { cn } from 'tailwind-variants';
+	import ArchiveIcon from '~icons/ph/archive';
 	import PhDotsSixVerticalBold from '~icons/ph/dots-six-vertical-bold';
+	import PlusIcon from '~icons/ph/plus';
 	import StackIcon from '~icons/ph/stack';
 
 	import BudgetTableCell from './budget-table-cell.svelte';
@@ -31,6 +33,19 @@
 	} = $props();
 
 	const budgetId = getBudgetId();
+
+	// Create + archived live in the Category column header (desktop) and a mobile
+	// action row above the cards; the archived link only shows when there is
+	// something archived to reach.
+	const archivedCategories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
+	const archivedHref = $derived(
+		resolve('/(app)/[budgetId=id]/categories/archived', { budgetId: budgetId() })
+	);
+	// Mobile create routes to the standalone form page rather than the inline
+	// dialog (mirrors the previous quick-actions behaviour below the breakpoint).
+	const createHref = $derived(
+		resolve('/(app)/[budgetId=id]/categories/new', { budgetId: budgetId() })
+	);
 
 	const { currency } = $derived(await getBudget(budgetId()));
 	// `month` can transiently be null while navigating away from this route —
@@ -91,8 +106,30 @@
 	<div role="table">
 		<div role="rowgroup" class="hidden @3xl/main:block">
 			<div role="row" class="flex border-b border-muted/30 bg-muted/3">
-				<BudgetTableHeader class="w-2/5">
-					{m.budget_monthly_table_header_category()}
+				<!-- aria-label keeps the columnheader's accessible name as just the column
+				     title; the create/archived controls inside carry their own names. -->
+				<BudgetTableHeader class="w-2/5" aria-label={m.budget_monthly_table_header_category()}>
+					<span class="flex items-center gap-1">
+						{m.budget_monthly_table_header_category()}
+						<Button
+							size="xs"
+							class="ml-1"
+							aria-label={m.category_create_button()}
+							onclick={() => (createDialogOpen = true)}
+						>
+							<PlusIcon class="size-4" />
+						</Button>
+						{#if archivedCategories.length > 0}
+							<Button
+								variant="ghost"
+								size="xs"
+								href={archivedHref}
+								aria-label={m.category_archived_link({ amount: archivedCategories.length })}
+							>
+								<ArchiveIcon class="size-4" />
+							</Button>
+						{/if}
+					</span>
 				</BudgetTableHeader>
 				<BudgetTableHeader class="w-1/5">
 					{m.budget_monthly_table_header_amount()}
@@ -107,6 +144,21 @@
 					<span class="sr-only">{m.budget_monthly_table_header_actions()}</span>
 				</BudgetTableHeader>
 			</div>
+		</div>
+
+		<!-- The desktop column header carries create + archived, but it is hidden
+		     below @3xl — surface the same actions as a row above the cards. -->
+		<div class="mb-2 flex flex-wrap gap-0.5 @3xl/main:hidden">
+			<Button href={createHref} class="h-11">
+				<PlusIcon class="size-6" />
+				{m.category_create_button()}
+			</Button>
+			{#if archivedCategories.length > 0}
+				<Button variant="ghost" class="h-11" href={archivedHref}>
+					<ArchiveIcon class="size-6" />
+					{m.category_archived_link({ amount: archivedCategories.length })}
+				</Button>
+			{/if}
 		</div>
 
 		<!-- Zebra open ledger (design language P5) on the desktop table; the

--- a/src/routes/(app)/[budgetId=id]/[month=month]/month-navigator.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/month-navigator.svelte
@@ -47,7 +47,7 @@
 
 <div>
 	{#snippet monthStepButton(ariaLabel: string, icon: Snippet, onClick: () => void)}
-		<Button aria-label={ariaLabel} size="icon" class="@max-3xl/main:size-11" onclick={onClick}>
+		<Button aria-label={ariaLabel} size="icon-sm" class="@max-3xl/main:size-11" onclick={onClick}>
 			{@render icon()}
 		</Button>
 	{/snippet}
@@ -84,7 +84,8 @@
 				{#snippet child({ props })}
 					<Button
 						{...props}
-						class="min-w-26 text-base font-bold text-foreground @max-3xl/main:h-11"
+						size="sm"
+						class="min-w-20 text-sm font-semibold text-foreground @max-3xl/main:h-11"
 					>
 						{formatMonth({ month: selectedMonth, options: { month: 'short', year: '2-digit' } })}
 					</Button>


### PR DESCRIPTION
Part of the **restyle** effort ([map #254](https://github.com/lj-n/genug/issues/254)). Resolves [#272](https://github.com/lj-n/genug/issues/272).

## What

The month view's header controls (month toggle, create-category, archived) read too big and competed with the budget table. This moves category actions out of the header row and into the table itself.

- **Desktop:** create + archived become `xs` icon buttons beside the **Category** column header (`CATEGORY [+] [▤]`) — `+` tinted, archive ghost, archive shown only when something is archived.
- **Mobile:** the desktop column header is hidden below `@3xl`, so the actions surface as a labelled action row **above the category cards** (create routes to the standalone form page, matching the prior mobile behaviour).
- **Header row** now carries only the slimmed month toggle + the right-anchored unassigned status.

## Approach

Explored live in the running app via a throwaway `?variant=` switcher (six arrangements: fused button groups, overflow menu, top-right dropdown, table-header icons/labels). Converged on table-header icon buttons (variant F). All prototype scaffolding removed before merge.

## Preserved

- Empty-state CTA, the "last category archived" reachability branch, month-toggle 44px mobile touch targets, and the unassigned mobile band.
- Columnheader accessible name pinned to "Category" so the inline controls don't pollute it.

## Verification

- `npm run check` (0 errors), lint/format clean, 669 unit tests pass.
- Full Playwright suite green.
- Light + dark × desktop + mobile confirmed visually in the live app.

No CHANGELOG entry — per the restyle map, a single entry is added at the final `restyle` → `main` PR.