### PR TITLE
feat(transaction): relayout account balances and fold filter into action group (#274)

### DIFF
--- a/src/lib/components/features/account/account-balances.svelte
+++ b/src/lib/components/features/account/account-balances.svelte
@@ -26,7 +26,7 @@
 <!-- Below @3xl each entry is a compact label/amount row (operators dropped);
      at @3xl and up the original horizontal validated + pending = balance strip. -->
 <div
-	class="flex w-full flex-col gap-1 rounded-md bg-muted/5 p-3 @3xl/main:w-fit @3xl/main:flex-row @3xl/main:flex-wrap @3xl/main:items-center @3xl/main:gap-x-6 @3xl/main:gap-y-2"
+	class="flex w-full flex-col gap-1 @3xl/main:w-fit @3xl/main:flex-row @3xl/main:flex-wrap @3xl/main:items-center @3xl/main:gap-x-6 @3xl/main:gap-y-2"
 >
 	<div
 		class="flex flex-row-reverse items-center justify-between gap-4 @3xl/main:flex-col @3xl/main:items-start @3xl/main:justify-center @3xl/main:gap-0"

--- a/src/lib/components/features/transaction/transaction-table-filter.svelte
+++ b/src/lib/components/features/transaction/transaction-table-filter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import * as ButtonGroup from '$lib/components/ui/button-group';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { m } from '$lib/paraglide/messages';
 	import { type Snippet, tick } from 'svelte';
@@ -15,6 +16,7 @@
 		budgetId,
 		children,
 		filter,
+		leading,
 		onClearAllFilters,
 		onClearFilter,
 		onSetFilter
@@ -22,6 +24,7 @@
 		budgetId: string;
 		children?: Snippet;
 		filter: TransactionFilter;
+		leading?: Snippet;
 		onClearAllFilters: () => void;
 		onClearFilter: (type: FilterType) => void;
 		onSetFilter: (type: FilterType, value: string | string[]) => void;
@@ -52,36 +55,40 @@
 </script>
 
 <div class="flex w-full flex-col gap-2">
-	<div class="flex gap-1.5">
-		<!-- Filtering is desktop-only; on the phone the register keeps only the create affordance. -->
-		<div class="hidden gap-1.5 @3xl/main:flex">
-			<DropdownMenu.Root>
-				<DropdownMenu.Trigger disabled={allActive}>
-					{#snippet child({ props })}
-						<Button {...props}>
-							<FunnelBoldIcon />
-							{m.transaction_filter_title()}
-						</Button>
-					{/snippet}
-				</DropdownMenu.Trigger>
+	<div class="flex flex-wrap items-end gap-3">
+		<!-- Balances (or nothing) sit to the left; every control clusters on the right. -->
+		{@render leading?.()}
+		<div class="ml-auto flex gap-1.5">
+			<!-- Filtering is desktop-only; on the phone the register keeps only the create affordance.
+			     The filter trigger and clear-all form their own group, separate from the create actions. -->
+			<ButtonGroup.Root class="hidden @3xl/main:flex">
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger disabled={allActive}>
+						{#snippet child({ props })}
+							<Button {...props} size="icon" aria-label={m.transaction_filter_title()}>
+								<FunnelBoldIcon />
+							</Button>
+						{/snippet}
+					</DropdownMenu.Trigger>
 
-				<DropdownMenu.Content class="w-fit">
-					{#each availableFilters as f (f.type)}
-						<DropdownMenu.Item onSelect={() => addAndFocus(f.type)}>
-							{filter.getConfig(f.type).label()}
-						</DropdownMenu.Item>
-					{/each}
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
+					<DropdownMenu.Content class="w-fit">
+						{#each availableFilters as f (f.type)}
+							<DropdownMenu.Item onSelect={() => addAndFocus(f.type)}>
+								{filter.getConfig(f.type).label()}
+							</DropdownMenu.Item>
+						{/each}
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
 
-			{#if anyActive}
-				<Button variant="destructive" size="icon" onclick={() => onClearAllFilters()}>
-					<XIcon />
-				</Button>
-			{/if}
+				{#if anyActive}
+					<Button variant="destructive" size="icon" onclick={() => onClearAllFilters()}>
+						<XIcon />
+					</Button>
+				{/if}
+			</ButtonGroup.Root>
+
+			{@render children?.()}
 		</div>
-
-		{@render children?.()}
 	</div>
 
 	{#each filter.items as f (f.type)}

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { ListTransaction } from '$lib/server/db/user-context/transaction';
 	import type { CURRENCIES } from '$lib/utils/currencies';
+	import type { Snippet } from 'svelte';
 
 	import { Button } from '$lib/components/ui/button';
 	import * as ButtonGroup from '$lib/components/ui/button-group';
@@ -29,6 +30,7 @@
 	import TransferTableRow from './transfer-table-row.svelte';
 
 	let {
+		accountBalances,
 		accountId,
 		budgetId,
 		currency,
@@ -36,6 +38,7 @@
 		tableState,
 		transactions
 	}: {
+		accountBalances?: Snippet;
 		accountId: string;
 		budgetId: string;
 		currency: (typeof CURRENCIES)[number];
@@ -71,13 +74,14 @@
 	<TableFilter
 		{budgetId}
 		filter={tableState.filter}
+		leading={accountBalances}
 		onSetFilter={(type, value) => tableState.setFilter(type, value)}
 		onClearFilter={(type) => tableState.clearFilter(type)}
 		onClearAllFilters={() => tableState.clearAllFilters()}
 	>
 		<!-- One create group per affordance (ADR-0014): the inline popover rows at
 		     @3xl and up, the bottom sheets below. Only one group is ever visible. -->
-		<ButtonGroup.Root class="ml-auto hidden @3xl/main:flex" bind:ref={createTriggerGroup}>
+		<ButtonGroup.Root class="hidden @3xl/main:flex" bind:ref={createTriggerGroup}>
 			<Button
 				aria-expanded={openCreateRow}
 				onclick={() => {
@@ -101,7 +105,7 @@
 			</Button>
 		</ButtonGroup.Root>
 
-		<ButtonGroup.Root class="ml-auto flex @3xl/main:hidden">
+		<ButtonGroup.Root class="flex @3xl/main:hidden">
 			<Button class="h-11" onclick={() => (createModalOpen = true)}>
 				<PlusBoldIcon />
 				{m.transactions_table_create_transaction()}

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -108,11 +108,11 @@
 	</Page.Header>
 
 	<Page.Content>
-		<AccountBalances {balances} currency={budget.currency} />
-
-		<Separator orientation="horizontal" />
-
 		{#if account.archivedAt}
+			<AccountBalances {balances} currency={budget.currency} />
+
+			<Separator orientation="horizontal" />
+
 			<AccountArchivedNotice accountId={accountId()} />
 		{:else}
 			<TransactionTable
@@ -126,7 +126,11 @@
 				}}
 				{tableState}
 				transactions={result.transactions}
-			/>
+			>
+				{#snippet accountBalances()}
+					<AccountBalances {balances} currency={budget.currency} />
+				{/snippet}
+			</TransactionTable>
 		{/if}
 	</Page.Content>
 </Page.Root>


### PR DESCRIPTION
Resolves the prototype ticket #274 on the restyle map (#254).

## What changed (transaction / account screen)
- **Balances → header row left.** Account balances now sit at the left of the table's header row (where the filter button was), rendered **flat** — no `bg-muted/5` card, no padding — reading as plain content aligned with the table's left edge.
- **Divider dropped.** The horizontal separator beneath the balances is gone (active accounts). Archived accounts keep the old top placement + divider (no table there).
- **Filter → icon-only, own group.** The filter trigger is now an icon-only funnel button with `aria-label="Filter"`, grouped with the clear-all button in its own `ButtonGroup`, separate from the create/transfer group. Both clusters right-aligned, **bottom-aligned** with the balances.
- **Mobile.** Balances stack full-width (label/amount rows), the create-only group sits right-aligned below; filter stays desktop-only.

Balances are threaded into the table via a `leading`/`accountBalances` snippet, keeping the account component in the page.

## Review
Prototyped live, one detail at a time, signed off in both light and dark (desktop + mobile).

- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run test:unit` — 669 passed
- `npm run test:e2e` — 114 passed (chromium + tablet)

No CHANGELOG entry per the map's working agreement (consolidated into the final `restyle` → `main` PR).