### PR TITLE
feat(budget): Create Account as a dialog stacked over Budget Settings (#294)

### DIFF
--- a/src/lib/components/features/account/account-create.svelte
+++ b/src/lib/components/features/account/account-create.svelte
@@ -26,10 +26,14 @@
 	// the close signal and the account list refreshes single-flight, plus any
 	// caller-declared `updates`. Without it, the redirect is the success signal.
 	let {
+		class: className,
 		currency,
 		onSuccess,
 		updates
 	}: {
+		// Override the form-body chrome — e.g. flatten the tinted card when the form
+		// already sits on a dialog surface.
+		class?: string;
 		currency: (typeof CURRENCIES)[number];
 		onSuccess?: () => void;
 		updates?: () => RemoteQueryUpdate[];
@@ -57,7 +61,7 @@
 	});
 </script>
 
-<FormBody {...submit.attrs}>
+<FormBody {...submit.attrs} class={className}>
 	<input {...form.fields.budgetId.as('hidden', budgetId())} />
 
 	<FormField field={form.fields.accountName} label={m.account_label_name()}>

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -31,8 +31,8 @@
 	let open = $state(false);
 	let addOpen = $state(false);
 
-	// Collapse the add-account form when the dialog closes, so reopening starts
-	// from the "Add Account" button rather than a half-filled form.
+	// Close the Add Account dialog whenever Budget Settings closes, so it never
+	// lingers over a dismissed parent and reopening starts fresh.
 	$effect(() => {
 		if (!open) addOpen = false;
 	});
@@ -151,15 +151,40 @@
 						{/if}
 					</ul>
 				{/if}
-
-				{#if addOpen}
-					<AccountCreate currency={budget.currency} onSuccess={() => (addOpen = false)} />
-				{/if}
 			</div>
 		</Dialog.Body>
 
 		<Dialog.Footer>
 			<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
 		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<!--
+	Create Account is its own dialog stacked over Budget Settings, opened by the
+	`+` button above. It's a sibling root (not nested inside the settings
+	`Dialog.Content`) on purpose: our `Dialog.Content` renders its children through
+	a snippet, so a nested `Dialog.Root` would be instantiated in this component's
+	context — outside bits' content context — and never open. As an independent
+	root its own focus trap also fixes the old focus jump to the Budget Name input.
+-->
+<Dialog.Root bind:open={addOpen}>
+	<!--
+		Lighter scrim (`bg-background/30`) so the settings dialog stays present behind
+		instead of receding under a second full scrim. Flat form (`AccountCreate`'s
+		card chrome dropped) so the fields sit on the dialog surface like the budget
+		form above.
+	-->
+	<Dialog.Content class="sm:max-w-md" overlayClass="bg-background/30">
+		<Dialog.Header>
+			<Dialog.Title>{m.new_account_title()}</Dialog.Title>
+		</Dialog.Header>
+		<Dialog.Body>
+			<AccountCreate
+				currency={budget.currency}
+				onSuccess={() => (addOpen = false)}
+				class="rounded-none bg-transparent p-0"
+			/>
+		</Dialog.Body>
 	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -15,19 +15,25 @@
 	let {
 		children,
 		class: className,
+		overlayClass,
 		portalProps,
 		ref = $bindable(null),
 		showCloseButton = true,
 		...restProps
 	}: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
 		children: Snippet;
+		// Override the scrim: a class merged onto the overlay, or `null` to drop the
+		// overlay entirely (e.g. a dialog stacked over another that already dims).
+		overlayClass?: null | string;
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DialogPortal>>;
 		showCloseButton?: boolean;
 	} = $props();
 </script>
 
 <DialogPortal {...portalProps}>
-	<Dialog.Overlay />
+	{#if overlayClass !== null}
+		<Dialog.Overlay class={overlayClass ?? undefined} />
+	{/if}
 	<DialogPrimitive.Content
 		data-slot="dialog-content"
 		{...restProps}

--- a/tests/playwright/a11y.spec.ts
+++ b/tests/playwright/a11y.spec.ts
@@ -134,11 +134,13 @@ for (const theme of THEMES) {
 			await page.keyboard.press('Escape');
 			await expect(categoryDialog).not.toBeVisible();
 
-			// Add account: the inline create-account form in the Budget Settings dialog.
+			// Add account: the create-account form is a nested dialog stacked over
+			// the Budget Settings dialog (#294). Scan both surfaces together.
 			await page.getByRole('button', { name: 'Budget Settings' }).click();
-			const accountsDialog = page.getByRole('dialog');
-			await accountsDialog.getByRole('button', { name: 'Add Account' }).click();
-			await expect(accountsDialog.getByRole('textbox', { name: 'Account Name' })).toBeVisible();
+			const settingsDialog = page.getByRole('dialog', { name: 'Budget Settings' });
+			await settingsDialog.getByRole('button', { name: 'Add Account' }).click();
+			const addAccountDialog = page.getByRole('dialog', { name: 'Add New Account' });
+			await expect(addAccountDialog.getByRole('textbox', { name: 'Account Name' })).toBeVisible();
 			await expectAxeClean(page);
 		});
 

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -30,24 +30,26 @@ export class BudgetPage extends BasePage {
 	}
 
 	async createAccount(name: string, startingBalance = '0') {
-		// Accounts live in the Budget Settings dialog now (#273): open it, expand
-		// the inline Add Account form, and submit.
+		// Accounts live in the Budget Settings dialog now (#273); the Add Account
+		// form is a nested dialog stacked over it (#294). Open settings, open the
+		// account dialog, fill and submit.
 		await this.page.getByRole('button', { name: 'Budget Settings' }).click();
-		const dialog = this.page.getByRole('dialog');
-		await dialog.getByRole('button', { name: 'Add Account' }).click();
+		const settings = this.page.getByRole('dialog', { name: 'Budget Settings' });
+		await settings.getByRole('button', { name: 'Add Account' }).click();
 
-		await dialog.getByRole('textbox', { name: 'Account Name' }).fill(name);
-		await dialog
+		const addDialog = this.page.getByRole('dialog', { name: 'Add New Account' });
+		await addDialog.getByRole('textbox', { name: 'Account Name' }).fill(name);
+		await addDialog
 			.getByRole('textbox', { name: 'What is the current balance?' })
 			.fill(startingBalance);
 
-		await dialog.getByRole('button', { name: 'Create Account' }).click();
+		await addDialog.getByRole('button', { name: 'Create Account' }).click();
 
-		// The inline form creates in place (no redirect): the new account joins
-		// the dialog's account list. Open its link to reach the account page and
-		// capture the URL, then return to the budget page so subsequent
+		// Creates in place (no redirect): the account dialog closes and the new
+		// account joins the settings list. Open its link to reach the account page
+		// and capture the URL, then return to the budget page so subsequent
 		// createCategory / assignAmount calls work.
-		const accountLink = dialog.getByRole('link', { name });
+		const accountLink = settings.getByRole('link', { name });
 		await expect(accountLink).toBeVisible();
 		await accountLink.click();
 		await expect(this.page.getByRole('heading', { name })).toBeVisible();
@@ -66,16 +68,17 @@ export class BudgetPage extends BasePage {
 	async createAccountExpectingError(name: string) {
 		await this.page.getByRole('button', { name: 'Budget Settings' }).click();
 
-		const dialog = this.page.getByRole('dialog');
-		await dialog.getByRole('button', { name: 'Add Account' }).click();
+		const settings = this.page.getByRole('dialog', { name: 'Budget Settings' });
+		await settings.getByRole('button', { name: 'Add Account' }).click();
 
-		await dialog.getByRole('textbox', { name: 'Account Name' }).fill(name);
-		await dialog.getByRole('button', { name: 'Create Account' }).click();
+		const addDialog = this.page.getByRole('dialog', { name: 'Add New Account' });
+		await addDialog.getByRole('textbox', { name: 'Account Name' }).fill(name);
+		await addDialog.getByRole('button', { name: 'Create Account' }).click();
 
-		await expect(dialog.getByText(`${name} already exists.`)).toBeVisible();
-		// The field error keeps the dialog open — a successful create would clear
-		// the form and add the account to the list instead.
-		await expect(dialog).toBeVisible();
+		await expect(addDialog.getByText(`${name} already exists.`)).toBeVisible();
+		// The field error keeps the account dialog open — a successful create would
+		// close it and add the account to the settings list instead.
+		await expect(addDialog).toBeVisible();
 	}
 
 	/**


### PR DESCRIPTION
Resolves #294 (restyle map #254 — Branch-review polish pass II).

Moves the inline Add Account form in the Budget Settings dialog into its own dialog, opened by the `+` beside **Accounts**, so it no longer crowds the accounts list. The account dialog's own focus trap fixes the old focus jump to the Budget Name input.

### Nested vs sibling
The account dialog is an **independent sibling `Dialog.Root`**, not nested inside the settings `Dialog.Content`. Our `Dialog.Content` renders its `children` through a snippet, so a nested `Dialog.Root` instantiates in the parent component's context — outside bits' content context — and never opens (bits' `--bits-dialog-nested-count` stays 0). A sibling root opens reliably and stacks over the settings dialog.

### Locked live (variant switch, then stripped) — light + dark
- **scrim: lighter** — new `overlayClass` prop on `Dialog.Content` (`bg-background/30`) so the settings dialog stays readable behind, instead of vanishing under a second full scrim (bits' default nearly erased it in dark mode).
- **form: flat** — new optional `class` on `AccountCreate` drops the tinted `bg-muted/5` card so fields sit on the dialog surface, matching the flat budget form above.
- **chrome** — "Add New Account" title + X, no footer.

### Tests
- `createAccount` / `createAccountExpectingError` POM and the a11y scan rescoped for the two-dialog flow (Add Account button scoped to the settings dialog; the form to the account dialog).
- `check`, lint, unit (669), full e2e (114) green — including light+dark axe over both stacked dialogs.

No CHANGELOG entry per the map's convention (single entry at the final `restyle` → `main` PR).