### PR TITLE
feat(budget): detint the invite input in the user-management dialog (#296)

### DIFF
--- a/src/lib/components/features/budget-user-manager/user-invitation.svelte
+++ b/src/lib/components/features/budget-user-manager/user-invitation.svelte
@@ -58,46 +58,44 @@
 				</ParaglideMessage>
 			</div>
 
-			<div class="flex w-full items-center gap-2 rounded-lg bg-muted/5 p-3">
-				<FormField
-					class="w-full"
-					field={inviteUser.fields.inviteeName}
-					label={m.admin_input_placeholder_username()}
-					hideLabel
-				>
-					{#snippet input(field)}
-						<InputGroup.Root>
-							<InputGroup.Input
-								{...field.as('text')}
-								placeholder={m.admin_input_placeholder_username()}
-								class="w-full bg-transparent text-base"
-							/>
+			<FormField
+				class="w-full"
+				field={inviteUser.fields.inviteeName}
+				label={m.admin_input_placeholder_username()}
+				hideLabel
+			>
+				{#snippet input(field)}
+					<InputGroup.Root>
+						<InputGroup.Input
+							{...field.as('text')}
+							placeholder={m.admin_input_placeholder_username()}
+							class="w-full bg-transparent text-base"
+						/>
 
-							<InputGroup.Addon align="block-end" class="text-xs font-normal">
-								{#if findUserResult?.current?.userId}
-									<div class="flex items-center gap-1 text-success">
-										{m.budget_users_invite_success()}
-									</div>
-								{:else}
-									<div class="flex items-center gap-1 text-muted">
-										{m.budget_users_username_case_hint()}
-									</div>
-								{/if}
+						<InputGroup.Addon align="block-end" class="text-xs font-normal">
+							{#if findUserResult?.current?.userId}
+								<div class="flex items-center gap-1 text-success">
+									{m.budget_users_invite_success()}
+								</div>
+							{:else}
+								<div class="flex items-center gap-1 text-muted">
+									{m.budget_users_username_case_hint()}
+								</div>
+							{/if}
 
-								<Button
-									type="submit"
-									class="ms-auto"
-									aria-disabled={!findUserResult?.current?.userId}
-									loading={submit.pending}
-									{@attach submit.anchor}
-								>
-									{m.budget_users_invite_button()}
-								</Button>
-							</InputGroup.Addon>
-						</InputGroup.Root>
-					{/snippet}
-				</FormField>
-			</div>
+							<Button
+								type="submit"
+								class="ms-auto"
+								aria-disabled={!findUserResult?.current?.userId}
+								loading={submit.pending}
+								{@attach submit.anchor}
+							>
+								{m.budget_users_invite_button()}
+							</Button>
+						</InputGroup.Addon>
+					</InputGroup.Root>
+				{/snippet}
+			</FormField>
 		</form>
 	</Collapsible.Content>
 </Collapsible.Root>


### PR DESCRIPTION
Part of #254 (restyle). Closes #296.

## What

The invite field in the budget user-management dialog (`user-invitation.svelte`) sat inside a `bg-muted/5 p-3` panel wrapped around the `InputGroup`'s **own** standard field tint (`border-muted/20 bg-muted/5`) — a tinted field stacked inside a tinted panel, the exact noise #277 removed elsewhere.

Dropped the wrapper so the invite field sits **flat on the dialog surface at standard-input register**. The single-child wrapper's `flex/gap` did nothing, so the div is removed entirely and `FormField` sits directly on the form (the rest of the diff is re-indentation).

Scope-guarded per the ticket ("detint the invite input") and the map's one-detail rule: the `bg-info/5` info callout above and the "Users with Access" row tint are left untouched.

## Verification

Live, one detail at a time, via the variant-switch harness (stripped before commit). Both light and dark mode reviewed.

- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run test:unit` — 669 passed
- `npm run test:e2e` — 114 passed