### PR TITLE
Sweep: thin restyle-authored comments in src/lib/components/features (#319)

### DIFF
--- a/src/lib/components/features/account/account-archive.svelte
+++ b/src/lib/components/features/account/account-archive.svelte
@@ -20,8 +20,7 @@
 		currency: (typeof CURRENCIES)[number];
 	} = $props();
 
-	// The account visibly moving to the archive is the success signal — no toast.
-	// The settings page redirects to the archive once `archivedAt` populates.
+	// The redirect to the archive is the success signal — no toast.
 	const submit = createFormSubmit(() => archiveAccount, { toast: {} });
 
 	const archivability = $derived(await getAccountArchivability({ accountId: account.id }));

--- a/src/lib/components/features/account/account-create.svelte
+++ b/src/lib/components/features/account/account-create.svelte
@@ -31,8 +31,6 @@
 		onSuccess,
 		updates
 	}: {
-		// Override the form-body chrome — e.g. flatten the tinted card when the form
-		// already sits on a dialog surface.
 		class?: string;
 		currency: (typeof CURRENCIES)[number];
 		onSuccess?: () => void;

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -25,15 +25,14 @@
 	const archivedAccounts = $derived(await getArchivedAccounts(budgetId()));
 
 	const form = $derived(editBudget.for(budgetId()));
-	// Toast-confirms the save without closing the dialog — accounts live here too,
-	// so renaming the budget shouldn't dismiss the surface mid-task.
+	// The save toast-confirms without closing the dialog — accounts live here
+	// too, so renaming the budget shouldn't dismiss the surface mid-task.
 	const submit = createFormSubmit(() => form, { toast: {} });
 
 	let open = $state(false);
 	let addOpen = $state(false);
 
-	// Close the Add Account dialog whenever Budget Settings closes, so it never
-	// lingers over a dismissed parent and reopening starts fresh.
+	// The Add Account dialog must never outlive its dismissed parent.
 	$effect(() => {
 		if (!open) addOpen = false;
 	});
@@ -164,20 +163,15 @@
 </ResponsiveModal.Root>
 
 <!--
-	Create Account is its own dialog stacked over Budget Settings, opened by the
-	`+` button above. It's a sibling root (not nested inside the settings
-	`Dialog.Content`) on purpose: our `Dialog.Content` renders its children through
-	a snippet, so a nested `Dialog.Root` would be instantiated in this component's
-	context — outside bits' content context — and never open. As an independent
-	root its own focus trap also fixes the old focus jump to the Budget Name input.
+	Create Account stacks over Budget Settings as a sibling root, not nested
+	inside the settings `Dialog.Content`: our `Dialog.Content` renders its
+	children through a snippet, so a nested `Dialog.Root` would be instantiated
+	outside bits' content context and never open.
 -->
 <Dialog.Root bind:open={addOpen}>
-	<!--
-		Lighter scrim (`bg-background/30`) so the settings dialog stays present behind
-		instead of receding under a second full scrim. Flat form (`AccountCreate`'s
-		card chrome dropped) so the fields sit on the dialog surface like the budget
-		form above.
-	-->
+	<!-- Lighter scrim so the settings dialog stays present behind; the `class`
+	     drops AccountCreate's card chrome so the fields sit flat on the dialog
+	     surface. -->
 	<Dialog.Content class="sm:max-w-md" overlayClass="bg-background/30">
 		<Dialog.Header>
 			<Dialog.Title>{m.new_account_title()}</Dialog.Title>

--- a/src/lib/components/features/category/category-stats-ledger.svelte
+++ b/src/lib/components/features/category/category-stats-ledger.svelte
@@ -1,9 +1,7 @@
-<!-- Chrome-less month stats ledger for the budget table's category popover: the
-     same flat zebra "open ledger" rows the category detail page wears (#280), so
-     the glance surface and the detail page read the same. Just the viewed
-     month's rows — Average, Spend-vs, Target — since the popover header already
-     names the category and month, and the glance stays quick. The target row
-     reads out the saved-of-target amounts, not just the bare percentage. -->
+<!-- Month stats ledger for the budget table's category popover: the same rows
+     the category detail page wears, so glance surface and detail page read the
+     same. Only the viewed month's rows — the popover header already names the
+     category and month. -->
 <script lang="ts">
 	import { m } from '$lib/paraglide/messages';
 	import { getCategoryStats } from '$lib/remote-functions/category.remote';
@@ -24,8 +22,7 @@
 
 	const stats = $derived(await getCategoryStats({ categoryId, month }));
 
-	// Same row chrome as the detail page's stats ledger (#280): no dividers, an
-	// even-row tint for scanability (P5's zebra idiom), a touch of inset padding.
+	// Same row chrome as the detail page's stats ledger.
 	const rowChrome = 'rounded px-2 py-1.5 even:bg-muted/3';
 </script>
 
@@ -66,9 +63,8 @@
 
 	{#if stats.currentTargetPercentage !== null && stats.targetBalance !== null}
 		{@const clamped = clamp(stats.currentTargetPercentage, 0, 100)}
-		<!-- The target row reads out the saved-of-target amounts above a full-width
-		     bar — so the glance shows how much is set aside toward the target, not
-		     just a bare percentage. -->
+		<!-- Saved-of-target amounts above the bar: the glance shows how much is
+		     set aside, not just a bare percentage. -->
 		<div class="{rowChrome} flex flex-col gap-1">
 			<div class="flex items-baseline justify-between">
 				<dt class="text-sm text-muted">{m.category_stats_target_percentage()}</dt>

--- a/src/lib/components/features/category/category-stats.svelte
+++ b/src/lib/components/features/category/category-stats.svelte
@@ -20,12 +20,9 @@
 
 	const stats = $derived(await getCategoryStats({ categoryId: category.id, month }));
 
-	// The tallest bar spans the full sparkline height; the floor of 1 avoids
-	// dividing by zero when every month is empty.
+	// The floor of 1 avoids dividing by zero when every month is empty.
 	const maxSpend = $derived(Math.max(...stats.sparkline.map((b) => b.spend), 1));
 
-	// Stats read as an open ledger of label/value rows: no dividers, an even-row
-	// tint for scanability (P5's zebra idiom), a touch of inset padding.
 	const rowChrome = 'rounded px-2 py-1.5 even:bg-muted/3';
 </script>
 

--- a/src/lib/components/features/side-menu/side-menu.svelte
+++ b/src/lib/components/features/side-menu/side-menu.svelte
@@ -61,8 +61,7 @@
 					aria-hidden="true"
 				/>
 			{:else}
-				<!-- The inline dot marks the current budget; the slot keeps budget
-				     labels aligned whether or not they are active. -->
+				<!-- Transparent when inactive so budget labels stay aligned. -->
 				<span
 					class={cn('size-1.5 shrink-0 rounded-full', isActive ? 'bg-info' : 'bg-transparent')}
 					aria-hidden="true"

--- a/src/lib/components/features/transaction/transaction-table-cols.ts
+++ b/src/lib/components/features/transaction/transaction-table-cols.ts
@@ -1,52 +1,38 @@
-// Shared register-table geometry (#259). Read and edit modes render the SAME
-// cells with the same tracks and the same px-2 text inset, so toggling edit
-// moves nothing (pixel-lock). fr tracks use minmax(0,…) because a bare 1fr
-// track flexes with the edit controls' min-content width and would shift the
-// columns between modes.
+// Read and edit modes share these tracks and the px-2 text inset so toggling
+// edit moves nothing. minmax(0,…) instead of bare 1fr: the edit controls'
+// min-content width would otherwise shift the columns between modes.
 export const colsClass =
 	'grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,0.5fr)_minmax(0,0.5fr)_5rem]';
 
-// Excel-style grid cell: every cell carries its own bottom + left hairline
-// (first-of-type drops the frame-adjacent left one — hidden form inputs may
-// precede the cells, hence -of-type). The border sits inside the min-h-9
-// border-box in both modes, so text centers identically read ⇄ edit.
-// Touch band (#297): in the nav-hidden band (@3xl→@max-7xl) rows grow to a
-// 44px min so cells are comfortably tappable; ≥7xl (sidebar back = pointer)
-// snaps to the resting min-h-9. Both read + edit cells share this const, so
-// the pixel-lock holds at every width.
+// Every cell carries its own bottom + left hairline; first-of-type (not
+// first-child — hidden form inputs may precede the cells) drops the
+// frame-adjacent left one. The border sits inside the min-h border-box so text
+// centers identically read ⇄ edit. In the nav-hidden band (@3xl→@max-7xl) rows
+// grow to a 44px touch minimum; ≥7xl (pointer) snaps back to min-h-9.
 export const cellClass =
 	'grid min-h-9 border-b border-l border-muted/10 p-0 first-of-type:border-l-0 @3xl/main:min-h-11 @7xl/main:min-h-9';
 
-// Read-mode click-to-edit trigger: fills the cell so hover/focus feedback
-// sits at the cell edge (design-language interaction-layer rules). Focus
-// lifts one level above hover (z-20 vs z-10) so a hovered neighbour's surface
-// fill never paints over the focused cell's gold outline where the ring
-// overlaps the shared cell edge (#275).
+// Read-mode click-to-edit trigger. Focus lifts above hover (z-20 vs z-10) so a
+// hovered neighbour's surface fill never paints over the focused cell's
+// outline where the ring overlaps the shared cell edge.
 export const cellTriggerClass =
 	'relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
-// Edit-mode control: borderless, fills the whole cell, keeps the trigger's
-// px-2 so the text does not move when the row switches read ⇄ edit. Hover
-// mirrors the read triggers (surface fill + neutral outline) so every edit
-// cell reacts the same way the date trigger does. Focus lifts above hover
-// (z-20 vs z-10) so a hovered neighbour never clips the focus outline (#275).
+// Edit-mode control: keeps the trigger's px-2 (pixel-lock) and mirrors its
+// hover/focus layering.
 export const editInputClass =
 	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
-// Touch band (#297): the open-row footer actions (Cancel / Save / Save &
-// continue, on both the transaction and transfer create + edit rows) rest at
-// `size="xs"` (24px) — too small to tap. In the nav-hidden band (@3xl→@max-7xl)
-// they grow to a 44px touch target; ≥7xl (pointer) they snap back to the xs
-// resting geometry. Applied via `class` alongside `size="xs"`.
+// Open-row footer actions rest at size="xs" (24px) — too small to tap. Grown
+// to 44px in the nav-hidden band, back to xs geometry ≥7xl (pointer).
 export const footerButtonTouchClass =
 	'@3xl/main:h-11 @3xl/main:gap-1.5 @3xl/main:px-4 @3xl/main:text-sm @7xl/main:h-6 @7xl/main:gap-1 @7xl/main:px-2 @7xl/main:text-xs';
 
-// SelectCategory extras: the container already wraps a px-2 input, so it goes
-// px-0 itself; min-w-0 on container and input stops the trigger caret from
+// The SelectCategory container already wraps a px-2 input, so it goes px-0
+// itself; min-w-0 on container and input stops the trigger caret from
 // overflowing the cell in narrow minmax(0,…) tracks.
 export const editSelectClass = 'min-w-0 px-0 [&>input]:min-w-0';
 
-// Uniform open-form treatment for edit and create rows: the form-input tint
-// across the whole row plus a light interactive ring marking the active row
-// (gold stays reserved for keyboard focus).
+// Open edit/create rows: form-input tint plus a light interactive ring (gold
+// stays reserved for keyboard focus).
 export const editRowClass = 'relative z-10 bg-interactive/5 ring-1 ring-interactive/40';

--- a/src/lib/components/features/transaction/transaction-table-filter.svelte
+++ b/src/lib/components/features/transaction/transaction-table-filter.svelte
@@ -56,11 +56,9 @@
 
 <div class="flex w-full flex-col gap-2">
 	<div class="flex flex-wrap items-end gap-3">
-		<!-- Balances (or nothing) sit to the left; every control clusters on the right. -->
 		{@render leading?.()}
 		<div class="ml-auto flex gap-1.5">
-			<!-- Filtering is desktop-only; on the phone the register keeps only the create affordance.
-			     The filter trigger and clear-all form their own group, separate from the create actions. -->
+			<!-- Filtering is desktop-only; the phone register keeps only the create affordance. -->
 			<ButtonGroup.Root class="hidden @3xl/main:flex">
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger disabled={allActive}>

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -79,11 +79,10 @@
 		return () => node.removeEventListener('keydown', handle);
 	};
 
-	// The draft is scoped to one account (carried as the hidden accountId), so it
-	// is stale once the viewed account changes. Reopening on the SAME account
-	// keeps the draft. A factory keyed on the accountId, so the attachment
-	// re-runs both on mount and when the account changes while the form stays
-	// mounted (a reversed close/open transition never unmounts it).
+	// Reopening on the same account keeps the draft; switching accounts resets
+	// it. The factory keys the attachment on accountId so it re-runs when the
+	// account changes while the form stays mounted (a reversed close/open
+	// transition never unmounts it).
 	let lastResetAccountId: string | undefined;
 
 	const resetOnAccountChange =

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
@@ -152,7 +152,6 @@ describe('TableRowCreate', () => {
 		await user.keyboard('{Enter}');
 
 		expect(remote.onSubmit).toHaveBeenCalledTimes(1);
-		// The row slides out; it leaves the DOM once the outro finishes.
 		await waitFor(() => expect(screen.queryByRole('row')).not.toBeInTheDocument());
 	});
 

--- a/src/lib/components/features/transaction/transaction-table-row.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row.svelte
@@ -59,13 +59,9 @@
 	const id = $props.id();
 	const form = editTransaction.for(id);
 	const deleteForm = batchDeleteTransactions.for(id);
-	// One row, two modes: the read cells and the edit inputs live in the same
-	// cell divs so the geometry cannot shift, and the same DOM row lets the
-	// actions bar animate out on cancel (an if/else swap between separate
-	// read/edit components would overlap both branches during the outro). The
-	// row stays a <div> because the read-mode ValidateToggle owns its own
-	// <form>; the edit form is a hidden sibling and every edit control is
-	// associated via the `form` attribute (same pattern as the delete form).
+	// The row stays a <div> because the read-mode ValidateToggle owns its own
+	// <form>; the edit and delete forms are hidden siblings and their controls
+	// associate via the `form` attribute.
 	const editFormId = `eform-${id}`;
 	const deleteFormId = `dform-${id}`;
 
@@ -79,8 +75,7 @@
 		updates: () => [listTransactions]
 	});
 
-	// No onSuccess: the refreshed list unmounts this row — that is the
-	// success signal.
+	// No onSuccess: the refreshed list unmounting this row is the success signal.
 	const deleteSubmit = createFormSubmit(() => deleteForm, {
 		toast: {},
 		updates: () => [listTransactions]
@@ -94,8 +89,7 @@
 	let dateOpen = $state(false);
 	let amountRef = $state<HTMLInputElement | null>(null);
 
-	// Which cell was clicked to enter edit mode; consumed by the focus effect
-	// below. Deliberately non-reactive — the isEditing flip drives the effect.
+	// Deliberately non-reactive — the isEditing flip drives the focus effect.
 	let pendingFocus: EditableField | null = null;
 
 	function startEditing(field: EditableField) {
@@ -103,9 +97,8 @@
 		setEditing();
 	}
 
-	// Seed the two fields whose inputs bind to field state instead of an
-	// `as(...)` default — on every entry into edit mode, untracked so a list
-	// refresh mid-edit cannot clobber the user's changes.
+	// Seed the fields that bind to field state instead of an `as(...)` default;
+	// untracked so a list refresh mid-edit cannot clobber the user's changes.
 	$effect(() => {
 		if (!isEditing) return;
 		untrack(() => {
@@ -114,12 +107,8 @@
 		});
 	});
 
-	// Focus the input of the clicked cell. Deferred past the flush with tick():
-	// the refs bind through child components and are not yet set when this
-	// effect first runs. Text inputs also select; the date cell opens its
-	// picker popover (which moves focus into the calendar), and the amount
-	// input selects itself via selectOnFocus (its value swap is deferred
-	// past focus).
+	// tick(): the refs bind through child components and are not yet set when
+	// this effect first runs.
 	$effect(() => {
 		if (!isEditing || pendingFocus === null) return;
 		const field = pendingFocus;
@@ -144,8 +133,8 @@
 	const cell = $derived(cn(cellClass, !isEditing && 'group-last-of-type/row:border-b-0'));
 </script>
 
-<!-- The keydown only listens for Escape bubbling out of the edit inputs;
-     the row itself is never a focus target. -->
+<!-- The keydown only catches Escape bubbling out of the edit inputs; the row
+     itself is never a focus target. -->
 <!-- svelte-ignore a11y_interactive_supports_focus -->
 <div
 	role="row"

--- a/src/lib/components/features/transaction/transaction-table.svelte
+++ b/src/lib/components/features/transaction/transaction-table.svelte
@@ -81,9 +81,8 @@
 	>
 		<!-- One create group per affordance (ADR-0014): the inline popover rows at
 		     @3xl and up, the bottom sheets below. Only one group is ever visible. -->
-		<!-- Touch band (#297): the action cluster grows to 44px targets in the
-		     nav-hidden band (@3xl→@max-7xl); ≥7xl (pointer) it resets to the
-		     resting h-9/size-9. -->
+		<!-- The action cluster grows to 44px touch targets in the nav-hidden band
+		     (@3xl→@max-7xl); ≥7xl (pointer) it resets to the resting h-9/size-9. -->
 		<ButtonGroup.Root class="hidden @3xl/main:flex" bind:ref={createTriggerGroup}>
 			<Button
 				class="@3xl/main:h-11 @7xl/main:h-9"

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -78,11 +78,10 @@
 		return () => node.removeEventListener('keydown', handle);
 	};
 
-	// The draft is scoped to one account (carried as the hidden accountId), so it
-	// is stale once the viewed account changes. Reopening on the SAME account
-	// keeps the draft. A factory keyed on the accountId, so the attachment
-	// re-runs both on mount and when the account changes while the form stays
-	// mounted (a reversed close/open transition never unmounts it).
+	// Reopening on the same account keeps the draft; switching accounts resets
+	// it. The factory keys the attachment on accountId so it re-runs when the
+	// account changes while the form stays mounted (a reversed close/open
+	// transition never unmounts it).
 	let lastResetAccountId: string | undefined;
 
 	const resetOnAccountChange =

--- a/src/lib/components/features/transaction/transfer-table-row.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row.svelte
@@ -58,10 +58,9 @@
 	const id = $props.id();
 	const form = editTransfer.for(id);
 	const deleteForm = batchDeleteTransactions.for(id);
-	// Same one-row-two-modes structure as transaction-table-row.svelte: the
-	// row stays a <div> (the read-mode ValidateToggle owns its own <form>),
-	// the edit form is a hidden sibling and the controls associate via the
-	// `form` attribute.
+	// The row stays a <div> because the read-mode ValidateToggle owns its own
+	// <form>; the edit and delete forms are hidden siblings and their controls
+	// associate via the `form` attribute.
 	const editFormId = `eform-${id}`;
 	const deleteFormId = `dform-${id}`;
 
@@ -78,8 +77,8 @@
 		updates: () => [listTransactions]
 	});
 
-	// Deleting either leg removes the whole transfer server-side (ADR-0015); the
-	// refreshed list unmounts this row — that is the success signal.
+	// Deleting either leg removes the whole transfer server-side (ADR-0015);
+	// the refreshed list unmounting this row is the success signal.
 	const deleteSubmit = createFormSubmit(() => deleteForm, {
 		toast: {},
 		updates: () => [listTransactions]
@@ -93,8 +92,7 @@
 	let dateOpen = $state(false);
 	let amountRef = $state<HTMLInputElement | null>(null);
 
-	// Which cell was clicked to enter edit mode; consumed by the focus effect
-	// below. Deliberately non-reactive — the isEditing flip drives the effect.
+	// Deliberately non-reactive — the isEditing flip drives the focus effect.
 	let pendingFocus: EditableField | null = null;
 
 	function startEditing(field: EditableField) {
@@ -102,9 +100,8 @@
 		setEditing();
 	}
 
-	// Seed the two fields whose inputs bind to field state instead of an
-	// `as(...)` default — on every entry into edit mode, untracked so a list
-	// refresh mid-edit cannot clobber the user's changes.
+	// Seed the fields that bind to field state instead of an `as(...)` default;
+	// untracked so a list refresh mid-edit cannot clobber the user's changes.
 	$effect(() => {
 		if (!isEditing) return;
 		untrack(() => {
@@ -113,12 +110,8 @@
 		});
 	});
 
-	// Focus the input of the clicked cell. Deferred past the flush with tick():
-	// the refs bind through child components and are not yet set when this
-	// effect first runs. Text inputs also select; the date cell opens its
-	// picker popover (which moves focus into the calendar), and the amount
-	// input selects itself via selectOnFocus (its value swap is deferred
-	// past focus).
+	// tick(): the refs bind through child components and are not yet set when
+	// this effect first runs.
 	$effect(() => {
 		if (!isEditing || pendingFocus === null) return;
 		const field = pendingFocus;
@@ -143,8 +136,8 @@
 	const cell = $derived(cn(cellClass, !isEditing && 'group-last-of-type/row:border-b-0'));
 </script>
 
-<!-- The keydown only listens for Escape bubbling out of the edit inputs;
-     the row itself is never a focus target. -->
+<!-- The keydown only catches Escape bubbling out of the edit inputs; the row
+     itself is never a focus target. -->
 <!-- svelte-ignore a11y_interactive_supports_focus -->
 <div
 	role="row"
@@ -261,8 +254,7 @@
 	</div>
 
 	<!-- Validation is per-leg and display-mode only; in edit mode the cell
-	     stays as an empty spacer so the columns hold. Right-aligned like the
-	     column header. -->
+	     stays as an empty spacer so the columns hold. -->
 	<div role="cell" class={cell}>
 		{#if !isEditing}
 			<ValidateToggle {transaction} class="mr-1 ml-auto" />


### PR DESCRIPTION
Closes #319. Part of the restyle sweep map #316.

Thins the restyle-authored comments in `src/lib/components/features` past the `docs/dev/code-style.md` floor: cuts what-narration, issue-number provenance, and long-winded why-comments the settled code makes self-evident; keeps only the genuinely surprising constraints (pixel-lock geometry, focus/z-layering, dialog-nesting and form-association quirks).

Comments only — no runtime change, no CHANGELOG entry. Bar: `npm run check` 0 errors, lint clean, 669 unit + 114 e2e green.