### PR TITLE
feat(budget): linked account list + currency symbols in Budget Settings dialog (#293)

### DIFF
--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -2,7 +2,6 @@
 	import { resolve } from '$app/paths';
 	import { AccountCreate } from '$lib/components/features/account';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
-	import { Collapsible, CollapsibleContent } from '$lib/components/ui/collapsible';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { FormField } from '$lib/components/ui/form-field';
 	import { Input } from '$lib/components/ui/input';
@@ -14,6 +13,7 @@
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { CURRENCIES } from '$lib/utils/currencies';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
+	import { currencySymbol } from '$lib/utils/money';
 	import ArchiveIcon from '~icons/ph/archive';
 	import PencilIcon from '~icons/ph/pencil';
 	import PlusIcon from '~icons/ph/plus';
@@ -74,15 +74,22 @@
 							(v) => form.fields.currency.set(v)
 						}
 					>
-						<Select.Trigger class="font-semibold">
-							{form.fields.currency.value() ?? budget.currency}
+						{@const selected = form.fields.currency.value() ?? budget.currency}
+						<Select.Trigger class="w-40">
+							<span class="flex items-center gap-1.5">
+								{selected}
+								<span class="text-muted">{currencySymbol(selected)}</span>
+							</span>
 						</Select.Trigger>
 						<Select.Content>
 							<Select.Group>
 								<Select.Label>{m.budget_settings_available_currencies()}</Select.Label>
 								{#each CURRENCIES as currency (currency)}
-									<Select.Item value={currency} label={currency} class="font-semibold">
-										{currency}
+									<Select.Item value={currency} label={currency}>
+										<span class="flex items-center gap-1.5">
+											{currency}
+											<span class="text-muted">{currencySymbol(currency)}</span>
+										</span>
 									</Select.Item>
 								{/each}
 							</Select.Group>
@@ -96,14 +103,24 @@
 			</form>
 
 			<div class="grid gap-2">
-				<div class="font-display text-base font-semibold">
-					{m.budget_account_list_accounts_label()}
+				<div class="flex items-center gap-1">
+					<div class="font-display text-base font-semibold">
+						{m.budget_account_list_accounts_label()}
+					</div>
+					<Button
+						size="xs"
+						class="ml-1"
+						aria-label={m.budget_account_list_add_account()}
+						onclick={() => (addOpen = true)}
+					>
+						<PlusIcon class="size-4" />
+					</Button>
 				</div>
 
-				{#if accounts.length === 0}
+				{#if accounts.length === 0 && archivedAccounts.length === 0}
 					<p class="px-1 text-sm text-muted">{m.account_dropdown_empty_hint()}</p>
 				{:else}
-					<ul class="grid gap-0.5">
+					<ul class="grid list-disc gap-1 pl-6 text-sm marker:text-muted/50">
 						{#each accounts as account (account.id)}
 							<li>
 								<a
@@ -112,41 +129,31 @@
 										budgetId: budgetId()
 									})}
 									onclick={() => (open = false)}
-									class="flex items-center rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-muted/10"
+									class="text-foreground underline-offset-3 hover:underline"
 								>
 									{account.name}
 								</a>
 							</li>
 						{/each}
+						{#if archivedAccounts.length > 0}
+							<li>
+								<a
+									href={resolve('/(app)/[budgetId=id]/accounts/archived', {
+										budgetId: budgetId()
+									})}
+									onclick={() => (open = false)}
+									class="inline-flex items-center gap-1.5 text-muted underline-offset-3 hover:text-foreground hover:underline"
+								>
+									<ArchiveIcon class="size-3.5" />
+									{m.account_archived_link({ amount: archivedAccounts.length })}
+								</a>
+							</li>
+						{/if}
 					</ul>
 				{/if}
 
-				<Collapsible bind:open={addOpen}>
-					{#if !addOpen}
-						<Button
-							variant="ghost"
-							size="sm"
-							class="w-full justify-start hover:bg-muted/10"
-							onclick={() => (addOpen = true)}
-						>
-							<PlusIcon />
-							{m.budget_account_list_add_account()}
-						</Button>
-					{/if}
-					<CollapsibleContent>
-						<AccountCreate currency={budget.currency} onSuccess={() => (addOpen = false)} />
-					</CollapsibleContent>
-				</Collapsible>
-
-				{#if archivedAccounts.length > 0}
-					<a
-						href={resolve('/(app)/[budgetId=id]/accounts/archived', { budgetId: budgetId() })}
-						onclick={() => (open = false)}
-						class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted transition-colors hover:bg-muted/10"
-					>
-						<ArchiveIcon class="size-4" />
-						{m.account_archived_link({ amount: archivedAccounts.length })}
-					</a>
+				{#if addOpen}
+					<AccountCreate currency={budget.currency} onSuccess={() => (addOpen = false)} />
 				{/if}
 			</div>
 		</Dialog.Body>

--- a/src/lib/utils/money.ts
+++ b/src/lib/utils/money.ts
@@ -29,6 +29,19 @@ export function asMoney(cents: number): Money {
 	return cents as Money;
 }
 
+/** The narrow currency glyph (e.g. `$`, `€`, `¥`) for display beside a code. */
+export function currencySymbol(
+	currency: (typeof CURRENCIES)[number],
+	locale: Locale = getLocale()
+): string {
+	const parts = new Intl.NumberFormat(locale, {
+		currency,
+		currencyDisplay: 'narrowSymbol',
+		style: 'currency'
+	}).formatToParts(0);
+	return parts.find((part) => part.type === 'currency')?.value ?? currency;
+}
+
 export function formatMoney({
 	currency,
 	locale = getLocale(),


### PR DESCRIPTION
Closes #293 (child of the restyle map #254).

Budget Settings dialog visual polish, iterated live one detail at a time (both modes), then merged into `restyle`.

## Account list
- The folded-in accounts now read as a **proper bulleted list** — muted dot markers, names as **resting-ink links** that underline on hover (dropped the button-ish `rounded-md px-2 py-1.5 hover:bg-muted/10` rows).
- The **archived** link becomes a **peer list element**: archive glyph + muted "N archived", underline on hover.
- **Add Account** moves to a tinted `xs` `+` icon button beside the Lora "Accounts" title — the same pattern as the budget table's category header (#272). Opens the inline add form.

## Currency select
- Dropped the `font-semibold` override on the trigger and options so the value/options render at **normal input-text weight** (they were heavier than the field label above).
- Trigger widened to `w-40`; trigger **and** options show the code + a **muted currency symbol** (`EUR €`, `USD $`, `GBP £`, …), via a new locale-aware `currencySymbol()` helper in `money.ts` (`narrowSymbol`, single source of truth alongside `formatMoney`).

## Fix found en route
Moving the add-account trigger out of the header exposed a bits-ui quirk: a `Collapsible` driven **only** by external `bind:open` (no `Collapsible.Trigger` inside it) leaves the content `data-state="open"` but still `hidden`/`display:none`, so the form never became visible — reproduced as an e2e timeout waiting for the Account Name textbox. Replaced the Collapsible with a deterministic `{#if addOpen}` render.

## Verification
- `npm run check`, `npm run lint`, `npm run test:unit` (669) green.
- `npm run test:e2e` for account / budget / empty-states / a11y (incl. light+dark axe on the dialog) — **44 passed**.
- Light and dark reviewed live.

No CHANGELOG entry — consolidated into the single final `restyle` → `main` PR per the map's working agreement.