### PR TITLE
feat(budget): enlarge table touch targets at landscape-tablet width (#297)

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-cols.ts
+++ b/src/lib/components/features/transaction/transaction-table-cols.ts
@@ -10,8 +10,12 @@ export const colsClass =
 // (first-of-type drops the frame-adjacent left one — hidden form inputs may
 // precede the cells, hence -of-type). The border sits inside the min-h-9
 // border-box in both modes, so text centers identically read ⇄ edit.
+// Touch band (#297): in the nav-hidden band (@3xl→@max-7xl) rows grow to a
+// 44px min so cells are comfortably tappable; ≥7xl (sidebar back = pointer)
+// snaps to the resting min-h-9. Both read + edit cells share this const, so
+// the pixel-lock holds at every width.
 export const cellClass =
-	'grid min-h-9 border-b border-l border-muted/10 p-0 first-of-type:border-l-0';
+	'grid min-h-9 border-b border-l border-muted/10 p-0 first-of-type:border-l-0 @3xl/main:min-h-11 @7xl/main:min-h-9';
 
 // Read-mode click-to-edit trigger: fills the cell so hover/focus feedback
 // sits at the cell edge (design-language interaction-layer rules). Focus
@@ -28,6 +32,14 @@ export const cellTriggerClass =
 // (z-20 vs z-10) so a hovered neighbour never clips the focus outline (#275).
 export const editInputClass =
 	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
+
+// Touch band (#297): the open-row footer actions (Cancel / Save / Save &
+// continue, on both the transaction and transfer create + edit rows) rest at
+// `size="xs"` (24px) — too small to tap. In the nav-hidden band (@3xl→@max-7xl)
+// they grow to a 44px touch target; ≥7xl (pointer) they snap back to the xs
+// resting geometry. Applied via `class` alongside `size="xs"`.
+export const footerButtonTouchClass =
+	'@3xl/main:h-11 @3xl/main:gap-1.5 @3xl/main:px-4 @3xl/main:text-sm @7xl/main:h-6 @7xl/main:gap-1 @7xl/main:px-2 @7xl/main:text-xs';
 
 // SelectCategory extras: the container already wraps a px-2 input, so it goes
 // px-0 itself; min-w-0 on container and input stops the trigger caret from

--- a/src/lib/components/features/transaction/transaction-table-filter.svelte
+++ b/src/lib/components/features/transaction/transaction-table-filter.svelte
@@ -65,7 +65,12 @@
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger disabled={allActive}>
 						{#snippet child({ props })}
-							<Button {...props} size="icon" aria-label={m.transaction_filter_title()}>
+							<Button
+								{...props}
+								size="icon"
+								class="@3xl/main:size-11 @7xl/main:size-9"
+								aria-label={m.transaction_filter_title()}
+							>
 								<FunnelBoldIcon />
 							</Button>
 						{/snippet}
@@ -81,7 +86,12 @@
 				</DropdownMenu.Root>
 
 				{#if anyActive}
-					<Button variant="destructive" size="icon" onclick={() => onClearAllFilters()}>
+					<Button
+						variant="destructive"
+						size="icon"
+						class="@3xl/main:size-11 @7xl/main:size-9"
+						onclick={() => onClearAllFilters()}
+					>
 						<XIcon />
 					</Button>
 				{/if}

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -21,7 +21,8 @@
 		cellClass,
 		editInputClass,
 		editRowClass,
-		editSelectClass
+		editSelectClass,
+		footerButtonTouchClass
 	} from './transaction-table-cols';
 	import RowErrors from './transaction-table-row-errors.svelte';
 	import ValidationCheckbox from './transaction-validation-checkbox.svelte';
@@ -196,6 +197,7 @@
 						<Button
 							type="button"
 							size="xs"
+							class={footerButtonTouchClass}
 							variant="ghost"
 							disabled={submit.pending}
 							onclick={() => (open = false)}
@@ -206,6 +208,7 @@
 						<Button
 							type="submit"
 							size="xs"
+							class={footerButtonTouchClass}
 							disabled={submit.pending}
 							onclick={() => (submitAndContinue = false)}
 						>
@@ -215,6 +218,7 @@
 						<Button
 							type="submit"
 							size="xs"
+							class={footerButtonTouchClass}
 							disabled={submit.pending}
 							onclick={() => (submitAndContinue = true)}
 						>

--- a/src/lib/components/features/transaction/transaction-table-row.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row.svelte
@@ -31,7 +31,8 @@
 		colsClass,
 		editInputClass,
 		editRowClass,
-		editSelectClass
+		editSelectClass,
+		footerButtonTouchClass
 	} from './transaction-table-cols';
 	import RowErrors from './transaction-table-row-errors.svelte';
 	import ValidateToggle from './transaction-validate-toggle.svelte';
@@ -289,7 +290,14 @@
 			transition:slide={{ duration: 150 }}
 			class="col-span-full flex items-center justify-end gap-1 p-1"
 		>
-			<Button type="button" size="xs" variant="ghost" disabled={pending} onclick={cancelEditing}>
+			<Button
+				type="button"
+				size="xs"
+				class={footerButtonTouchClass}
+				variant="ghost"
+				disabled={pending}
+				onclick={cancelEditing}
+			>
 				{m.cancel()}
 			</Button>
 
@@ -297,6 +305,7 @@
 				type="submit"
 				variant="destructive"
 				size="icon-xs"
+				class="@3xl/main:size-11 @7xl/main:size-6"
 				form={deleteFormId}
 				name={deleteForm.fields.ids.as('select multiple').name}
 				value={[transaction.id]}
@@ -307,7 +316,13 @@
 				<span class="sr-only">{m.delete()}</span>
 			</Button>
 
-			<Button type="submit" size="xs" form={editFormId} disabled={pending}>
+			<Button
+				type="submit"
+				size="xs"
+				class={footerButtonTouchClass}
+				form={editFormId}
+				disabled={pending}
+			>
 				{m.save()}
 			</Button>
 		</div>

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -81,8 +81,12 @@
 	>
 		<!-- One create group per affordance (ADR-0014): the inline popover rows at
 		     @3xl and up, the bottom sheets below. Only one group is ever visible. -->
+		<!-- Touch band (#297): the action cluster grows to 44px targets in the
+		     nav-hidden band (@3xl→@max-7xl); ≥7xl (pointer) it resets to the
+		     resting h-9/size-9. -->
 		<ButtonGroup.Root class="hidden @3xl/main:flex" bind:ref={createTriggerGroup}>
 			<Button
+				class="@3xl/main:h-11 @7xl/main:h-9"
 				aria-expanded={openCreateRow}
 				onclick={() => {
 					openTransferCreateRow = false;
@@ -94,6 +98,7 @@
 			</Button>
 			<Button
 				size="icon"
+				class="@3xl/main:size-11 @7xl/main:size-9"
 				aria-label={m.transactions_table_create_transfer()}
 				aria-expanded={openTransferCreateRow}
 				onclick={() => {

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -20,7 +20,8 @@
 		cellClass,
 		editInputClass,
 		editRowClass,
-		editSelectClass
+		editSelectClass,
+		footerButtonTouchClass
 	} from './transaction-table-cols';
 	import RowErrors from './transaction-table-row-errors.svelte';
 
@@ -195,6 +196,7 @@
 							<Button
 								type="button"
 								size="xs"
+								class={footerButtonTouchClass}
 								variant="ghost"
 								disabled={submit.pending}
 								onclick={() => (open = false)}
@@ -202,7 +204,12 @@
 								{m.cancel()}
 							</Button>
 
-							<Button type="submit" size="xs" disabled={submit.pending}>
+							<Button
+								type="submit"
+								size="xs"
+								class={footerButtonTouchClass}
+								disabled={submit.pending}
+							>
 								{m.save()}
 							</Button>
 						</div>

--- a/src/lib/components/features/transaction/transfer-table-row.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row.svelte
@@ -30,7 +30,8 @@
 		colsClass,
 		editInputClass,
 		editRowClass,
-		editSelectClass
+		editSelectClass,
+		footerButtonTouchClass
 	} from './transaction-table-cols';
 	import RowErrors from './transaction-table-row-errors.svelte';
 	import ValidateToggle from './transaction-validate-toggle.svelte';
@@ -279,7 +280,14 @@
 			<p class="px-1 text-sm text-muted">{m.transfer_amount_hint()}</p>
 
 			<div class="flex items-center gap-1">
-				<Button type="button" size="xs" variant="ghost" disabled={pending} onclick={cancelEditing}>
+				<Button
+					type="button"
+					size="xs"
+					class={footerButtonTouchClass}
+					variant="ghost"
+					disabled={pending}
+					onclick={cancelEditing}
+				>
 					{m.cancel()}
 				</Button>
 
@@ -287,6 +295,7 @@
 					type="submit"
 					variant="destructive"
 					size="icon-xs"
+					class="@3xl/main:size-11 @7xl/main:size-6"
 					form={deleteFormId}
 					name={deleteForm.fields.ids.as('select multiple').name}
 					value={[transaction.id]}
@@ -297,7 +306,13 @@
 					<span class="sr-only">{m.delete()}</span>
 				</Button>
 
-				<Button type="submit" size="xs" form={editFormId} disabled={pending}>
+				<Button
+					type="submit"
+					size="xs"
+					class={footerButtonTouchClass}
+					form={editFormId}
+					disabled={pending}
+				>
 					{m.save()}
 				</Button>
 			</div>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -171,7 +171,7 @@
 						data-drag-item="category"
 						data-sortable-id={row.id}
 						role="row"
-						class="relative flex hover:bg-muted/5 @max-3xl/main:rounded-xs @max-3xl/main:border @max-3xl/main:border-muted/20 @max-3xl/main:bg-surface @3xl/main:even:bg-muted/3"
+						class="relative flex hover:bg-muted/5 @max-3xl/main:rounded-xs @max-3xl/main:border @max-3xl/main:border-muted/20 @max-3xl/main:bg-surface @3xl/main:min-h-11 @3xl/main:even:bg-muted/3 @7xl/main:min-h-0"
 					>
 						<BudgetTableCell class="relative hidden w-2/5 p-0 @3xl/main:flex">
 							<CategoryPopover {currency} {month} {row} />


### PR DESCRIPTION
Resolves #297. Part of the restyle effort (#254).

In the **nav-hidden container-query band** (`@3xl → @max-7xl` of `@container/main` — the desktop table is shown but the sidebar rail is hidden and the floating bottom-nav is up, which is exactly where a ~1180px landscape tablet lands) both flagship tables switch to touch density. At `≥7xl` (sidebar back = pointer) they snap to the resting geometry. Both tables share the one hook (the #297 breakpoint decision); no new breakpoint token.

## Budget month-view table
- Rows grow to `min-h-11` (44px) in the band. The `size-full` popover / assignment / reassignment triggers stretch to the row, so every tap target grows with it.

## Transaction register
- `cellClass` grows to `min-h-11` — read + edit cells stay pixel-locked because both share the const.
- The action cluster (New Transaction / transfer / filter / clear-all) reaches 44px.
- All four open-row footers (Cancel / Save / Save & Continue — transaction + transfer, create + edit) reach 44px via a shared `footerButtonTouchClass`.

## Verification
Iterated live one detail at a time (variant-switch harness, then stripped — no trace ships). Reviewed both light and dark. `check` / `lint` / `unit (669)` green; touched e2e specs + the `tablet` project pass.

No CHANGELOG entry — the restyle effort ships one consolidated entry at the final `restyle → main` PR.