### PR TITLE
refactor(ui): thin restyle-authored comments in components/ui (#318)

### DIFF
--- a/src/lib/components/ui/focus-ring/focus-ring.ts
+++ b/src/lib/components/ui/focus-ring/focus-ring.ts
@@ -6,19 +6,17 @@
  */
 
 /**
- * Canonical hover feedback (design language P7): a crisp neutral 1px
- * outline flush with the element edge. Gold stays reserved for keyboard
- * focus. Guarded on `:not(:disabled)` for form controls that keep pointer
- * events while disabled.
+ * Hover feedback (P7): gold stays reserved for keyboard focus.
+ * `:not(:disabled)` guards form controls that keep pointer events while
+ * disabled.
  */
 export const hoverOutline =
 	'hover:not-disabled:outline-1 hover:not-disabled:-outline-offset-1 hover:not-disabled:outline-foreground/50';
 
 /**
- * Error halo for invalid controls (the red border is separate and always
- * shows). Suppressed while the control draws its focus ring — the ring
- * utilities would otherwise override the base-layer gold ring, and gold
- * must stay visible as "keyboard focus is here" (P7).
+ * Error halo for invalid controls (the always-on red border is separate).
+ * Suppressed while the control draws its focus ring — the ring utilities
+ * would otherwise override the gold "keyboard focus is here" ring (P7).
  */
 export const invalidRing =
 	'aria-invalid:not-focus-visible:ring-3 aria-invalid:not-focus-visible:ring-error/20';

--- a/src/lib/components/ui/overlay-motion/overlay-motion.ts
+++ b/src/lib/components/ui/overlay-motion/overlay-motion.ts
@@ -3,18 +3,14 @@
  * `forceMount` + `child` snippets (the pattern bits-ui recommends for
  * transitions).
  *
- * Character ("slingshot light", picked live in #258): surfaces enter with
- * a short directional travel and a slight overshoot past their resting
- * point (backOut), and always exit with a quick plain fade — spring
- * curves look wrong played backwards, hence the `in:`/`out:` split
- * instead of `transition:`. Scrims plain-fade both ways.
- *
- * The drawer is exempt: vaul-svelte owns its slide/drag motion (its
- * timing is tightened via a `duration` override in `drawer-content`).
+ * Surfaces enter with a short directional travel and a slight overshoot
+ * (backOut), and always exit with a quick plain fade — spring curves look
+ * wrong played backwards, hence the `in:`/`out:` split instead of
+ * `transition:`. The drawer is exempt: vaul-svelte owns its slide/drag
+ * motion.
  */
 import { fade, type TransitionConfig } from 'svelte/transition';
 
-/** How far past the resting point the overshoot swings. */
 const OVERSHOOT = 2;
 
 /** Unit direction a floating surface travels in from, per bits-ui `data-side`. */
@@ -26,9 +22,9 @@ const SLIDE_DIRS: Record<string, { x: number; y: number }> = {
 };
 
 /**
- * Anchored floating surfaces (popover, menus, select) entering: 8px
- * travel from the anchor side. Pass bits-ui's `props['data-side']` as
- * `side`; anything else falls back to the `bottom` behavior.
+ * Anchored floating surfaces (popover, menus, select) entering. Pass
+ * bits-ui's `props['data-side']` as `side`; anything else falls back to
+ * the `bottom` behavior.
  */
 export function floatingIn(node: Element, { side }: { side?: unknown } = {}): TransitionConfig {
 	const dir = (typeof side === 'string' && SLIDE_DIRS[side]) || SLIDE_DIRS.bottom;
@@ -40,12 +36,11 @@ export function floatingIn(node: Element, { side }: { side?: unknown } = {}): Tr
 	};
 }
 
-/** Floating surfaces exit with a quick fade. */
 export function floatingOut(node: Element): TransitionConfig {
 	return fade(node, { duration: duration(100) });
 }
 
-/** Centered modal surfaces (dialog, alert-dialog) entering: 12px drop-in. */
+/** Centered modal surfaces (dialog, alert-dialog) entering. */
 export function modalIn(_node: Element): TransitionConfig {
 	const ease = backOut(OVERSHOOT);
 	return {
@@ -54,12 +49,11 @@ export function modalIn(_node: Element): TransitionConfig {
 	};
 }
 
-/** Modal surfaces exit with a quick fade. */
 export function modalOut(node: Element): TransitionConfig {
 	return fade(node, { duration: duration(130) });
 }
 
-/** Scrim behind modal surfaces: plain fade both ways. */
+/** Scrim behind modal surfaces. */
 export function scrimFade(node: Element): TransitionConfig {
 	return fade(node, { duration: duration(200) });
 }

--- a/src/lib/components/ui/pagination/pagination-link.svelte
+++ b/src/lib/components/ui/pagination/pagination-link.svelte
@@ -28,8 +28,8 @@
 	data-active={isActive}
 	data-size={size}
 	class={cn(
-		// The current page wears the interactive tint (amends the #259
-		// selection-is-ink lock for pagination); other pages stay ghosts.
+		// The current page wears the interactive tint — pagination's exception
+		// to the selection-is-ink rule.
 		buttonVariants({ size, variant: isActive ? 'default' : 'ghost' }),
 		'cn-pagination-link',
 		className

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -17,7 +17,6 @@
 		/**
 		 * When `false`, interacting outside the modal does not close it — the Dialog
 		 * variant ignores outside clicks, the Drawer variant is non-dismissible.
-		 * Mirrors the plain `Dialog.Content interactOutsideBehavior="ignore"` intent.
 		 */
 		dismissible?: boolean;
 		/**


### PR DESCRIPTION
Sweep ticket #318 (map #316): thin the restyle-authored comments in `src/lib/components/ui` past the `docs/dev/code-style.md` floor.

- **overlay-motion.ts** — drop provenance (`#258`, "picked live"), the `drawer-content` duration aside, and the pure-what JSDoc one-liners (`floatingOut`, `modalOut`, `OVERSHOOT`); compact the header to the surviving why (springs look wrong backwards → `in:`/`out:` split; drawer exempt).
- **focus-ring.ts** — tighten `hoverOutline`/`invalidRing` docs to the constraint (gold reserved for keyboard focus, suppression rationale); drop the class-string narration.
- **pagination-link.svelte** — replace the `#259` change-log reference with the plain rule exception.
- **responsive-modal.svelte** — drop the "Mirrors `interactOutsideBehavior`" aside from the `dismissible` prop doc.

Kept: the genuinely surprising why (WebKit `select()` focus ping-pong in input-money, jsdom `matchMedia` guard, zebra even-stripe rationale, prop contracts).

Bar: `npm run check` 0 errors · lint clean · 669 unit · 114 e2e passed.

Closes #318.