### PR TITLE
fix(transaction): keep edit-cell focus outline above neighbour hover fill

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-cols.ts
+++ b/src/lib/components/features/transaction/transaction-table-cols.ts
@@ -14,16 +14,20 @@ export const cellClass =
 	'grid min-h-9 border-b border-l border-muted/10 p-0 first-of-type:border-l-0';
 
 // Read-mode click-to-edit trigger: fills the cell so hover/focus feedback
-// sits at the cell edge (design-language interaction-layer rules).
+// sits at the cell edge (design-language interaction-layer rules). Focus
+// lifts one level above hover (z-20 vs z-10) so a hovered neighbour's surface
+// fill never paints over the focused cell's gold outline where the ring
+// overlaps the shared cell edge (#275).
 export const cellTriggerClass =
-	'relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10';
+	'relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
 // Edit-mode control: borderless, fills the whole cell, keeps the trigger's
 // px-2 so the text does not move when the row switches read ⇄ edit. Hover
 // mirrors the read triggers (surface fill + neutral outline) so every edit
-// cell reacts the same way the date trigger does.
+// cell reacts the same way the date trigger does. Focus lifts above hover
+// (z-20 vs z-10) so a hovered neighbour never clips the focus outline (#275).
 export const editInputClass =
-	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10';
+	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
 // SelectCategory extras: the container already wraps a px-2 input, so it goes
 // px-0 itself; min-w-0 on container and input stops the trigger caret from


### PR DESCRIPTION
Resolves #275 (child of the `restyle` map #254).

## Problem

In the transaction register, when keyboard focus is in a cell (category/notes) and the pointer hovers the adjacent cell to the right, the hovered cell's white surface fill paints over the focused cell's gold focus outline by ~1px along the shared hairline edge.

## Cause

Cells are transparent grid items (z auto), so the inner triggers/inputs resolve their `z-index` in the row's stacking context. A focused cell (`focus-visible:z-10`) and a hovered neighbour (`hover:z-10` + `hover:bg-surface`) both sat at `z-10` → the tie broke by DOM order → the right-hand hovered cell painted its fill over the focus ring where the ring spreads past the cell edge.

## Fix

Lift keyboard focus one stacking level above hover — `focus-visible:z-20` vs `hover:z-10` — in both the read-mode trigger (`cellTriggerClass`) and the edit-mode input (`editInputClass`), so the focus outline always stays above neighbouring hover fills. Applies to both modes as the ticket asks.

One file: `transaction-table-cols.ts` (the shared register geometry). No behaviour, DOM, or layout change — z-index value only.

## Checks

- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run test:unit` — 669 passed

Per the map's working agreement, no CHANGELOG entry (consolidated into the final `restyle` → `main` PR). Visual review in both light/dark + both modes is the reviewer's step before merge into `restyle`.