### PR TITLE
feat(budget): bring login + first-login onto the new UI (#302)

### DIFF
--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { FormField } from '$lib/components/ui/form-field';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import { InputPassword } from '$lib/components/ui/input-password';
 	import { Logo } from '$lib/components/ui/logo';
-	import { SourceLink } from '$lib/components/ui/source-link';
 	import { m } from '$lib/paraglide/messages';
 	import { login } from '$lib/remote-functions/auth.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
@@ -13,10 +13,10 @@
 	const submit = createFormSubmit(() => login, { toast: {} });
 </script>
 
-<form class="mx-auto mt-20 grid w-full max-w-sm space-y-6" {...submit.attrs}>
-	<Logo class="mx-auto mt-auto" aria-hidden />
+<form class="mx-auto mt-20 grid w-full max-w-sm space-y-6 px-4" {...submit.attrs}>
+	<Logo class="mx-auto" href={resolve('/')} />
 
-	<div class="grid space-y-2 rounded-lg bg-muted/5 p-3">
+	<div class="grid space-y-2">
 		<FormField field={login.fields.username} label={m.login_label_username()} hideLabel>
 			{#snippet input(field)}
 				<InputGroup.Root>
@@ -46,5 +46,3 @@
 		</Button>
 	</div>
 </form>
-
-<SourceLink class="mx-auto mt-6 block w-fit" />

--- a/src/routes/login/first/+page.svelte
+++ b/src/routes/login/first/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { FormField } from '$lib/components/ui/form-field';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import { Logo } from '$lib/components/ui/logo';
-	import { SourceLink } from '$lib/components/ui/source-link';
 	import { m } from '$lib/paraglide/messages';
 	import { register } from '$lib/remote-functions/auth.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
@@ -32,11 +32,8 @@
 	</InputGroup.Button>
 {/snippet}
 
-<form
-	class="mx-auto mt-20 grid w-full max-w-sm space-y-6 rounded-lg bg-muted/5 p-3 py-6"
-	{...submit.attrs}
->
-	<Logo class="mx-auto mt-auto" aria-hidden />
+<form class="mx-auto mt-20 grid w-full max-w-sm space-y-6 px-4" {...submit.attrs}>
+	<Logo class="mx-auto" href={resolve('/')} />
 
 	<p class="text-center">
 		{m.login_admin_introduction()}
@@ -71,7 +68,7 @@
 			{/snippet}
 		</FormField>
 
-		<p class="mt-3 rounded-md bg-info/5 p-2 text-center text-base text-info">
+		<p class="mt-3 text-center text-base text-muted">
 			{m.login_admin_credentials_info()}
 		</p>
 	</div>
@@ -80,5 +77,3 @@
 		{m.login_admin_button()}
 	</Button>
 </form>
-
-<SourceLink class="mx-auto mt-6 block w-fit" />


### PR DESCRIPTION
Resolves #302 (child of the restyle map #254).

Takes the login (`/login`) and first-login (`/login/first`) pages onto the locked restyle language, matching the rest of the app. Worked live one detail at a time, both light + dark mode.

## What changed

- **Flat form** — dropped the `bg-muted/5` rounded panel so the fields sit directly on the page (per #277/#278/#281), keeping only the standard field tint.
- **Menu-style logo** — switched to the nav-rail `href` `Logo`: pixel mark + Lora wordmark with the **version · Source code** row underneath, replacing the standalone bottom source link. The AGPL §13 source link is preserved, just relocated into that row.
- **First-login credentials warning** — the mistinted `bg-info/5` callout (reads purple in dark) becomes quiet muted centered text, consistent with the page.
- **`px-4` gutter on both forms** — the removed panel padding was the only thing insetting the fields at phone width, so the password toggle addon bled 3px past 375; the gutter restores the horizontal breathing room.

Visual + layout only; the auth flow, fields, and labels are untouched.

## Verification

- `npm run check`, `npm run lint`, unit (669) green.
- e2e: both `mobile-responsive` "Login works at phone width" tests green (chromium + tablet), `expectNoHorizontalOverflow` passes; full suite otherwise green (the one `unassigned-month-scope` blip was flaky and passes on rerun).
- Reviewed both pages in light and dark at desktop and phone width.

Per the map, no per-ticket CHANGELOG entry — the single entry lands at the final `restyle` → `main` PR.