### PR TITLE
feat(budget): darker popover surface + zebra stats in the category popover (#295)

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -45,6 +45,7 @@
 	"category_delete_confirm_action": "Löschen",
 	"category_stats_spent": "Bis jetzt ausgegeben",
 	"category_stats_target_percentage": "des Zielbetrags erreicht",
+	"category_stats_target_amount": "{saved} von {target}",
 	"category_stats_transaction_count": "Anzahl Transaktionen",
 	"category_stats_group_all_time": "Gesamter Zeitraum",
 	"category_stats_average": "Durchschnittliche Ausgaben pro Monat",

--- a/messages/en.json
+++ b/messages/en.json
@@ -41,6 +41,7 @@
 	"category_delete_confirm_action": "Delete",
 	"category_stats_spent": "Spent so far",
 	"category_stats_target_percentage": "Of Target Amount Reached",
+	"category_stats_target_amount": "{saved} of {target}",
 	"category_stats_transaction_count": "Number of Transactions",
 	"category_stats_group_all_time": "All Time",
 	"category_stats_average": "Average Monthly Spend",

--- a/src/lib/components/features/category/category-stats-ledger.svelte
+++ b/src/lib/components/features/category/category-stats-ledger.svelte
@@ -1,0 +1,90 @@
+<!-- Chrome-less month stats ledger for the budget table's category popover: the
+     same flat zebra "open ledger" rows the category detail page wears (#280), so
+     the glance surface and the detail page read the same. Just the viewed
+     month's rows — Average, Spend-vs, Target — since the popover header already
+     names the category and month, and the glance stays quick. The target row
+     reads out the saved-of-target amounts, not just the bare percentage. -->
+<script lang="ts">
+	import { m } from '$lib/paraglide/messages';
+	import { getCategoryStats } from '$lib/remote-functions/category.remote';
+	import { clamp } from '$lib/utils/clamp';
+	import { type CURRENCIES } from '$lib/utils/currencies';
+	import { asMoney, formatMoney } from '$lib/utils/money';
+	import { addMonths, formatMonth, type Month } from '$lib/utils/month';
+
+	let {
+		categoryId,
+		currency,
+		month
+	}: {
+		categoryId: string;
+		currency: (typeof CURRENCIES)[number];
+		month: Month;
+	} = $props();
+
+	const stats = $derived(await getCategoryStats({ categoryId, month }));
+
+	// Same row chrome as the detail page's stats ledger (#280): no dividers, an
+	// even-row tint for scanability (P5's zebra idiom), a touch of inset padding.
+	const rowChrome = 'rounded px-2 py-1.5 even:bg-muted/3';
+</script>
+
+<dl class="flex flex-col">
+	<div class="{rowChrome} flex items-baseline justify-between">
+		<dt class="text-sm text-muted">{m.category_stats_average()}</dt>
+		<dd class="font-currency">
+			{stats.trailingAverageSpend === null
+				? '—'
+				: formatMoney({ currency, money: asMoney(stats.trailingAverageSpend) })}
+		</dd>
+	</div>
+
+	<div class="{rowChrome} flex flex-col gap-0.5">
+		<div class="flex items-baseline justify-between">
+			<dt class="text-sm text-muted">
+				{m.category_stats_delta({
+					month: formatMonth({
+						month: addMonths(month, -1),
+						options: { month: 'short', year: 'numeric' }
+					})
+				})}
+			</dt>
+			<dd class="font-currency">
+				{stats.spendDelta > 0 ? '+' : ''}{formatMoney({
+					currency,
+					money: asMoney(stats.spendDelta)
+				})}
+			</dd>
+		</div>
+		<div class="font-currency text-xs text-foreground/60">
+			{m.category_stats_delta_breakdown({
+				currentSpend: formatMoney({ currency, money: asMoney(stats.monthSpend) }),
+				previousSpend: formatMoney({ currency, money: asMoney(stats.previousMonthSpend) })
+			})}
+		</div>
+	</div>
+
+	{#if stats.currentTargetPercentage !== null && stats.targetBalance !== null}
+		{@const clamped = clamp(stats.currentTargetPercentage, 0, 100)}
+		<!-- The target row reads out the saved-of-target amounts above a full-width
+		     bar — so the glance shows how much is set aside toward the target, not
+		     just a bare percentage. -->
+		<div class="{rowChrome} flex flex-col gap-1">
+			<div class="flex items-baseline justify-between">
+				<dt class="text-sm text-muted">{m.category_stats_target_percentage()}</dt>
+				<dd class="font-currency text-sm">
+					{m.category_stats_target_amount({
+						saved: formatMoney({ currency, money: asMoney(stats.currentTargetSaved) }),
+						target: formatMoney({ currency, money: asMoney(stats.targetBalance) })
+					})}
+				</dd>
+			</div>
+			<div class="flex items-center gap-2">
+				<div class="h-1.5 flex-1 overflow-hidden rounded-full bg-muted/20">
+					<div class="h-full bg-success" style="width: {clamped}%"></div>
+				</div>
+				<span class="font-currency text-xs text-muted">{stats.currentTargetPercentage}%</span>
+			</div>
+		</div>
+	{/if}
+</dl>

--- a/src/lib/components/features/category/index.ts
+++ b/src/lib/components/features/category/index.ts
@@ -2,5 +2,6 @@ export { default as CategoryArchive } from './category-archive.svelte';
 export { default as CategoryCreate } from './category-create.svelte';
 export { default as CategoryDelete } from './category-delete.svelte';
 export { default as CategoryEdit } from './category-edit.svelte';
+export { default as CategoryStatsLedger } from './category-stats-ledger.svelte';
 export { default as CategoryStatsMonthly } from './category-stats-monthly.svelte';
 export { default as CategoryStats } from './category-stats.svelte';

--- a/src/lib/server/db/user-context/category.ts
+++ b/src/lib/server/db/user-context/category.ts
@@ -117,8 +117,14 @@ export const queries = (userId: string, db: Database = database) => ({
 						WHEN ${tables.categories.targetBalance} IS NULL THEN NULL
 						ELSE coalesce(${bal.remaining}, 0) * 100 / ${tables.categories.targetBalance}
 					END`,
+				// The target amount and the balance saved toward it in the viewed
+				// month — the two figures a target progress reads out (the popover
+				// shows "saved of target", not just the bare percentage). Saved is
+				// the same viewed-month remaining the percentage divides.
+				currentTargetSaved: sql<number>`coalesce(${bal.remaining}, 0)`,
 				lastActivityDate: sql<null | string>`${bal.lastTransactionDate}`,
 				pendingTransactionCount: sql<number>`coalesce(${bal.pendingCount}, 0)`,
+				targetBalance: sql<null | number>`${tables.categories.targetBalance}`,
 				totalAssignedBudgetCount: sql<number>`coalesce(${bal.assignCount}, 0)`,
 				totalAssignedBudgetSum: sql<number>`coalesce(${bal.allTimeAssignmentSum}, 0)`,
 				totalRelatedTransactionCount: sql<number>`coalesce(${bal.txCount}, 0)`,

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
@@ -8,7 +8,7 @@
 	import type { Month } from '$lib/utils/month';
 
 	import { resolve } from '$app/paths';
-	import { CategoryStatsMonthly } from '$lib/components/features/category';
+	import { CategoryStatsLedger } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
 	import * as Popover from '$lib/components/ui/popover';
 	import { m } from '$lib/paraglide/messages';
@@ -73,7 +73,7 @@
 		align="start"
 		sideOffset={-cellHeight}
 		motion="fade"
-		class="w-(--bits-popover-anchor-width) gap-0 overflow-hidden rounded-xs p-0 shadow-sm ring-1 ring-muted/30"
+		class="w-(--bits-popover-anchor-width) gap-0 overflow-hidden rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30"
 	>
 		<!-- Title strip mirrors the cell: same px-2 inset and height, and the name
 		     repeats the cell's exact font (Plex Sans 16px/400/24) so it stays put —
@@ -98,10 +98,8 @@
 			</Button>
 		</div>
 
-		<!-- flex-gap so the sparkline and the stat tiles don't touch (the two are
-		     bare siblings out of CategoryStatsMonthly). -->
-		<div class="flex flex-col gap-3 p-3">
-			<CategoryStatsMonthly categoryId={row.id} {currency} {month} />
+		<div class="p-2">
+			<CategoryStatsLedger categoryId={row.id} {currency} {month} />
 		</div>
 	</Popover.Content>
 </Popover.Root>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -107,7 +107,7 @@
 		align="end"
 		sideOffset={-cellHeight}
 		motion="fade"
-		class="w-80 gap-0 overflow-hidden rounded-xs p-0 shadow-sm ring-1 ring-muted/30"
+		class="w-80 gap-0 overflow-hidden rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30"
 	>
 		<!-- Header mirrors the cell: label left, amount right (px-2 inset + cell
 		     font), sized to the cell's height so the amount lands where it was.

--- a/tests/playwright/category-responsive.spec.ts
+++ b/tests/playwright/category-responsive.spec.ts
@@ -44,7 +44,8 @@ test('Category name cell opens the monthly-stats popover on wide viewports', asy
 		month: 'short',
 		year: 'numeric'
 	}).format(new Date());
-	// exact: the sparkline's SVG <title> also contains the month ("Jul 2026: €…").
+	// exact: the "Spend vs." row names the previous month, so an inexact match
+	// would risk colliding with a neighbouring month label.
 	await expect(popover.getByText(monthLabel, { exact: true })).toBeVisible();
 	await expect(popover.getByRole('link', { name: 'Settings' })).toBeVisible();
 	await expect(popover.getByText('Average Monthly Spend')).toBeVisible();


### PR DESCRIPTION
Resolves the branch-review polish ticket #295 (part of the restyle map #254). Visual + layout only; merges into `restyle`.

## Detail 1 — dark-mode surface (both popovers)
The two budget-table popovers (category detail + assignment-transfer, #276) drifted from the dialogs after #277 darkened dialogs to `bg-surface`: they still wore the too-bright `bg-surface-high` overlay fill. Both now use `bg-surface`, scoped to just these two popovers (other overlays keep the standard surface). The hairline `ring-muted/30` + `shadow-sm` still read on the darker fill — verified light **and** dark.

## Detail 2 — category-detail popover stats
The loud info-tinted stat tiles become the flat **zebra ledger** from #280, via a new `CategoryStatsLedger` fragment. Trimmed to a quick glance: just the viewed month's rows — **Average / Spend-vs / Target** — since the popover header already names the category and month (no sparkline, no all-time, no redundant month title). Content padding tightened `p-3 → p-2`.

The **target row** now reads out the saved-of-target amounts (**"€115.00 of €400.00"**) above a full-width bar + %, not just the bare percentage. `category.stats()` gains `targetBalance` + `currentTargetSaved` to feed it (new `category_stats_target_amount` message, en + de).

## Note for review
The ticket asked to keep `category-stats-monthly.svelte` **intact**, so it's untouched — but with the popover now on the new ledger, that fragment is no longer imported anywhere (dead export). Kept per the ticket; happy to remove in a follow-up if preferred.

## Checks
`npm run check` (0 errors), lint, unit (669), e2e (114, incl. light+dark axe on the popover) all green. Variant-switch harness stripped — no trace. No CHANGELOG entry (consolidated into the final `restyle` → `main` PR per #254).