### PR TITLE
feat(budget): drawer the remaining plain dialogs on mobile (#313)

### DIFF
--- a/src/lib/components/features/api-tokens/api-token-manager.svelte
+++ b/src/lib/components/features/api-tokens/api-token-manager.svelte
@@ -6,10 +6,10 @@
 	import { AlertDialogForm } from '$lib/components/ui/alert-dialog-form';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import { DatePicker } from '$lib/components/ui/date-picker';
-	import * as Dialog from '$lib/components/ui/dialog';
 	import { FormField } from '$lib/components/ui/form-field';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import {
 		getApiTokens,
@@ -148,38 +148,42 @@
 	{/snippet}
 </AlertDialogForm>
 
-<Dialog.Root bind:open={openReveal}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.api_token_created_title()}</Dialog.Title>
-			<Dialog.Description>{m.api_token_created_description()}</Dialog.Description>
-		</Dialog.Header>
+<ResponsiveModal.Root bind:open={openReveal}>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.api_token_created_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description>{m.api_token_created_description()}</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
 		{#if issued && qrSvg}
-			<div class="grid justify-items-center gap-2">
-				<!-- Fixed white backdrop in both themes: scanners need dark-on-light contrast. -->
-				<div
-					role="img"
-					aria-label={m.api_token_qr_alt()}
-					class="w-52 rounded-lg bg-white p-2 [&_svg]:h-auto [&_svg]:w-full"
-				>
-					<!-- eslint-disable-next-line svelte/no-at-html-tags -- locally generated QR markup -->
-					{@html qrSvg}
+			<ResponsiveModal.Body class="grid gap-6">
+				<div class="grid justify-items-center gap-2">
+					<!-- Fixed white backdrop in both themes: scanners need dark-on-light contrast. -->
+					<div
+						role="img"
+						aria-label={m.api_token_qr_alt()}
+						class="w-52 rounded-lg bg-white p-2 [&_svg]:h-auto [&_svg]:w-full"
+					>
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -- locally generated QR markup -->
+						{@html qrSvg}
+					</div>
+					<div class="text-sm text-muted">{page.url.origin}</div>
 				</div>
-				<div class="text-sm text-muted">{page.url.origin}</div>
-			</div>
 
-			<div class="flex items-center justify-between gap-4 rounded-lg bg-muted/5 p-2">
-				<div class="min-w-0 p-3 break-all text-info" aria-label="api-token">{issued.token}</div>
-				<Button size="icon" {@attach copyToClipboard(issued.token)}>
-					<CopySimpleIcon />
-					<span class="sr-only">{m.api_token_copy()}</span>
-				</Button>
-			</div>
+				<div class="flex items-center justify-between gap-4 rounded-lg bg-muted/5 p-2">
+					<div class="min-w-0 p-3 break-all text-info" aria-label="api-token">{issued.token}</div>
+					<Button size="icon" {@attach copyToClipboard(issued.token)}>
+						<CopySimpleIcon />
+						<span class="sr-only">{m.api_token_copy()}</span>
+					</Button>
+				</div>
+			</ResponsiveModal.Body>
 		{/if}
 
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'default' })}>{m.dialog_close()}</Dialog.Close>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Footer>
+			<ResponsiveModal.Close class={buttonVariants({ variant: 'default' })}>
+				{m.dialog_close()}
+			</ResponsiveModal.Close>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -6,6 +6,7 @@
 	import { FormField } from '$lib/components/ui/form-field';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import * as Select from '$lib/components/ui/select';
 	import { m } from '$lib/paraglide/messages';
 	import { getAccounts, getArchivedAccounts } from '$lib/remote-functions/account.remote';
@@ -38,23 +39,23 @@
 	});
 </script>
 
-<Dialog.Root bind:open>
-	<Dialog.Trigger>
+<ResponsiveModal.Root bind:open>
+	<ResponsiveModal.Trigger>
 		{#snippet child({ props })}
 			<Button {...props} variant="ghost" size="icon" class="bg-muted/10 hover:bg-muted/20">
 				<PencilIcon />
 				<span class="sr-only">{m.budget_settings_title()}</span>
 			</Button>
 		{/snippet}
-	</Dialog.Trigger>
+	</ResponsiveModal.Trigger>
 
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.budget_settings_title()}</Dialog.Title>
-			<Dialog.Description>{m.budget_settings_description()}</Dialog.Description>
-		</Dialog.Header>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.budget_settings_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description>{m.budget_settings_description()}</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<Dialog.Body class="flex flex-col gap-6">
+		<ResponsiveModal.Body class="flex flex-col gap-6">
 			<form {...submit.attrs} class="grid gap-2">
 				<input {...editBudget.fields.budgetId.as('hidden', budgetId())} />
 
@@ -152,13 +153,15 @@
 					</ul>
 				{/if}
 			</div>
-		</Dialog.Body>
+		</ResponsiveModal.Body>
 
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Footer>
+			<ResponsiveModal.Close class={buttonVariants({ variant: 'ghost' })}>
+				{m.dialog_close()}
+			</ResponsiveModal.Close>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>
 
 <!--
 	Create Account is its own dialog stacked over Budget Settings, opened by the

--- a/src/lib/components/features/budget-user-manager/budget-user-manager.svelte
+++ b/src/lib/components/features/budget-user-manager/budget-user-manager.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import { getBudgetUsers } from '$lib/remote-functions/budget.remote';
 	import { getUser } from '$lib/remote-functions/user.remote';
@@ -20,8 +20,8 @@
 	const members = $derived(budgetUsers.filter((f) => f.role !== 'INVITEE'));
 </script>
 
-<Dialog.Root>
-	<Dialog.Trigger>
+<ResponsiveModal.Root dismissible={false}>
+	<ResponsiveModal.Trigger>
 		{#snippet child({ props })}
 			<Button
 				{...props}
@@ -37,26 +37,30 @@
 				{/if}
 			</Button>
 		{/snippet}
-	</Dialog.Trigger>
+	</ResponsiveModal.Trigger>
 
-	<Dialog.Content class="gap-0" interactOutsideBehavior="ignore">
-		<Dialog.Header>
-			<Dialog.Title>{m.budget_users_dialog_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
+	<ResponsiveModal.Content class="gap-0">
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.budget_users_dialog_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description class="grid gap-4">
 				<div>
 					{m.budget_users_dialog_description()}
 				</div>
-			</Dialog.Description>
-		</Dialog.Header>
+			</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<UserList {isOwner} title={m.budget_users_with_access_title()} users={members} />
+		<ResponsiveModal.Body>
+			<UserList {isOwner} title={m.budget_users_with_access_title()} users={members} />
 
-		<UserList {isOwner} title={m.budget_users_invited_title()} users={invited} />
+			<UserList {isOwner} title={m.budget_users_invited_title()} users={invited} />
 
-		<UserInvitation />
+			<UserInvitation />
+		</ResponsiveModal.Body>
 
-		<Dialog.Footer class="mt-6">
-			<Dialog.Close class={buttonVariants({ variant: 'ghost' })}>{m.dialog_close()}</Dialog.Close>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Footer class="mt-6">
+			<ResponsiveModal.Close class={buttonVariants({ variant: 'ghost' })}>
+				{m.dialog_close()}
+			</ResponsiveModal.Close>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/lib/components/ui/responsive-modal/context.ts
+++ b/src/lib/components/ui/responsive-modal/context.ts
@@ -6,6 +6,11 @@ export const DESKTOP_QUERY = '(min-width: 640px)';
 const CONTEXT_KEY = Symbol('responsive-modal');
 
 export type ResponsiveModalContext = {
+	/**
+	 * When `false`, interacting outside the modal does not close it — the Dialog
+	 * variant ignores outside clicks, the Drawer variant is non-dismissible.
+	 */
+	readonly dismissible: boolean;
 	/** `true` renders the Dialog variant, `false` the Drawer variant. Reactive. */
 	readonly isDesktop: boolean;
 };

--- a/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
@@ -22,7 +22,11 @@
 </script>
 
 {#if ctx.isDesktop}
-	<Dialog.Content class={className} {showCloseButton}>
+	<Dialog.Content
+		class={className}
+		{showCloseButton}
+		interactOutsideBehavior={ctx.dismissible ? undefined : 'ignore'}
+	>
 		{@render children()}
 	</Dialog.Content>
 {:else}

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -9,10 +9,17 @@
 
 	let {
 		children,
+		dismissible = true,
 		onOpenChangeComplete,
 		open = $bindable(false)
 	}: {
 		children?: Snippet;
+		/**
+		 * When `false`, interacting outside the modal does not close it — the Dialog
+		 * variant ignores outside clicks, the Drawer variant is non-dismissible.
+		 * Mirrors the plain `Dialog.Content interactOutsideBehavior="ignore"` intent.
+		 */
+		dismissible?: boolean;
 		/**
 		 * Fires after the open/close transition finishes, with the resulting open
 		 * state. Bridges bits-ui `onOpenChangeComplete` and vaul `onAnimationEnd`.
@@ -24,6 +31,9 @@
 	const media = new MediaQuery(DESKTOP_QUERY, true);
 
 	setResponsiveModalContext({
+		get dismissible() {
+			return dismissible;
+		},
 		get isDesktop() {
 			return media.matches;
 		}
@@ -35,7 +45,7 @@
 		{@render children?.()}
 	</Dialog.Root>
 {:else}
-	<Drawer.Root bind:open direction="bottom" onAnimationEnd={onOpenChangeComplete}>
+	<Drawer.Root bind:open {dismissible} direction="bottom" onAnimationEnd={onOpenChangeComplete}>
 		{@render children?.()}
 	</Drawer.Root>
 {/if}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -4,8 +4,8 @@
 	import { resolve } from '$app/paths';
 	import { CategoryCreate } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
 	import { EmptyState } from '$lib/components/ui/empty-state';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import { getBudget, getMonthly } from '$lib/remote-functions/budget.remote';
 	import { getArchivedCategories, reorderCategories } from '$lib/remote-functions/category.remote';
@@ -291,18 +291,20 @@
 	</div>
 {/if}
 
-<Dialog.Root bind:open={createDialogOpen}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.new_category_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
+<ResponsiveModal.Root bind:open={createDialogOpen}>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.new_category_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description class="grid gap-4">
 				<p>{m.new_category_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+			</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<CategoryCreate onSuccess={() => (createDialogOpen = false)} />
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Body>
+			<CategoryCreate onSuccess={() => (createDialogOpen = false)} />
+		</ResponsiveModal.Body>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>
 
 {#if month !== null}
 	<CategoryAssignmentModal

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-quick-actions.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-quick-actions.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { CategoryCreate } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import { getArchivedCategories } from '$lib/remote-functions/category.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
@@ -49,15 +49,17 @@
 	{/if}
 </div>
 
-<Dialog.Root bind:open>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.new_category_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
+<ResponsiveModal.Root bind:open>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.new_category_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description class="grid gap-4">
 				<p>{m.new_category_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+			</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<CategoryCreate onSuccess={() => (open = false)} />
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Body>
+			<CategoryCreate onSuccess={() => (open = false)} />
+		</ResponsiveModal.Body>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
@@ -6,8 +6,8 @@
 	import { AccountCreate } from '$lib/components/features/account';
 	import { CategoryCreate } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
 	import { focusRing } from '$lib/components/ui/focus-ring';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import { getAccounts } from '$lib/remote-functions/account.remote';
 	import { getBudget, getMonthly, getUnassigned } from '$lib/remote-functions/budget.remote';
@@ -98,32 +98,36 @@
 	</section>
 {/if}
 
-<Dialog.Root bind:open={accountDialogOpen}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.new_account_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
+<ResponsiveModal.Root bind:open={accountDialogOpen}>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.new_account_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description class="grid gap-4">
 				<p>{m.new_account_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+			</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<AccountCreate
-			{currency}
-			onSuccess={() => (accountDialogOpen = false)}
-			updates={() => [getUnassigned({ budgetId: budgetId(), month })]}
-		/>
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Body>
+			<AccountCreate
+				{currency}
+				onSuccess={() => (accountDialogOpen = false)}
+				updates={() => [getUnassigned({ budgetId: budgetId(), month })]}
+			/>
+		</ResponsiveModal.Body>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>
 
-<Dialog.Root bind:open={categoryDialogOpen}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.new_category_title()}</Dialog.Title>
-			<Dialog.Description class="grid gap-4">
+<ResponsiveModal.Root bind:open={categoryDialogOpen}>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.new_category_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description class="grid gap-4">
 				<p>{m.new_category_description()}</p>
-			</Dialog.Description>
-		</Dialog.Header>
+			</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
 
-		<CategoryCreate onSuccess={() => (categoryDialogOpen = false)} />
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Body>
+			<CategoryCreate onSuccess={() => (categoryDialogOpen = false)} />
+		</ResponsiveModal.Body>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -2,11 +2,11 @@
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { AlertDialogForm } from '$lib/components/ui/alert-dialog-form';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { FormField } from '$lib/components/ui/form-field';
 	import * as InputGroup from '$lib/components/ui/input-group';
 	import * as Page from '$lib/components/ui/page';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { Separator } from '$lib/components/ui/separator';
 	import { m } from '$lib/paraglide/messages';
 	import {
@@ -197,22 +197,28 @@
 	{/snippet}
 </AlertDialogForm>
 
-<Dialog.Root bind:open={openDialog}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.admin_generated_password_title()}</Dialog.Title>
-			<Dialog.Description>{m.admin_generated_password_description()}</Dialog.Description>
-		</Dialog.Header>
+<ResponsiveModal.Root bind:open={openDialog}>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.admin_generated_password_title()}</ResponsiveModal.Title>
+			<ResponsiveModal.Description
+				>{m.admin_generated_password_description()}</ResponsiveModal.Description
+			>
+		</ResponsiveModal.Header>
 
-		<div class="flex items-center justify-between gap-4 rounded-lg bg-muted/5 p-2">
-			<div class="p-3 text-lg text-info" aria-label="generated-password">{generatedPassword}</div>
-			<Button size="icon" {@attach copyToClipboard(generatedPassword)}>
-				<CopySimpleIcon />
-			</Button>
-		</div>
+		<ResponsiveModal.Body>
+			<div class="flex items-center justify-between gap-4 rounded-lg bg-muted/5 p-2">
+				<div class="p-3 text-lg text-info" aria-label="generated-password">{generatedPassword}</div>
+				<Button size="icon" {@attach copyToClipboard(generatedPassword)}>
+					<CopySimpleIcon />
+				</Button>
+			</div>
+		</ResponsiveModal.Body>
 
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'default' })}>{m.dialog_close()}</Dialog.Close>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		<ResponsiveModal.Footer>
+			<ResponsiveModal.Close class={buttonVariants({ variant: 'default' })}>
+				{m.dialog_close()}
+			</ResponsiveModal.Close>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>

--- a/src/routes/(app)/invitation.svelte
+++ b/src/routes/(app)/invitation.svelte
@@ -2,7 +2,7 @@
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { AlertDialogForm } from '$lib/components/ui/alert-dialog-form';
 	import { Button } from '$lib/components/ui/button';
-	import * as Dialog from '$lib/components/ui/dialog';
+	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
 	import { acceptInvite, getInvitations, removeUser } from '$lib/remote-functions/budget.remote';
 	import { getUser } from '$lib/remote-functions/user.remote';
@@ -26,33 +26,35 @@
 	});
 </script>
 
-<Dialog.Root bind:open>
-	<Dialog.Trigger>
+<ResponsiveModal.Root bind:open dismissible={false}>
+	<ResponsiveModal.Trigger>
 		{#snippet child({ props })}
 			<Button {...props} class="mt-6 w-full">
 				<EnvelopeDuotoneIcon class="size-6 animate-pulse" />
 				<span class="font-semibold">{m.invitation_button_label()}</span>
 			</Button>
 		{/snippet}
-	</Dialog.Trigger>
+	</ResponsiveModal.Trigger>
 
-	<Dialog.Content class="sm:max-w-md" interactOutsideBehavior="ignore">
-		<Dialog.Header>
-			<Dialog.Title>{m.invitation_dialog_title()}</Dialog.Title>
-		</Dialog.Header>
+	<ResponsiveModal.Content class="sm:max-w-md">
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>{m.invitation_dialog_title()}</ResponsiveModal.Title>
+		</ResponsiveModal.Header>
 
-		<p>
-			<ParaglideMessage
-				message={m.invitation_dialog_description}
-				inputs={{ budgetName: invitation.budgetName ?? '', inviterName: invitation.inviterName }}
-			>
-				{#snippet b({ children })}
-					<b>{@render children?.()}</b>
-				{/snippet}
-			</ParaglideMessage>
-		</p>
+		<ResponsiveModal.Body>
+			<p>
+				<ParaglideMessage
+					message={m.invitation_dialog_description}
+					inputs={{ budgetName: invitation.budgetName ?? '', inviterName: invitation.inviterName }}
+				>
+					{#snippet b({ children })}
+						<b>{@render children?.()}</b>
+					{/snippet}
+				</ParaglideMessage>
+			</p>
+		</ResponsiveModal.Body>
 
-		<Dialog.Footer>
+		<ResponsiveModal.Footer>
 			<AlertDialogForm
 				form={removeUser}
 				onSuccess={() => {
@@ -94,6 +96,6 @@
 					{m.invitation_accept_button()}
 				</Button>
 			</form>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>


### PR DESCRIPTION
Resolves #313. Migrates the last **8 plain-`Dialog` surfaces** onto the `ResponsiveModal` shell — centered dialog on desktop, bottom drawer below the 640px breakpoint — matching the modals already on that shell. Visual + layout only.

## Surfaces migrated
- `api-token-manager` (reveal)
- `category-quick-actions` + `category-budget-table` (inline category-create)
- `tutorial-card` (account + category create)
- `budget-user-manager`
- `budget-settings`
- `invitation`
- `admin` generated-password

## Shell change
`ResponsiveModal.Content`/`Root` only forwarded `class`/`showCloseButton`. Two surfaces (`budget-user-manager`, `invitation`) used `Dialog.Content interactOutsideBehavior="ignore"`, which on the drawer side is vaul's `dismissible={false}`. Added a single **`dismissible`** prop on `ResponsiveModal.Root`, carried through context: `Content` maps it to `interactOutsideBehavior` on desktop, `Root` to `dismissible` on the drawer. Backward-compatible — the 5 already-migrated modals default to dismissible and are untouched.

Scrollable middles are wrapped in `ResponsiveModal.Body` for the ADR-0013 scroll seam.

## Nested overlays (kept as-is)
- `budget-settings` keeps the nested Create-Account dialog as a **sibling Dialog** — the #294 dialog-in-drawer.
- `invitation` / `admin` keep their nested **AlertDialogs** — the #147 path.

## Verified live (mobile 390px + desktop)
- api-token reveal — drawer, **light + dark**
- budget-settings drawer + nested Add Account dialog-in-drawer — created an account through it; nested dialog closed and the drawer's account list refreshed live
- budget-user-manager — drawer + **non-dismissible** (scrim click leaves it open)
- invitation — drawer nested over the nav drawer, with the **decline AlertDialog** nested inside (the #147 path); decline submitted and removed the row
- admin generated-password — drawer
- Desktop (900px) — budget-settings still a centered dialog with top-right X (no regression)

## Tests
`npm run check` ✅ · lint/format ✅ · unit **669** ✅ · e2e **113 passed** (1 unrelated `unassigned-month-scope` flake, passes in isolation).

## Out of scope
Declining/accepting an invitation doesn't auto-refresh `getInvitations` (nav indicator lingers until navigation) — pre-existing, identical on desktop and mobile, not a regression from this migration. Filed as #314.

No CHANGELOG entry (consolidated at the final `restyle` → `main` PR per the restyle map).