### PR TITLE
feat(budget): render table remaining amounts in medium weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- The budget table's remaining amounts now render in a medium weight rather
+  than semibold, so the figure still anchors each row without dominating the
+  quieter secondary numbers.
 - The settings page dropped its stacked tinted panels for a calmer layout:
   each section sits directly on the page, separated by hairline dividers that
   hug the heading they introduce. Dialogs now use a slightly darker surface so

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -248,7 +248,7 @@
 								<div class="flex items-center px-4">
 									<span
 										class={cn(
-											'font-currency',
+											'font-currency font-medium',
 											row.remaining < 0 && 'text-error',
 											row.remaining === 0 && 'text-muted'
 										)}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -91,7 +91,7 @@
 		aria-disabled={remaining === 0}
 		aria-label={m.reassignment_trigger_label({ name: categoryName })}
 		class={cn(
-			'flex size-full cursor-pointer items-center justify-end px-2 text-right font-currency font-semibold hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10',
+			'flex size-full cursor-pointer items-center justify-end px-2 text-right font-currency font-medium hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10',
 			remaining < 0 && 'text-error',
 			remaining === 0 &&
 				'cursor-default font-normal text-muted hover:bg-transparent hover:outline-none'
@@ -128,7 +128,7 @@
 			     16px em-context here so the amount matches the cell exactly — neither
 			     shrinks nor grows when the panel opens over it. -->
 			<span class="text-base leading-6">
-				<span class={cn('font-currency font-semibold', remaining < 0 && 'text-error')}>
+				<span class={cn('font-currency font-medium', remaining < 0 && 'text-error')}>
 					{formatMoney({ currency, money: asMoney(remaining) })}
 				</span>
 			</span>


### PR DESCRIPTION
Drops the budget table's Remaining figures from semibold to medium — on both the desktop cell (reassignment trigger + panel header mirror) and the mobile category card — so the amount still anchors each row without dominating the quieter secondary numbers. Positive/negative coloring is unchanged.

Explored via a throwaway `/prototype` (semibold / medium / normal); medium won.

### Changed
- Budget table remaining amounts now render `font-medium` instead of `font-semibold`.