### PR TITLE
feat(budget): bump modal-title size above section titles (#299)

### DIFF
--- a/docs/dev/design-language.md
+++ b/docs/dev/design-language.md
@@ -249,9 +249,16 @@ Hierarchy rules:
   `tracking-tighter` on the serif (Inter's tight tracking crushes it).
   `h1`–`h3` get `font-display` from the base layer in `layout.css`;
   weight and size stay per-site utilities.
-- **Section titles** (dialog/drawer/alert titles, empty-state titles,
-  `h2`/`h3`): `font-display font-semibold` — 600 has authority without
-  competing with the 700 page title.
+- **Modal titles** (dialog/drawer/alert titles): `font-display text-lg
+font-semibold` — 18px, one step above section titles (#299, amends #261).
+  Modals nest section titles (the "Accounts" heading in Budget Settings), so
+  the modal title needs its own tier to avoid colliding with them. All three
+  modal faces share the size so a responsive modal reads the same on desktop
+  (dialog) and mobile (drawer). Applied in the shared `ui/dialog`,
+  `ui/drawer`, `ui/alert-dialog` title primitives — every modal inherits it.
+- **Section titles** (empty-state titles, section headings inside a surface,
+  `h2`/`h3`): `font-display font-semibold` at the base 16px — 600 has authority
+  without competing with the 700 page title or the 18px modal title above it.
 - **Table column headers**: the P6 quiet chrome plus `font-display
 font-medium` (see the amended P6).
 - **Form labels — one spec**: `pl-1.5 text-sm font-semibold

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Title
 	bind:ref
 	data-slot="dialog-title"
-	class={cn('font-display text-base leading-none font-semibold', className)}
+	class={cn('font-display text-lg leading-none font-semibold', className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/drawer/drawer-title.svelte
+++ b/src/lib/components/ui/drawer/drawer-title.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Title
 	bind:ref
 	data-slot="drawer-title"
-	class={cn('font-display font-semibold text-foreground', className)}
+	class={cn('font-display text-lg font-semibold text-foreground', className)}
 	{...restProps}
 />


### PR DESCRIPTION
Closes #299. Dialog titles rendered at `text-base` (16px) — the same size as the section titles dialogs sometimes contain (e.g. the Lora "Accounts" heading in Budget Settings), so the two levels collided.

Bump the shared dialog-title primitive to `text-lg` (18px), one clear step above the 16px section title (amends the Typography lock #261). Locked live from a 16/17/18px variant switch, both modes. The alert-dialog title was already `text-lg`; the mobile drawer title (the responsive-modal's mobile face) is bumped to match, so dialog + drawer + alert form one modal-title tier across viewports.

Design-language Typography section updated to record the new tier.

check / lint / unit(669) / e2e(44, incl. light+dark axe on dialogs) green.