### PR TITLE
refactor(routes): thin restyle-authored comments in src/routes/(app) (#320)

### DIFF
--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -30,7 +30,7 @@
 	// Shared with the category table (same query, no extra round-trip): the
 	// month navigator and unassigned summary only appear once the budget has a
 	// category — before that the tutorial card and the table's empty state are
-	// the whole view. Create + archived live in the table's Category header.
+	// the whole view.
 	const categories = $derived(
 		await (month === null ? Promise.resolve([]) : getMonthly({ budgetId: budgetId(), month }))
 	);

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -34,15 +34,10 @@
 
 	const budgetId = getBudgetId();
 
-	// Create + archived live in the Category column header (desktop) and a mobile
-	// action row above the cards; the archived link only shows when there is
-	// something archived to reach.
 	const archivedCategories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
 	const archivedHref = $derived(
 		resolve('/(app)/[budgetId=id]/categories/archived', { budgetId: budgetId() })
 	);
-	// Mobile create routes to the standalone form page rather than the inline
-	// dialog (mirrors the previous quick-actions behaviour below the breakpoint).
 	const createHref = $derived(
 		resolve('/(app)/[budgetId=id]/categories/new', { budgetId: budgetId() })
 	);
@@ -161,8 +156,6 @@
 			{/if}
 		</div>
 
-		<!-- Zebra open ledger (design language P5) on the desktop table; the
-		     mobile cards keep the bordered slab look. -->
 		<div role="rowgroup" class="grid gap-2 @3xl/main:gap-0" {@attach categorySortable.attach}>
 			<!-- The if narrows `month` for the row children; `categories` is empty when `month` is null. -->
 			{#if month !== null}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
@@ -42,10 +42,8 @@
 		void getCategoryStats({ categoryId: row.id, month });
 	}
 
-	// The panel overlaps its trigger cell exactly: a negative main-axis offset
-	// equal to the cell's own height pulls the panel back over the cell (in both
-	// flip directions), hiding it. Measured live so it tracks the row density —
-	// the same height sizes the panel's title strip, so the name stays put.
+	// Cell height measured live so the overlap offset tracks the row density;
+	// the same height sizes the panel's title strip so the name stays put.
 	let triggerEl = $state<HTMLElement | null>(null);
 	let cellHeight = $state(0);
 	$effect(() => {
@@ -75,10 +73,8 @@
 		motion="fade"
 		class="w-(--bits-popover-anchor-width) gap-0 overflow-hidden rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30"
 	>
-		<!-- Title strip mirrors the cell: same px-2 inset and height, and the name
-		     repeats the cell's exact font (Plex Sans 16px/400/24) so it stays put —
-		     no size flicker — when the panel opens over the cell. The muted fill +
-		     hairline divider keep this "cell zone" distinct from the stats below. -->
+		<!-- Title strip mirrors the cell — same inset, height, and font — so the
+		     name doesn't shift when the panel opens over it. -->
 		<div
 			class="flex items-center justify-between gap-2 border-b border-muted/20 bg-muted/5 px-2"
 			style="min-height: {cellHeight}px"

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -1,9 +1,6 @@
-<!-- Desktop transfer surface for a category's Remaining cell. Like the category
-     detail popover, the panel sits directly on top of its cell (a negative
-     offset equal to the cell's height overlaps it exactly) and grows from
-     there. The header mirrors the cell: the move/cover label on the left, the
-     remaining amount pinned on the right in the cell's own font so it stays
-     put — no flicker — when the panel opens over it. The form follows below. -->
+<!-- Desktop transfer surface for a category's Remaining cell. The panel
+     overlaps the cell exactly (see category-popover) and its header mirrors
+     the cell so the amount stays put when it opens. -->
 <script lang="ts">
 	import type { Month } from '$lib/utils/month';
 
@@ -66,10 +63,8 @@
 		if (!open) submit.reset();
 	});
 
-	// The panel overlaps its trigger cell exactly (see category-popover): a
-	// negative main-axis offset equal to the cell's height pulls it back over the
-	// cell in both flip directions, and the same height sizes the header strip so
-	// the amount stays put.
+	// Cell height measured live — it both offsets the panel over the cell and
+	// sizes the header strip (see category-popover).
 	let triggerEl = $state<HTMLElement | null>(null);
 	let cellHeight = $state(0);
 	$effect(() => {
@@ -109,9 +104,6 @@
 		motion="fade"
 		class="w-80 gap-0 overflow-hidden rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30"
 	>
-		<!-- Header mirrors the cell: label left, amount right (px-2 inset + cell
-		     font), sized to the cell's height so the amount lands where it was.
-		     The muted fill + hairline divider match the category popover's header. -->
 		<div
 			class="flex items-center justify-between gap-2 border-b border-muted/20 bg-muted/5 px-2"
 			style="min-height: {cellHeight}px"
@@ -125,8 +117,7 @@
 
 			<!-- The popover base is text-sm, but the cell renders font-currency in a
 			     text-base (16px) context, so its 0.9375em lands at 15px. Restore that
-			     16px em-context here so the amount matches the cell exactly — neither
-			     shrinks nor grows when the panel opens over it. -->
+			     em-context so the amount matches the cell exactly. -->
 			<span class="text-base leading-6">
 				<span class={cn('font-currency font-medium', remaining < 0 && 'text-error')}>
 					{formatMoney({ currency, money: asMoney(remaining) })}

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/settings/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/settings/+page.svelte
@@ -45,9 +45,6 @@
 		</Page.Title>
 	</Page.Header>
 
-	<!-- A single quiet vertical list of titled sections, split by hairline
-	     dividers on the /settings rhythm (restyle #280, matching the category
-	     settings page). -->
 	<Page.Content class="max-w-xl">
 		<div class="space-y-3">
 			<AccountEdit {account} />

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
@@ -54,8 +54,6 @@
 		</Page.Title>
 	</Page.Header>
 
-	<!-- A single quiet vertical list of titled sections, split by hairline
-	     dividers on the /settings rhythm (restyle #280). -->
 	<Page.Content class="max-w-xl">
 		<div class="space-y-3">
 			<CategoryEdit {category} currency={budget.currency} />

--- a/src/routes/(app)/admin/reset-password-form.svelte
+++ b/src/routes/(app)/admin/reset-password-form.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	// Persistent hidden reset-password form, one per user row. It lives in the
-	// row (not inside the dropdown's portalled content, which unmounts on
-	// select), so its submit lifecycle survives the menu closing. The kebab
-	// menu item triggers it by id via requestSubmit; the keyed form instance
-	// (`.for(userId)`) owns its own `result`, surfaced up through `onReset`.
+	// Hidden form, one per user row, triggered by the row's kebab menu via
+	// requestSubmit; it lives in the row rather than the menu's portalled
+	// content (which unmounts on select) so the submit survives the menu closing.
 	import { resetUserPassword } from '$lib/remote-functions/admin.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 


### PR DESCRIPTION
Resolves #320 (part of map #316).

Thins the restyle-authored comments in `src/routes/(app)` (41 → 14 comment lines, 7 files):

- **Cut**: layout what-narration (create/archived button placement, "zebra open ledger", "quiet vertical list … (restyle #280)" provenance), the changelog-style "mirrors the previous quick-actions behaviour" line, and reassignment-popup comments duplicating its own file header.
- **Compacted**: both popovers' overlap-offset comments/headers to the non-obvious core (cell height measured live, reused for the header strip); reset-password-form header to the portalled-menu lifecycle constraint.
- **Kept**: the genuinely surprising whys — aria-label accessible name, z-order vs progress bar, `font-sans` vs h3's Lora default, the 15px/16px em-context math, ring-vs-border 1px shift, archived-redirect rationale.

Bar: `npm run check` 0 errors, lint clean, 669 unit + 114 e2e green. No CHANGELOG entry (comments only).