### PR TITLE
Quiet the form panels with dividers, darken dialogs (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- The settings page dropped its stacked tinted panels for a calmer layout:
+  each section sits directly on the page, separated by hairline dividers that
+  hug the heading they introduce. Dialogs now use a slightly darker surface so
+  they no longer read as too bright in dark mode.
 - The navigation sidebar follows the design language now: a narrower, quieter
   rail at the tables' compact density. The "Budgets" heading is gone — budget
   names anchor their accounts in ink, and the current budget or account is

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -44,7 +44,7 @@
 					bind:this={ref}
 					{...props}
 					class={cn(
-						'fixed inset-0 z-50 m-auto flex h-fit max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] flex-col gap-6 overflow-hidden rounded-md bg-surface-high p-6 text-sm shadow-md ring-1 ring-foreground/10 outline-none sm:max-w-lg',
+						'fixed inset-0 z-50 m-auto flex h-fit max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] flex-col gap-6 overflow-hidden rounded-md bg-surface p-6 text-sm shadow-md ring-1 ring-foreground/10 outline-none sm:max-w-lg',
 						className
 					)}
 					in:modalIn

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -7,6 +7,7 @@
 	import { InputPassword } from '$lib/components/ui/input-password';
 	import * as Page from '$lib/components/ui/page';
 	import * as Select from '$lib/components/ui/select';
+	import { Separator } from '$lib/components/ui/separator';
 	import { m } from '$lib/paraglide/messages';
 	import { getLocale, type Locale, locales, setLocale } from '$lib/paraglide/runtime';
 	import { changePassword, changeUsername, getUser } from '$lib/remote-functions/user.remote';
@@ -36,7 +37,7 @@
 	</Page.Header>
 
 	<Page.Content class="max-w-xl">
-		<form {...usernameSubmit.attrs} class="grid gap-3 rounded-lg bg-muted/5 p-3">
+		<form {...usernameSubmit.attrs} class="grid gap-3">
 			<h2 class="font-semibold">{m.settings_change_display_name()}</h2>
 
 			<FormField
@@ -59,7 +60,9 @@
 			</Button>
 		</form>
 
-		<form {...passwordSubmit.attrs} class="grid gap-3 rounded-lg bg-muted/5 p-3">
+		<Separator class="mt-4 -mb-2.5" />
+
+		<form {...passwordSubmit.attrs} class="grid gap-3">
 			<h2 class="font-semibold">{m.settings_change_password()}</h2>
 
 			<FormField
@@ -87,20 +90,26 @@
 			</Button>
 		</form>
 
-		<div class="grid gap-3 rounded-lg bg-muted/5 p-3">
+		<Separator class="mt-4 -mb-2.5" />
+
+		<div class="grid gap-3">
 			<h2 class="font-semibold">{m.settings_theme()}</h2>
 
 			<ThemeControl theme={data.theme} />
 		</div>
 
-		<div class="grid gap-3 rounded-lg bg-muted/5 p-3">
+		<Separator class="mt-4 -mb-2.5" />
+
+		<div class="grid gap-3">
 			<h2 class="font-semibold">{m.settings_api_tokens()}</h2>
 
 			<ApiTokenManager />
 		</div>
 
-		<div class="grid rounded-lg bg-muted/5 p-3">
-			<h2 class="mb-6 font-semibold">{m.settings_language()}</h2>
+		<Separator class="mt-4 -mb-2.5" />
+
+		<div class="grid gap-3">
+			<h2 class="font-semibold">{m.settings_language()}</h2>
 
 			<Select.Root
 				type="single"


### PR DESCRIPTION
Closes #277.

## What & why

The input-tint restyle read as visual noise mainly because tinted fields sat inside tinted panels — tinted box in tinted box. This prototypes and lands a quieter treatment.

The decision from the live prototype loop: **keep the field tint**, and instead quiet what surrounds it.

- **Settings page** — dropped the stacked `bg-muted/5` section panels; each section now sits directly on the page, separated by `Separator` hairlines with asymmetric **Hug** spacing (`mt-4 -mb-2.5`) so each divider hugs the heading it introduces rather than floating between sections.
- **Dialogs** — `bg-surface-high` → `bg-surface`, so they no longer read as too bright in dark mode.

## Scope

This establishes the *direction*. The account-settings dialog and `/new` still wrap fields in a tinted `FormBody`; those per-screen passes are separate downstream work that depended on this decision.

## Verification

- `npm run check` → 0 errors / 0 warnings
- Prettier clean
- Both light and dark modes checked; divider spacing and dialog surface measured against the design tokens