### PR TITLE
Restyle category & transfer popovers to sit over their cells (#276)

### DIFF
--- a/src/lib/components/ui/popover/popover-content.svelte
+++ b/src/lib/components/ui/popover/popover-content.svelte
@@ -7,6 +7,7 @@
 		type WithChildren,
 		type WithoutChildrenOrChild
 	} from 'bits-ui';
+	import { fade, type TransitionConfig } from 'svelte/transition';
 	import { cn } from 'tailwind-variants';
 
 	import PopoverPortal from './popover-portal.svelte';
@@ -15,13 +16,24 @@
 		align = 'center',
 		children,
 		class: className,
+		motion = 'slingshot',
 		portalProps,
 		ref = $bindable(null),
 		sideOffset = 4,
 		...restProps
-	}: WithChildren<PopoverPrimitive.ContentProps> & {
+	}: {
+		/** `fade` opts out of the slingshot slide — for panels that overlay their anchor. */
+		motion?: 'fade' | 'slingshot';
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof PopoverPortal>>;
-	} = $props();
+	} & WithChildren<PopoverPrimitive.ContentProps> = $props();
+
+	// `motion` is read at play time (closure) so it stays live if toggled.
+	function enter(node: Element, params: { side?: unknown }): TransitionConfig {
+		return motion === 'fade' ? fade(node, { duration: 100 }) : floatingIn(node, params);
+	}
+	function exit(node: Element): TransitionConfig {
+		return motion === 'fade' ? fade(node, { duration: 100 }) : floatingOut(node);
+	}
 </script>
 
 <PopoverPortal {...portalProps}>
@@ -42,8 +54,8 @@
 							'z-50 flex w-72 origin-(--transform-origin) flex-col gap-4 rounded-md bg-surface-high p-4 text-sm shadow-md ring-1 ring-foreground/10 outline-hidden',
 							className
 						)}
-						in:floatingIn={{ side: props['data-side'] }}
-						out:floatingOut
+						in:enter={{ side: props['data-side'] }}
+						out:exit
 					>
 						{@render children?.()}
 					</div>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
@@ -1,6 +1,9 @@
 <!-- Desktop glance surface for a category: the budget table's name cell anchors
      a popover with the viewed month's stats and a link to the detail page.
-     The anchored cell already shows the name, so the popover carries none. -->
+     The popover sits directly on top of the cell — a negative offset equal to the
+     cell's own height overlaps it exactly, so the panel replaces ("hides") the
+     cell and grows from there (down by default, up when there's no room below).
+     That's why the panel repeats the category name before the viewed month. -->
 <script lang="ts">
 	import type { Month } from '$lib/utils/month';
 
@@ -38,12 +41,26 @@
 	function prefetch() {
 		void getCategoryStats({ categoryId: row.id, month });
 	}
+
+	// The panel overlaps its trigger cell exactly: a negative main-axis offset
+	// equal to the cell's own height pulls the panel back over the cell (in both
+	// flip directions), hiding it. Measured live so it tracks the row density —
+	// the same height sizes the panel's title strip, so the name stays put.
+	let triggerEl = $state<HTMLElement | null>(null);
+	let cellHeight = $state(0);
+	$effect(() => {
+		if (!triggerEl) return;
+		const observer = new ResizeObserver(() => (cellHeight = triggerEl!.offsetHeight));
+		observer.observe(triggerEl);
+		return () => observer.disconnect();
+	});
 </script>
 
 <Popover.Root>
 	<!-- relative + z on hover/focus: the outline must paint above the target
 	     progress bar that overlays the cell's bottom edge. -->
 	<Popover.Trigger
+		bind:ref={triggerEl}
 		class="relative flex size-full cursor-pointer items-center px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10"
 		onpointerenter={prefetch}
 		onfocus={prefetch}
@@ -51,18 +68,40 @@
 		{row.name}
 	</Popover.Trigger>
 
-	<Popover.Content align="start" sideOffset={1} class="w-(--bits-popover-anchor-width) gap-3 p-3">
-		<div class="flex items-center justify-between gap-2">
-			<h3 class="text-sm font-semibold">
-				{formatMonth({ month, options: { month: 'long', year: 'numeric' } })}
-			</h3>
+	<Popover.Content
+		side="bottom"
+		align="start"
+		sideOffset={-cellHeight}
+		motion="fade"
+		class="w-(--bits-popover-anchor-width) gap-0 overflow-hidden rounded-xs p-0 shadow-sm ring-1 ring-muted/30"
+	>
+		<!-- Title strip mirrors the cell: same px-2 inset and height, and the name
+		     repeats the cell's exact font (Plex Sans 16px/400/24) so it stays put —
+		     no size flicker — when the panel opens over the cell. The muted fill +
+		     hairline divider keep this "cell zone" distinct from the stats below. -->
+		<div
+			class="flex items-center justify-between gap-2 border-b border-muted/20 bg-muted/5 px-2"
+			style="min-height: {cellHeight}px"
+		>
+			<div class="flex min-w-0 items-baseline gap-1.5">
+				<!-- font-sans overrides the display (Lora) face that h3 gets by
+				     default, so the name matches the cell's Plex Sans exactly. -->
+				<h3 class="truncate font-sans text-base leading-6 font-normal">{row.name}</h3>
+				<span class="shrink-0 text-xs text-muted">
+					{formatMonth({ month, options: { month: 'short', year: 'numeric' } })}
+				</span>
+			</div>
 
-			<Button size="sm" href={settingsHref}>
+			<Button size="sm" variant="ghost" href={settingsHref}>
 				{m.category_popover_settings()}
 				<ArrowRightIcon />
 			</Button>
 		</div>
 
-		<CategoryStatsMonthly categoryId={row.id} {currency} {month} />
+		<!-- flex-gap so the sparkline and the stat tiles don't touch (the two are
+		     bare siblings out of CategoryStatsMonthly). -->
+		<div class="flex flex-col gap-3 p-3">
+			<CategoryStatsMonthly categoryId={row.id} {currency} {month} />
+		</div>
 	</Popover.Content>
 </Popover.Root>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -1,9 +1,15 @@
+<!-- Desktop transfer surface for a category's Remaining cell. Like the category
+     detail popover, the panel sits directly on top of its cell (a negative
+     offset equal to the cell's height overlaps it exactly) and grows from
+     there. The header mirrors the cell: the move/cover label on the left, the
+     remaining amount pinned on the right in the cell's own font so it stays
+     put — no flicker — when the panel opens over it. The form follows below. -->
 <script lang="ts">
 	import type { Month } from '$lib/utils/month';
 
 	import { Button } from '$lib/components/ui/button';
 	import { InputMoney } from '$lib/components/ui/input-money';
-	import { PopoverForm } from '$lib/components/ui/popover-form';
+	import * as Popover from '$lib/components/ui/popover';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { UNASSIGNED } from '$lib/constants';
 	import * as m from '$lib/paraglide/messages';
@@ -14,6 +20,7 @@
 		reassignment
 	} from '$lib/remote-functions/budget.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import { asMoney, formatMoney } from '$lib/utils/money';
 	import { Combobox } from 'bits-ui';
 	import { cn } from 'tailwind-variants';
@@ -46,115 +53,140 @@
 	const form = $derived(reassignment.for(id));
 
 	let open = $state(false);
+
+	const submit = createFormSubmit(() => form, {
+		onSuccess: () => {
+			open = false;
+		},
+		updates: () => [getMonthly, getUnassigned]
+	});
+
+	// Clear any thrown error when the popover closes so it never flashes on reopen.
+	$effect(() => {
+		if (!open) submit.reset();
+	});
+
+	// The panel overlaps its trigger cell exactly (see category-popover): a
+	// negative main-axis offset equal to the cell's height pulls it back over the
+	// cell in both flip directions, and the same height sizes the header strip so
+	// the amount stays put.
+	let triggerEl = $state<HTMLElement | null>(null);
+	let cellHeight = $state(0);
+	$effect(() => {
+		if (!triggerEl) return;
+		const observer = new ResizeObserver(() => (cellHeight = triggerEl!.offsetHeight));
+		observer.observe(triggerEl);
+		return () => observer.disconnect();
+	});
+
+	const isMove = $derived(remaining > 0);
 </script>
 
-<PopoverForm
-	{form}
-	bind:open
-	align="end"
-	sideOffset={1}
-	contentClass="rounded-xs p-3 shadow-lg"
-	formClass="flex flex-col gap-3"
-	updates={() => [getMonthly, getUnassigned]}
->
-	{#snippet trigger(props)}
-		<button
-			{...props}
-			class={cn(
-				'h-full w-full cursor-pointer p-1 text-right font-currency hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50',
-				'aria-disabled:text-muted aria-disabled:hover:bg-transparent aria-disabled:hover:outline-none'
-			)}
-			disabled={remaining === 0}
-			aria-disabled={remaining === 0}
-			aria-label={m.reassignment_trigger_label({ name: categoryName })}
-		>
-			<div
-				class={cn(
-					'flex size-full items-center justify-end rounded-sm px-1',
-					remaining !== 0 && 'font-semibold',
-					remaining < 0 && 'text-error'
-				)}
-			>
-				{formatMoney({ currency, money: asMoney(remaining) })}
-			</div>
-		</button>
-	{/snippet}
-
-	{#snippet fields()}
-		<input {...form.fields.budgetId.as('hidden', budgetId())} />
-		<input type="hidden" name={form.fields.month.as('number').name} value={month} />
-
-		{#if remaining > 0}
-			{@render moveform()}
-		{:else}
-			{@render coverform()}
-		{/if}
-	{/snippet}
-
-	{#snippet footer({ pending })}
-		<div class="flex justify-end gap-2">
-			<Button variant="ghost" size="sm" onclick={() => (open = false)}
-				>{m.reassignment_cancel()}</Button
-			>
-			<Button type="submit" size="sm" loading={pending}>{m.reassignment_ok()}</Button>
-		</div>
-	{/snippet}
-</PopoverForm>
-
-{#snippet sharedFields()}
-	<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
-	<SelectCategory
-		name={form.fields.targetCategoryId.as('select').name}
-		bind:value={
-			() => form.fields.targetCategoryId.value() ?? '', (v) => form.fields.targetCategoryId.set(v)
-		}
-		categories={otherCategories}
-		nullable
-		ariaInvalid={form.fields.targetCategoryId.issues()?.length ? true : undefined}
-		textEmpty={m.reassignment_unassigned()}
-		ariaLabel={m.reassignment_category()}
-		ariaLabelTrigger={m.reassignment_select_category()}
+<Popover.Root bind:open>
+	<!-- The closed cell IS the trigger; it mirrors the header's amount slot so the
+	     value doesn't jump when the panel opens over it. -->
+	<Popover.Trigger
+		bind:ref={triggerEl}
+		disabled={remaining === 0}
+		aria-disabled={remaining === 0}
+		aria-label={m.reassignment_trigger_label({ name: categoryName })}
+		class={cn(
+			'flex size-full cursor-pointer items-center justify-end px-2 text-right font-currency font-semibold hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10',
+			remaining < 0 && 'text-error',
+			remaining === 0 &&
+				'cursor-default font-normal text-muted hover:bg-transparent hover:outline-none'
+		)}
 	>
-		{#snippet customItemRow({ label, value: id })}
-			{@render customSelectRow({
-				balance: id === UNASSIGNED ? unassigned : getOtherRemaining(id),
-				id,
-				label
-			})}
-		{/snippet}
-	</SelectCategory>
-{/snippet}
+		{formatMoney({ currency, money: asMoney(remaining) })}
+	</Popover.Trigger>
 
-{#snippet moveform()}
-	<div class="flex flex-col gap-1.5">
-		<div class="flex items-center justify-between gap-4">
-			<span class="font-medium">{m.reassignment_move()}</span>
-			<ArrowFatLineDownDuotoneIcon class="size-5 text-success" />
+	<!-- ring (box-shadow), not border: a border-box border would shrink the
+	     content box and shift the header 1px off the cell on open. -->
+	<Popover.Content
+		side="bottom"
+		align="end"
+		sideOffset={-cellHeight}
+		motion="fade"
+		class="w-80 gap-0 overflow-hidden rounded-xs p-0 shadow-sm ring-1 ring-muted/30"
+	>
+		<!-- Header mirrors the cell: label left, amount right (px-2 inset + cell
+		     font), sized to the cell's height so the amount lands where it was.
+		     The muted fill + hairline divider match the category popover's header. -->
+		<div
+			class="flex items-center justify-between gap-2 border-b border-muted/20 bg-muted/5 px-2"
+			style="min-height: {cellHeight}px"
+		>
+			<span class="flex items-center gap-1.5 text-sm font-medium">
+				<ArrowFatLineDownDuotoneIcon
+					class={cn('size-4', isMove ? 'text-success' : 'rotate-180 text-error')}
+				/>
+				{isMove ? m.reassignment_move() : m.reassignment_cover()}
+			</span>
+
+			<!-- The popover base is text-sm, but the cell renders font-currency in a
+			     text-base (16px) context, so its 0.9375em lands at 15px. Restore that
+			     16px em-context here so the amount matches the cell exactly — neither
+			     shrinks nor grows when the panel opens over it. -->
+			<span class="text-base leading-6">
+				<span class={cn('font-currency font-semibold', remaining < 0 && 'text-error')}>
+					{formatMoney({ currency, money: asMoney(remaining) })}
+				</span>
+			</span>
 		</div>
 
-		<InputMoney
-			name={form.fields.amount.as('number').name}
-			aria-label={m.reassignment_amount()}
-			bind:value={() => form.fields.amount.value(), (v) => form.fields.amount.set(v)}
-			currency={budget.currency}
-			class="px-2 text-right font-currency"
-			selectOnFocus
-		/>
+		<form {...submit.attrs} class="flex flex-col gap-3 p-3">
+			<input {...form.fields.budgetId.as('hidden', budgetId())} />
+			<input type="hidden" name={form.fields.month.as('number').name} value={month} />
+			<input {...form.fields.sourceCategoryId.as('hidden', rowId)} />
 
-		{@render sharedFields()}
-	</div>
-{/snippet}
+			{#if isMove}
+				<InputMoney
+					name={form.fields.amount.as('number').name}
+					aria-label={m.reassignment_amount()}
+					bind:value={() => form.fields.amount.value(), (v) => form.fields.amount.set(v)}
+					currency={budget.currency}
+					class="px-2 text-right font-currency"
+					selectOnFocus
+				/>
+			{:else}
+				<input {...form.fields.amount.as('hidden', remaining)} />
+			{/if}
 
-{#snippet coverform()}
-	<div class="flex items-center justify-between gap-4">
-		<span class="font-medium">{m.reassignment_cover()}</span>
-		<ArrowFatLineDownDuotoneIcon class="size-5 rotate-180 text-error" />
-	</div>
+			<SelectCategory
+				name={form.fields.targetCategoryId.as('select').name}
+				bind:value={
+					() => form.fields.targetCategoryId.value() ?? '',
+					(v) => form.fields.targetCategoryId.set(v)
+				}
+				categories={otherCategories}
+				nullable
+				ariaInvalid={form.fields.targetCategoryId.issues()?.length ? true : undefined}
+				textEmpty={m.reassignment_unassigned()}
+				ariaLabel={m.reassignment_category()}
+				ariaLabelTrigger={m.reassignment_select_category()}
+			>
+				{#snippet customItemRow({ label, value: id })}
+					{@render customSelectRow({
+						balance: id === UNASSIGNED ? unassigned : getOtherRemaining(id),
+						id,
+						label
+					})}
+				{/snippet}
+			</SelectCategory>
 
-	<input {...form.fields.amount.as('hidden', remaining)} />
+			{#if submit.error}
+				<p class="text-sm text-error" role="alert">{submit.error.message}</p>
+			{/if}
 
-	{@render sharedFields()}
-{/snippet}
+			<div class="flex justify-end gap-2">
+				<Button variant="ghost" size="sm" onclick={() => (open = false)}>
+					{m.reassignment_cancel()}
+				</Button>
+				<Button type="submit" size="sm" loading={submit.pending}>{m.reassignment_ok()}</Button>
+			</div>
+		</form>
+	</Popover.Content>
+</Popover.Root>
 
 {#snippet customSelectRow(item: { balance: number; id: string; label: string })}
 	<Combobox.Item

--- a/tests/playwright/category-responsive.spec.ts
+++ b/tests/playwright/category-responsive.spec.ts
@@ -36,13 +36,16 @@ test('Category name cell opens the monthly-stats popover on wide viewports', asy
 	// off screen.
 	await expect(popover).toBeInViewport();
 
-	// Month label (the viewed month — what the stats are scoped to), the
-	// Settings link to the detail page, and the monthly stats body.
+	// The popover's heading repeats the category name (the panel opens over the
+	// name cell); the viewed month — what the stats are scoped to — sits beside
+	// it in short form. Plus the Settings link and the monthly stats body.
+	await expect(popover.getByRole('heading', { name: categoryName })).toBeVisible();
 	const monthLabel = new Intl.DateTimeFormat('en', {
-		month: 'long',
+		month: 'short',
 		year: 'numeric'
 	}).format(new Date());
-	await expect(popover.getByRole('heading', { name: monthLabel })).toBeVisible();
+	// exact: the sparkline's SVG <title> also contains the month ("Jul 2026: €…").
+	await expect(popover.getByText(monthLabel, { exact: true })).toBeVisible();
 	await expect(popover.getByRole('link', { name: 'Settings' })).toBeVisible();
 	await expect(popover.getByText('Average Monthly Spend')).toBeVisible();
 });


### PR DESCRIPTION
Resolves the `wayfinder:prototype` ticket **#276** under the **Wayfinder: restyle** map (#254). Delivers onto the long-lived `restyle` branch.

Both desktop budget-table popovers now open **directly on top of the cell** that triggers them, repeating the cell's own content in a mirrored header so nothing moves on open.

## Category detail popover
- Header repeats the category **name** (cell font, so it stays put) with the viewed month in short form beside it.
- Anchored to cover the cell exactly (top-left down / bottom-left up via Floating UI flip).
- Filled muted header strip + hairline divider; `ring` frame + `shadow-sm`.
- Fade-in (dropped the slingshot spring).
- Restored the gap between the sparkline and the stat tiles.

## Assignment-transfer popover
- Reworked to the same covering-popover baseline.
- Header mirrors the Remaining cell: **Move / Cover** label on the left, remaining **amount pinned on the right** in the cell's font (15px, no shrink/grow).
- Filled muted header + hairline, `ring` frame, fade-in — consistent with the category popover.

## Shared / mechanics
- `popover-content.svelte` gains an opt-in `motion="fade"` for panels that overlay their anchor (default slingshot unchanged for other callers).
- Frames use `ring` (box-shadow) not `border`, so the border-box content doesn't shrink and jog the header 1px on open.
- Header amount restores a 16px em-context so `font-currency`'s `0.9375em` lands at the cell's 15px.

## Verification
- Reviewed in **light and dark** mode.
- `npm run check`, lint, unit (669), and e2e all green. Updated `category-responsive.spec.ts` to the new popover structure (heading = category name, short month label).

No CHANGELOG entry per ticket — the single entry lands on the final `restyle` → `main` PR.