### PR TITLE
feat(budget): flatten the mobile/tablet nav drawer onto the side-menu language (#301)

### DIFF
--- a/docs/dev/design-language.md
+++ b/docs/dev/design-language.md
@@ -216,10 +216,14 @@ text-info`. No per-action accent colors (P1).
   six-dot grip at the row's right edge, `opacity-0 group-hover:opacity-100
 focus-visible:opacity-100` — reorder stays discoverable without
   furnishing the rail.
-- **The mobile drawer keeps slabs, drops shadows**: budget + accounts and
-  the utility list sit on `rounded-md border border-muted/20 bg-surface`
-  cards (flat per P2 — the drawer panel owns the overlay shadow), touch
-  paddings retained, same ink/`info` active idiom as the rail.
+- **The mobile drawer mirrors the rail, flat, at touch density** (#301):
+  the slab cards are gone — budgets and their indented accounts flow as one
+  group and the utility list sits behind the same `border-t border-muted/20`
+  hairline as the rail. Same idiom as desktop: active budget in `info` ink
+  with its inline `size-1.5` dot (transparent slot on the rest so labels
+  align), accounts as `text-muted` sub-items behind the `size-3` bend-arrow,
+  neutral `bg-muted/5` hover. Only the scale differs for touch — `text-lg`
+  rows, `p-2` tap targets, `size-6` utility icons.
 - **Page chrome gaps are 16px by default now**: `Page.Root` and
   `Page.Header` ship `gap-4`, `Page.Content` its grid's `gap-y-4` (P4
   generalized); the month view's call-site overrides are gone.

--- a/src/routes/(app)/navigation-mobile.svelte
+++ b/src/routes/(app)/navigation-mobile.svelte
@@ -86,9 +86,9 @@
 			{@render invitations?.()}
 
 			<nav class="mx-auto grid w-full max-w-md gap-6" {@attach closeDrawerAttachment}>
-				<ul class="space-y-4 text-lg">
+				<ul class="space-y-2 text-lg">
 					{#each await getBudgets() as budget (budget.id)}
-						<li class="flex flex-col gap-1 rounded-md border border-muted/20 bg-surface p-1.5">
+						<li class="flex flex-col gap-1">
 							<a
 								href={resolve('/(app)/[budgetId=id]', { budgetId: budget.id })}
 								class={cn(
@@ -96,6 +96,13 @@
 									isCurrentPage(page, budget.id) && 'text-info'
 								)}
 							>
+								<span
+									class={cn(
+										'size-1.5 shrink-0 rounded-full',
+										isCurrentPage(page, budget.id) ? 'bg-info' : 'bg-transparent'
+									)}
+									aria-hidden="true"
+								></span>
 								{budget.name}
 							</a>
 
@@ -130,7 +137,7 @@
 					{/each}
 				</ul>
 
-				<ul class="flex flex-col gap-1 rounded-md border border-muted/20 bg-surface p-1.5 text-lg">
+				<ul class="flex flex-col border-t border-muted/20 pt-2 text-lg">
 					<li class="flex">
 						<a
 							href={resolve('/(app)/new')}


### PR DESCRIPTION
Closes #301 — part of the restyle effort (#254).

Brings the mobile/tablet navigation drawer into line with the restyled desktop rail (#260), at touch density.

## What changed
- **Flat, no slabs** — dropped the `bg-surface` bordered cards. Budgets and their indented accounts flow as one group; the utility list sits behind the rail's `border-t border-muted/20` hairline instead of its own card.
- **Active `info` dot** — the current budget gets the rail's inline `size-1.5` dot (transparent slot on the rest so labels stay aligned).
- **Touch sizing kept** — `text-lg` rows, `p-2` tap targets, `size-6` utility icons. The active state stays `info` ink, hover stays neutral `bg-muted/5`.

Visual + layout only; same destinations. The design-language **Navigation shell** note was updated to describe the flat drawer (previously documented the slabs).

## Prototype decisions (live, one detail at a time, both modes)
1. **Container** — flat, chosen over keeping slabs / flat-with-separators.
2. **Active dot** — added, for full parity with the desktop rail.

## Checks
- `npm run check`, lint, unit (669) — green
- e2e (114, incl. the `tablet` project that drives the drawer) — green
- Light + dark both reviewed
- Variant-switch harness stripped (no `src/lib/dev` traces)
- No CHANGELOG entry (consolidated into the final `restyle` → `main` PR, per #254's working agreement)