### PR TITLE
prototype(#334): archive UX — popover, drawer, stacked dialog with inline restore

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -58,6 +58,8 @@
 	"category_archive_title": "Archivierte Kategorien",
 	"category_archive_description": "Hier findest du alle deine archivierten Kategorien. Du kannst sie jederzeit wiederherstellen, um sie erneut in deinem Budgetplan anzuzeigen und wieder Geld auf sie verteilen zu können.",
 	"category_archive_restore_button": "Wiederherstellen",
+	"category_archived_notice_title": "Diese Kategorie ist archiviert",
+	"category_archived_notice_description": "Der Verlauf bleibt erhalten, aber sie kann kein Budget und keine neuen Transaktionen erhalten. Stelle die Kategorie wieder her, um sie erneut zu nutzen.",
 	"category_archive_empty": "Archivierte Kategorien erscheinen hier.",
 	"category_table_empty_title": "Noch keine Kategorien",
 	"category_table_empty_description": "Kategorien sind die Umschläge, auf die du dein Geld verteilst. Erstelle eine, um deine Ausgaben zu planen.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,6 +54,8 @@
 	"category_archive_title": "Archived Categories",
 	"category_archive_description": "Here you can find all your archived categories. You can restore them at any time to show them again in your budget overview and assign budgets to them.",
 	"category_archive_restore_button": "Restore",
+	"category_archived_notice_title": "This category is archived",
+	"category_archived_notice_description": "Its history is kept but it can't receive budget or new transactions. Restore it to use the category again.",
 	"category_archive_empty": "Archived categories will show up here.",
 	"category_table_empty_title": "No categories yet",
 	"category_table_empty_description": "Categories are the envelopes you assign money to. Create one to plan your spending.",

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -19,6 +19,10 @@
 	import PencilIcon from '~icons/ph/pencil';
 	import PlusIcon from '~icons/ph/plus';
 
+	// PROTOTYPE (#334): archived accounts move from a list link to a stacked
+	// dialog, triggered next to the create button (mirrors the category header).
+	import PrototypeAccountArchiveDialog from './prototype-account-archive-dialog.svelte';
+
 	const budgetId = getBudgetId();
 	const budget = $derived(await getBudget(budgetId()));
 	const accounts = $derived(await getAccounts(budgetId()));
@@ -31,10 +35,14 @@
 
 	let open = $state(false);
 	let addOpen = $state(false);
+	let archiveOpen = $state(false);
 
-	// The Add Account dialog must never outlive its dismissed parent.
+	// The stacked dialogs must never outlive their dismissed parent.
 	$effect(() => {
-		if (!open) addOpen = false;
+		if (!open) {
+			addOpen = false;
+			archiveOpen = false;
+		}
 	});
 </script>
 
@@ -115,6 +123,16 @@
 					>
 						<PlusIcon class="size-4" />
 					</Button>
+					{#if archivedAccounts.length > 0}
+						<Button
+							variant="ghost"
+							size="xs"
+							aria-label={m.account_archived_link({ amount: archivedAccounts.length })}
+							onclick={() => (archiveOpen = true)}
+						>
+							<ArchiveIcon class="size-4" />
+						</Button>
+					{/if}
 				</div>
 
 				{#if accounts.length === 0 && archivedAccounts.length === 0}
@@ -135,20 +153,6 @@
 								</a>
 							</li>
 						{/each}
-						{#if archivedAccounts.length > 0}
-							<li>
-								<a
-									href={resolve('/(app)/[budgetId=id]/accounts/archived', {
-										budgetId: budgetId()
-									})}
-									onclick={() => (open = false)}
-									class="inline-flex items-center gap-1.5 text-muted underline-offset-3 hover:text-foreground hover:underline"
-								>
-									<ArchiveIcon class="size-3.5" />
-									{m.account_archived_link({ amount: archivedAccounts.length })}
-								</a>
-							</li>
-						{/if}
 					</ul>
 				{/if}
 			</div>
@@ -185,3 +189,5 @@
 		</Dialog.Body>
 	</Dialog.Content>
 </Dialog.Root>
+
+<PrototypeAccountArchiveDialog accounts={archivedAccounts} bind:open={archiveOpen} />

--- a/src/lib/components/features/budget-settings/prototype-account-archive-dialog.svelte
+++ b/src/lib/components/features/budget-settings/prototype-account-archive-dialog.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. Archived-accounts dialog stacking over
+	// budget settings (same sibling-root pattern as Add Account); C-style
+	// text-link restore rows.
+	import type { getArchivedAccounts } from '$lib/remote-functions/account.remote';
+
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+	import ArchiveIcon from '~icons/ph/archive';
+
+	import PrototypeAccountRestoreLink from './prototype-account-restore-link.svelte';
+
+	let {
+		accounts,
+		open = $bindable(false)
+	}: {
+		accounts: Awaited<ReturnType<typeof getArchivedAccounts>>;
+		open?: boolean;
+	} = $props();
+</script>
+
+<Dialog.Root bind:open>
+	<!-- Lighter scrim so the settings dialog stays present behind (same as the
+	     Add Account stack). -->
+	<Dialog.Content class="sm:max-w-md" overlayClass="bg-background/30">
+		<Dialog.Header>
+			<Dialog.Title class="flex items-baseline gap-1.5">
+				<ArchiveIcon class="size-4 shrink-0 self-center" />
+				{m.account_archive_title()}
+				<span class="text-xs font-normal text-muted">{accounts.length}</span>
+			</Dialog.Title>
+		</Dialog.Header>
+		<Dialog.Body>
+			<ul class="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+				{#each accounts as account (account.id)}
+					<li
+						animate:flip={{ duration: 200 }}
+						class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+					>
+						<PrototypeAccountRestoreLink {account} />
+					</li>
+				{/each}
+			</ul>
+		</Dialog.Body>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/features/budget-settings/prototype-account-archive-dialog.svelte
+++ b/src/lib/components/features/budget-settings/prototype-account-archive-dialog.svelte
@@ -18,6 +18,12 @@
 		accounts: Awaited<ReturnType<typeof getArchivedAccounts>>;
 		open?: boolean;
 	} = $props();
+
+	// Restoring the last account removes the trigger button; the open dialog
+	// must vanish with it instead of lingering as an empty "0" shell.
+	$effect(() => {
+		if (accounts.length === 0) open = false;
+	});
 </script>
 
 <Dialog.Root bind:open>

--- a/src/lib/components/features/budget-settings/prototype-account-restore-link.svelte
+++ b/src/lib/components/features/budget-settings/prototype-account-restore-link.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. One archived-account row with the winning
+	// text-link restore affordance (mirrors the category popover's variant C).
+	import { Button } from '$lib/components/ui/button';
+	import { m } from '$lib/paraglide/messages';
+	import { restoreAccount } from '$lib/remote-functions/account.remote';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
+
+	let { account }: { account: { id: string; name: string } } = $props();
+
+	const form = $derived(restoreAccount.for(account.id));
+	// The item leaving the list is the success signal — no toast.
+	const submit = createFormSubmit(() => form, { toast: {} });
+</script>
+
+<span class="line-clamp-1">{account.name}</span>
+<form {...submit.attrs}>
+	<input {...form.fields.accountId.as('hidden', account.id)} />
+	<Button
+		type="submit"
+		size="xs"
+		variant="link"
+		class="px-0"
+		loading={submit.pending}
+		{@attach submit.anchor}
+	>
+		{m.account_archive_restore_button()}
+	</Button>
+</form>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/+page.svelte
@@ -13,6 +13,8 @@
 	import CategoryBudgetTable from './category-budget-table.svelte';
 	import CategoryQuickActions from './category-quick-actions.svelte';
 	import MonthNavigator from './month-navigator.svelte';
+	// PROTOTYPE (#334): floating variant switcher for the archive popover.
+	import PrototypeArchiveSwitcher from './prototype-archive-switcher.svelte';
 	import TutorialCard from './tutorial-card.svelte';
 	import UnassignedSummary from './unassigned-summary.svelte';
 
@@ -74,3 +76,5 @@
 		{/if}
 	</Page.Content>
 </Page.Root>
+
+<PrototypeArchiveSwitcher />

--- a/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
@@ -1,0 +1,77 @@
+# Prototype notes — archive popover (#334)
+
+Three variants of the category archive popover, switchable via `?variant=`, on the existing
+`/[budgetId]/[month]` route. The trigger replaces the desktop table header's archived-page link;
+the popover opens `side="right" align="start"`, max-height + scroll, per-item restore wired to the
+real `restoreCategory` remote function (restored rows visibly return to the budget table).
+
+Dev data: `local.db` is an isolated copy of the restyle worktree's dev DB, seeded with 10 archived
+categories (2 real ones archived + 8 fabricated `PROTO000AAA*` rows) for scroll testing.
+
+## Round 1 (2026-07-28)
+
+- **A — Slim list**: minimal single-line rows, always-visible icon-only restore, w-64, no header.
+- **B — Titled panel**: Popover.Header with title + count, dated card rows, labeled restore button, w-80.
+- **C — Row action**: whole row is the restore button; hover/focus swaps the archived date for a
+  "Restore" label, w-72, count hint at top.
+
+Open questions (not yet prototyped):
+
+- Mobile: the below-@3xl action row still links to the old archived page — popover vs drawer TBD.
+- Accounts side: same winning pattern to be mounted next to the "Accounts" label in budget settings
+  (its popover would open inside the ResponsiveModal).
+- Archived detail pages: category page currently redirects away; target design = disclaimer +
+  restore only (accounts already ~have this via AccountArchivedNotice, minus the balances block).
+
+## Feedback log
+
+### Round 2 (2026-07-28)
+
+- User liked round 1's direction; asked for a **hybrid of A (slim list) + a title, padding kept
+  tight**. Slot A replaced in place with the hybrid (old A snapshotted to
+  `history/round-1-VariantA.svelte`): compact title row (`Popover.Title` + muted count, `px-2`)
+  over the unchanged slim rows, popover stays `w-64 p-2`. B and C untouched for comparison.
+- Session note: dev login is a minted session cookie in the DB copy (user "Ada"); "Subscriptions"
+  was restored live during round 1 — restore-to-table behaviour confirmed working.
+
+### Round 3 (2026-07-28)
+
+- **A declared the winner of round 2** (slim list + compact title). Two follow-ups: max height
+  smaller (now `max-h-48` everywhere, was `max-h-72`), and restore discoverability — the tiny
+  icon-only button didn't communicate "how do I restore".
+- All three slots converged on A's chrome, differing only in the restore affordance
+  (round-2 files snapshotted to `history/*.svelte.bak` — renamed so svelte-check ignores them):
+  - **A — Labeled button**: always-visible xs `Restore` button (interactive tint) per row.
+  - **B — Row press**: the whole row is the restore button; muted icon+label always visible,
+    turns interactive on hover/focus.
+  - **C — Text link**: quiet always-visible `Restore` text link per row.
+
+### Round 4 (2026-07-28)
+
+- **C (text link) declared the restore-affordance winner.** Next ask: the popover must be
+  consistent with the budget table's category/assignment popovers — tinted header strip, and the
+  trigger icon staying pixel-locked with the title appearing next to it (like the table popovers
+  keep name/amount in place).
+- Slot C rebuilt on the `category-popover.svelte` overlay pattern (old C →
+  `history/round-3-VariantC.svelte.bak`): `side="bottom" align="start"` with
+  `sideOffset={-triggerHeight}` (trigger height measured via ResizeObserver in the wrapper),
+  `motion="fade"`, panel `w-64 gap-0 p-0 rounded-xs bg-surface shadow-sm ring-1 ring-muted/30`,
+  header strip `bg-muted/5 border-b border-muted/20 px-2` at trigger height repeating the
+  ArchiveIcon with the title beside it and the muted count right-aligned. Text-link rows under a
+  `max-h-48` scroll area.
+
+### Round 5 (2026-07-28)
+
+- **Round-4 C locked as the category archive popover design.**
+- **Accounts side built** (in `src/lib/components/features/budget-settings/`):
+  - Trigger: ghost xs ArchiveIcon button directly right of the small create (+) button next to
+    the "Accounts" label in budget settings — mirroring the category table header. The old
+    archived-page list link is removed.
+  - Surface: an **extra dialog stacking over budget settings** (same sibling-root +
+    `overlayClass="bg-background/30"` pattern as Add Account; closes with its parent).
+    `Dialog.Title` = ArchiveIcon + "Archived Accounts" + inline muted count (count must NOT be
+    `ml-auto` — it collides with the dialog's close X). Body: C-style text-link restore rows,
+    `max-h-48` scroll, wired to the real `restoreAccount` — restored accounts reappear in the
+    settings account list live.
+- Seed data: 3 extra archived accounts fabricated (`PROTOACCT*`); categories re-archived after
+  live restores emptied the archive.

--- a/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
@@ -109,3 +109,10 @@ Open questions (not yet prototyped):
     `AccountArchivedNotice`.
   - Restore-in-place verified: submitting refreshes the page query and the full detail view
     returns without navigation.
+
+### Final lock (2026-07-29)
+
+- **All rounds locked.** The complete archive UX prototype: desktop category popover (round-4 C),
+  accounts stacked dialog, mobile categories bottom drawer, disclaimer-only archived detail
+  pages, zero-state auto-hide everywhere, live restore into the owning views.
+- Prototyping phase closed; this branch is the primary source for the implementation pass.

--- a/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
@@ -97,3 +97,15 @@ Open questions (not yet prototyped):
 - **Mobile round 1 locked.** Archived categories on mobile = bottom drawer
   (`prototype-archive-drawer.svelte`); archived accounts on mobile stay in the stacked dialog
   over the settings drawer, as shown.
+
+### Round 8 (2026-07-29)
+
+- **Archived detail pages** (last piece of the original spec): both pages now show nothing but
+  a disclaimer + restore.
+  - Category: the redirect-to-archived-list `$effect` is gone; the page renders
+    `prototype-category-archived-notice.svelte` (mirrors `account-archived-notice.svelte`) when
+    `archivedAt` is set. New messages `category_archived_notice_title/description` (en + de).
+  - Account: the archived branch drops `AccountBalances` + separator and keeps only
+    `AccountArchivedNotice`.
+  - Restore-in-place verified: submitting refreshes the page query and the full detail view
+    returns without navigation.

--- a/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
@@ -91,3 +91,9 @@ Open questions (not yet prototyped):
 - Account side on mobile checked as-is: budget settings renders as a drawer, and the stacked
   archive **dialog** over it reads fine at 390px — open question for the user whether it should
   become a (nested) drawer for consistency.
+
+### Round 7 (2026-07-29)
+
+- **Mobile round 1 locked.** Archived categories on mobile = bottom drawer
+  (`prototype-archive-drawer.svelte`); archived accounts on mobile stay in the stacked dialog
+  over the settings drawer, as shown.

--- a/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/PROTOTYPE-NOTES.md
@@ -75,3 +75,19 @@ Open questions (not yet prototyped):
     settings account list live.
 - Seed data: 3 extra archived accounts fabricated (`PROTOACCT*`); categories re-archived after
   live restores emptied the archive.
+
+### Round 6 (2026-07-29)
+
+- **Post-lock fix:** restoring the last archived account left the account archive dialog open as
+  an empty "0" shell (the `length > 0` guard only wrapped the trigger). The dialog now closes
+  itself via `$effect` when the list empties; the new mobile drawer ships with the same guard
+  from day one.
+- **Mobile round 1** (user: "simple list there, maybe in drawer"): the `@max-3xl` action-row
+  link to the old archived page is replaced by `prototype-archive-drawer.svelte` — a bottom
+  `Drawer` (vaul) triggered by the same ghost "N archived" button. Centered drawer title =
+  ArchiveIcon + "Archived Categories" + muted count; body = the C-style simple rows with
+  text-link Restore, drawer-native scroll. Restore verified live at 390px (count updates,
+  category reappears in the card list behind).
+- Account side on mobile checked as-is: budget settings renders as a drawer, and the stacked
+  archive **dialog** over it reads fine at 390px — open question for the user whether it should
+  become a (nested) drawer for consistency.

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -14,7 +14,6 @@
 	import { asMoney, formatMoney } from '$lib/utils/money';
 	import { createSortable } from '$lib/utils/sort-helper.svelte';
 	import { cn } from 'tailwind-variants';
-	import ArchiveIcon from '~icons/ph/archive';
 	import PhDotsSixVerticalBold from '~icons/ph/dots-six-vertical-bold';
 	import PlusIcon from '~icons/ph/plus';
 	import StackIcon from '~icons/ph/stack';
@@ -24,7 +23,9 @@
 	import CategoryAssignmentForm from './category-assignment-form.svelte';
 	import CategoryAssignmentModal from './category-assignment-modal.svelte';
 	import CategoryPopover from './category-popover.svelte';
-	// PROTOTYPE (#334): replaces the archived-page link in the desktop header.
+	// PROTOTYPE (#334): replaces the archived-page links — popover in the
+	// desktop header, bottom drawer in the mobile action row.
+	import PrototypeArchiveDrawer from './prototype-archive-drawer.svelte';
 	import PrototypeArchivePopover from './prototype-archive-popover.svelte';
 	import ReassignmentPopup from './reassignment-popup.svelte';
 
@@ -37,9 +38,6 @@
 	const budgetId = getBudgetId();
 
 	const archivedCategories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
-	const archivedHref = $derived(
-		resolve('/(app)/[budgetId=id]/categories/archived', { budgetId: budgetId() })
-	);
 	const createHref = $derived(
 		resolve('/(app)/[budgetId=id]/categories/new', { budgetId: budgetId() })
 	);
@@ -141,12 +139,7 @@
 				<PlusIcon class="size-6" />
 				{m.category_create_button()}
 			</Button>
-			{#if archivedCategories.length > 0}
-				<Button variant="ghost" class="h-11" href={archivedHref}>
-					<ArchiveIcon class="size-6" />
-					{m.category_archived_link({ amount: archivedCategories.length })}
-				</Button>
-			{/if}
+			<PrototypeArchiveDrawer categories={archivedCategories} />
 		</div>
 
 		<div role="rowgroup" class="grid gap-2 @3xl/main:gap-0" {@attach categorySortable.attach}>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -24,6 +24,8 @@
 	import CategoryAssignmentForm from './category-assignment-form.svelte';
 	import CategoryAssignmentModal from './category-assignment-modal.svelte';
 	import CategoryPopover from './category-popover.svelte';
+	// PROTOTYPE (#334): replaces the archived-page link in the desktop header.
+	import PrototypeArchivePopover from './prototype-archive-popover.svelte';
 	import ReassignmentPopup from './reassignment-popup.svelte';
 
 	let {
@@ -114,16 +116,7 @@
 						>
 							<PlusIcon class="size-4" />
 						</Button>
-						{#if archivedCategories.length > 0}
-							<Button
-								variant="ghost"
-								size="xs"
-								href={archivedHref}
-								aria-label={m.category_archived_link({ amount: archivedCategories.length })}
-							>
-								<ArchiveIcon class="size-4" />
-							</Button>
-						{/if}
+						<PrototypeArchivePopover />
 					</span>
 				</BudgetTableHeader>
 				<BudgetTableHeader class="w-1/5">

--- a/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantA.svelte.bak
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantA.svelte.bak
@@ -1,0 +1,26 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant A "Slim list": minimal single-line rows, name +
+	// always-visible icon-only restore. No header, tight width.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-64 gap-1 p-2">
+	<ul class="flex max-h-72 flex-col gap-0.5 overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+			>
+				<span class="line-clamp-1">{category.name}</span>
+				<PrototypeRestoreForm {category} style="icon" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantB.svelte.bak
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantB.svelte.bak
@@ -1,0 +1,44 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant B "Titled panel": popover header with title +
+	// count, rows carry the archived date, labeled restore button per row.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { formatDate } from '$lib/utils/format-date';
+	import { flip } from 'svelte/animate';
+	import ArchiveIcon from '~icons/ph/archive';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-80 gap-3">
+	<Popover.Header>
+		<Popover.Title>{m.category_archive_title()}</Popover.Title>
+		<Popover.Description>
+			{m.category_archived_link({ amount: categories.length })}
+		</Popover.Description>
+	</Popover.Header>
+
+	<ul class="-mr-2 flex max-h-80 flex-col gap-2 overflow-y-auto pr-2">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-md border border-muted/20 bg-surface p-2"
+			>
+				<div class="flex min-w-0 flex-col gap-0.5">
+					<span class="line-clamp-1">{category.name}</span>
+					<span class="flex items-center gap-1 text-xs text-muted">
+						<ArchiveIcon class="size-3" />
+						{category.archivedAt
+							? formatDate({ date: category.archivedAt, options: { dateStyle: 'medium' } })
+							: ''}
+					</span>
+				</div>
+				<PrototypeRestoreForm {category} style="labeled" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantC.svelte.bak
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/history/round-1-VariantC.svelte.bak
@@ -1,0 +1,26 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant C "Row action": the whole row is the restore
+	// button — hover/focus swaps the archived date for a Restore label.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-72 gap-1 p-2">
+	<p class="px-2 pt-1 text-xs text-muted">
+		{m.category_archived_link({ amount: categories.length })}
+	</p>
+	<ul class="flex max-h-72 flex-col overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li animate:flip={{ duration: 200 }}>
+				<PrototypeRestoreForm {category} style="row" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/history/round-2-VariantA.svelte.bak
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/history/round-2-VariantA.svelte.bak
@@ -1,0 +1,32 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant A "Slim list + title" (round 2 hybrid): compact
+	// title row over the minimal single-line rows; padding stays tight.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-64 gap-1 p-2">
+	<div class="flex items-baseline justify-between gap-2 px-2 pt-1 pb-0.5">
+		<Popover.Title>{m.category_archive_title()}</Popover.Title>
+		<span class="text-xs text-muted">{categories.length}</span>
+	</div>
+
+	<ul class="flex max-h-72 flex-col gap-0.5 overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+			>
+				<span class="line-clamp-1">{category.name}</span>
+				<PrototypeRestoreForm {category} style="icon" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/history/round-3-VariantC.svelte.bak
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/history/round-3-VariantC.svelte.bak
@@ -1,0 +1,32 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant C (round 3): A's chrome; restore is an
+	// always-visible quiet text link per row.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-64 gap-1 p-2">
+	<div class="flex items-baseline justify-between gap-2 px-2 pt-1 pb-0.5">
+		<Popover.Title>{m.category_archive_title()}</Popover.Title>
+		<span class="text-xs text-muted">{categories.length}</span>
+	</div>
+
+	<ul class="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+			>
+				<span class="line-clamp-1">{category.name}</span>
+				<PrototypeRestoreForm {category} style="link" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-drawer.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-drawer.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. Mobile take: archived categories in a
+	// bottom drawer; same slim rows + text-link restore as the locked desktop
+	// popover (round-4 C). Replaces the old archived-page link in the @max-3xl
+	// action row.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import { Button } from '$lib/components/ui/button';
+	import * as Drawer from '$lib/components/ui/drawer';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+	import ArchiveIcon from '~icons/ph/archive';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+
+	let open = $state(false);
+
+	// Restoring the last category removes the trigger; the open drawer must
+	// vanish with it instead of lingering as an empty shell.
+	$effect(() => {
+		if (categories.length === 0) open = false;
+	});
+</script>
+
+{#if categories.length > 0}
+	<Drawer.Root bind:open>
+		<Drawer.Trigger>
+			{#snippet child({ props })}
+				<Button {...props} variant="ghost" class="h-11">
+					<ArchiveIcon class="size-6" />
+					{m.category_archived_link({ amount: categories.length })}
+				</Button>
+			{/snippet}
+		</Drawer.Trigger>
+
+		<Drawer.Content>
+			<Drawer.Header>
+				<Drawer.Title class="flex items-center justify-center gap-1.5">
+					<ArchiveIcon class="size-4 shrink-0" />
+					{m.category_archive_title()}
+					<span class="text-xs font-normal text-muted">{categories.length}</span>
+				</Drawer.Title>
+			</Drawer.Header>
+
+			<Drawer.Body class="px-4">
+				<ul class="flex flex-col gap-0.5">
+					{#each categories as category (category.id)}
+						<li
+							animate:flip={{ duration: 200 }}
+							class="flex items-center justify-between gap-3 rounded-sm px-2 py-1.5"
+						>
+							<span class="line-clamp-1">{category.name}</span>
+							<PrototypeRestoreForm {category} style="link" />
+						</li>
+					{/each}
+				</ul>
+			</Drawer.Body>
+		</Drawer.Content>
+	</Drawer.Root>
+{/if}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-a.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-a.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant A (round 3): winning slim-list-plus-title
+	// chrome; restore is an always-visible labeled xs button per row.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-64 gap-1 p-2">
+	<div class="flex items-baseline justify-between gap-2 px-2 pt-1 pb-0.5">
+		<Popover.Title>{m.category_archive_title()}</Popover.Title>
+		<span class="text-xs text-muted">{categories.length}</span>
+	</div>
+
+	<ul class="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+			>
+				<span class="line-clamp-1">{category.name}</span>
+				<PrototypeRestoreForm {category} style="labeled" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-b.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-b.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant B (round 3): A's chrome; the whole row is the
+	// restore button, with an always-visible muted "Restore" label that turns
+	// interactive on hover/focus.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let { categories }: { categories: Awaited<ReturnType<typeof getArchivedCategories>> } = $props();
+</script>
+
+<Popover.Content side="right" align="start" class="w-64 gap-1 p-2">
+	<div class="flex items-baseline justify-between gap-2 px-2 pt-1 pb-0.5">
+		<Popover.Title>{m.category_archive_title()}</Popover.Title>
+		<span class="text-xs text-muted">{categories.length}</span>
+	</div>
+
+	<ul class="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+		{#each categories as category (category.id)}
+			<li animate:flip={{ duration: 200 }}>
+				<PrototypeRestoreForm {category} style="row" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-c.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover-variant-c.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — Variant C (round 4): text-link rows in the budget
+	// table's popover chrome — panel overlays the trigger (negative offset), a
+	// tinted title strip repeats the archive icon at its exact anchor position
+	// with the title beside it, mirroring category-popover.svelte.
+	import type { getArchivedCategories } from '$lib/remote-functions/category.remote';
+
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { flip } from 'svelte/animate';
+	import ArchiveIcon from '~icons/ph/archive';
+
+	import PrototypeRestoreForm from './prototype-restore-form.svelte';
+
+	let {
+		categories,
+		triggerHeight
+	}: {
+		categories: Awaited<ReturnType<typeof getArchivedCategories>>;
+		triggerHeight: number;
+	} = $props();
+</script>
+
+<Popover.Content
+	side="bottom"
+	align="start"
+	sideOffset={-triggerHeight}
+	motion="fade"
+	class="w-64 gap-0 overflow-hidden rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30"
+>
+	<!-- Title strip mirrors the trigger button — same inset and height — so the
+	     archive icon doesn't shift when the panel opens over it. -->
+	<div
+		class="flex items-center gap-1.5 border-b border-muted/20 bg-muted/5 px-2"
+		style="min-height: {triggerHeight}px"
+	>
+		<ArchiveIcon class="size-4 shrink-0" />
+		<Popover.Title class="truncate text-sm">{m.category_archive_title()}</Popover.Title>
+		<span class="ml-auto text-xs text-muted">{categories.length}</span>
+	</div>
+
+	<ul class="flex max-h-48 flex-col gap-0.5 overflow-y-auto p-1">
+		{#each categories as category (category.id)}
+			<li
+				animate:flip={{ duration: 200 }}
+				class="flex items-center justify-between gap-2 rounded-sm px-2 py-0.5 hover:bg-muted/5"
+			>
+				<span class="line-clamp-1">{category.name}</span>
+				<PrototypeRestoreForm {category} style="link" />
+			</li>
+		{/each}
+	</ul>
+</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-popover.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. Three takes on the archive popover replacing
+	// the archived-list page, switchable via `?variant=` (see
+	// prototype-archive-switcher.svelte). Mounted next to the category title in
+	// the budget table header.
+	import { page } from '$app/state';
+	import { buttonVariants } from '$lib/components/ui/button';
+	import * as Popover from '$lib/components/ui/popover';
+	import { m } from '$lib/paraglide/messages';
+	import { getArchivedCategories } from '$lib/remote-functions/category.remote';
+	import { getBudgetId } from '$lib/utils/budget-id-context';
+	import ArchiveIcon from '~icons/ph/archive';
+
+	import VariantA from './prototype-archive-popover-variant-a.svelte';
+	import VariantB from './prototype-archive-popover-variant-b.svelte';
+	import VariantC from './prototype-archive-popover-variant-c.svelte';
+
+	const budgetId = getBudgetId();
+	const categories = $derived(await getArchivedCategories({ budgetId: budgetId() }));
+
+	const variant = $derived(page.url.searchParams.get('variant')?.toUpperCase() ?? 'A');
+
+	// Trigger height measured live (category-popover.svelte pattern) so variant
+	// C's overlay panel can pixel-lock the icon inside its title strip.
+	let triggerEl = $state<HTMLElement | null>(null);
+	let triggerHeight = $state(0);
+	$effect(() => {
+		if (!triggerEl) return;
+		const observer = new ResizeObserver(() => (triggerHeight = triggerEl!.offsetHeight));
+		observer.observe(triggerEl);
+		return () => observer.disconnect();
+	});
+</script>
+
+{#if categories.length > 0}
+	<Popover.Root>
+		<Popover.Trigger
+			bind:ref={triggerEl}
+			class={buttonVariants({ size: 'xs', variant: 'ghost' })}
+			aria-label={m.category_archived_link({ amount: categories.length })}
+		>
+			<ArchiveIcon class="size-4" />
+		</Popover.Trigger>
+
+		{#if variant === 'B'}
+			<VariantB {categories} />
+		{:else if variant === 'C'}
+			<VariantC {categories} {triggerHeight} />
+		{:else}
+			<VariantA {categories} />
+		{/if}
+	</Popover.Root>
+{/if}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-switcher.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-archive-switcher.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. Floating bottom bar cycling the archive
+	// popover variants via `?variant=`. Dev-only.
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+
+	const VARIANTS = [
+		{ key: 'A', name: 'Labeled button' },
+		{ key: 'B', name: 'Row press' },
+		{ key: 'C', name: 'Text link' }
+	];
+
+	const current = $derived(page.url.searchParams.get('variant')?.toUpperCase() ?? 'A');
+	const index = $derived(
+		Math.max(
+			0,
+			VARIANTS.findIndex((v) => v.key === current)
+		)
+	);
+
+	function go(step: number) {
+		const next = VARIANTS[(index + step + VARIANTS.length) % VARIANTS.length];
+		const url = new URL(page.url);
+		url.searchParams.set('variant', next.key);
+		// eslint-disable-next-line svelte/no-navigation-without-resolve -- same-page param swap in throwaway prototype
+		goto(url, { keepFocus: true, noScroll: true, replaceState: true });
+	}
+
+	function onKeydown(event: KeyboardEvent) {
+		const target = event.target as HTMLElement | null;
+		if (target?.closest('input, textarea, [contenteditable]')) return;
+		if (event.key === 'ArrowLeft') go(-1);
+		if (event.key === 'ArrowRight') go(1);
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if import.meta.env.DEV}
+	<div
+		class="fixed bottom-4 left-1/2 z-100 flex -translate-x-1/2 items-center gap-1 rounded-full bg-foreground px-3 py-1.5 text-sm text-background shadow-lg"
+	>
+		<button
+			type="button"
+			class="cursor-pointer px-1.5"
+			onclick={() => go(-1)}
+			aria-label="Previous variant"
+		>
+			←
+		</button>
+		<span class="min-w-36 text-center font-medium">
+			{VARIANTS[index].key} — {VARIANTS[index].name}
+		</span>
+		<button
+			type="button"
+			class="cursor-pointer px-1.5"
+			onclick={() => go(1)}
+			aria-label="Next variant"
+		>
+			→
+		</button>
+	</div>
+{/if}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/prototype-restore-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/prototype-restore-form.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. One restore affordance per archived
+	// category; `style` selects the per-variant look. Wired to the real
+	// `restoreCategory` remote function so the restored row visibly returns to
+	// the budget table.
+	import { Button } from '$lib/components/ui/button';
+	import { m } from '$lib/paraglide/messages';
+	import { restoreCategory } from '$lib/remote-functions/category.remote';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
+	import HandWithdrawIcon from '~icons/ph/hand-withdraw';
+
+	let {
+		category,
+		style
+	}: {
+		category: { archivedAt: Date | null; id: string; name: string };
+		style: 'labeled' | 'link' | 'row';
+	} = $props();
+
+	const form = $derived(restoreCategory.for(category.id));
+	// The item leaving the popover list is the success signal — no toast.
+	const submit = createFormSubmit(() => form, { toast: {} });
+</script>
+
+{#if style === 'labeled'}
+	<form {...submit.attrs}>
+		<input {...form.fields.categoryId.as('hidden', category.id)} />
+		<Button type="submit" size="xs" loading={submit.pending} {@attach submit.anchor}>
+			<HandWithdrawIcon class="size-3" />
+			{m.category_archive_restore_button()}
+		</Button>
+	</form>
+{:else if style === 'link'}
+	<form {...submit.attrs}>
+		<input {...form.fields.categoryId.as('hidden', category.id)} />
+		<Button
+			type="submit"
+			size="xs"
+			variant="link"
+			class="px-0"
+			loading={submit.pending}
+			{@attach submit.anchor}
+		>
+			{m.category_archive_restore_button()}
+		</Button>
+	</form>
+{:else}
+	<form {...submit.attrs} class="w-full">
+		<input {...form.fields.categoryId.as('hidden', category.id)} />
+		<button
+			type="submit"
+			class="group flex w-full cursor-pointer items-center justify-between gap-3 rounded-sm px-2 py-1 text-left hover:bg-interactive/10 focus-visible:bg-interactive/10 focus-visible:outline-none"
+			{@attach submit.anchor}
+		>
+			<span class="line-clamp-1">{category.name}</span>
+			<span
+				class="flex items-center gap-1 text-xs text-muted group-hover:text-interactive group-focus-visible:text-interactive"
+			>
+				<HandWithdrawIcon class="size-3.5" />
+				{m.category_archive_restore_button()}
+			</span>
+		</button>
+	</form>
+{/if}

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -8,7 +8,6 @@
 	import { TableState, TransactionTable } from '$lib/components/features/transaction';
 	import { Button } from '$lib/components/ui/button';
 	import * as Page from '$lib/components/ui/page';
-	import { Separator } from '$lib/components/ui/separator';
 	import { m } from '$lib/paraglide/messages';
 	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
@@ -107,10 +106,8 @@
 
 	<Page.Content>
 		{#if account.archivedAt}
-			<AccountBalances {balances} currency={budget.currency} />
-
-			<Separator orientation="horizontal" />
-
+			<!-- PROTOTYPE (#334): an archived account's page is nothing but the
+			     disclaimer + restore (balances dropped). -->
 			<AccountArchivedNotice accountId={accountId()} />
 		{:else}
 			<TransactionTable

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/+page.svelte
@@ -17,6 +17,9 @@
 
 	import type { PageProps } from './$types';
 
+	// PROTOTYPE (#334): disclaimer + restore replaces the archived redirect.
+	import PrototypeCategoryArchivedNotice from './prototype-category-archived-notice.svelte';
+
 	let { params }: PageProps = $props();
 
 	const budgetId = getBudgetId();
@@ -28,15 +31,6 @@
 	// The page's stats are always scoped to the current month — there is no
 	// month in this URL.
 	const month = currentMonth();
-
-	// Archived categories are managed through the archived list's restore flow,
-	// not this page. Archiving here trips the same redirect: the submit
-	// refreshes getCategoryById, populating archivedAt.
-	$effect(() => {
-		if (category.archivedAt !== null) {
-			goto(resolve('/(app)/[budgetId=id]/categories/archived', { budgetId: budgetId() }));
-		}
-	});
 
 	const onDeleted = () =>
 		goto(
@@ -55,20 +49,26 @@
 	</Page.Header>
 
 	<Page.Content class="max-w-xl">
-		<div class="space-y-3">
-			<CategoryEdit {category} currency={budget.currency} />
+		<!-- PROTOTYPE (#334): an archived category's page is nothing but the
+		     disclaimer + restore (was: redirect to the archived-list page). -->
+		{#if category.archivedAt !== null}
+			<PrototypeCategoryArchivedNotice categoryId={categoryId()} />
+		{:else}
+			<div class="space-y-3">
+				<CategoryEdit {category} currency={budget.currency} />
 
-			<Separator class="mt-6 mb-3" />
+				<Separator class="mt-6 mb-3" />
 
-			<CategoryStats {category} currency={budget.currency} {month} />
+				<CategoryStats {category} currency={budget.currency} {month} />
 
-			<Separator class="mt-6 mb-3" />
+				<Separator class="mt-6 mb-3" />
 
-			<CategoryArchive {category} currency={budget.currency} />
+				<CategoryArchive {category} currency={budget.currency} />
 
-			<Separator class="mt-6 mb-3" />
+				<Separator class="mt-6 mb-3" />
 
-			<CategoryDelete {category} currency={budget.currency} {onDeleted} />
-		</div>
+				<CategoryDelete {category} currency={budget.currency} {onDeleted} />
+			</div>
+		{/if}
 	</Page.Content>
 </Page.Root>

--- a/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/prototype-category-archived-notice.svelte
+++ b/src/routes/(app)/[budgetId=id]/categories/[categoryId=id]/prototype-category-archived-notice.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	// PROTOTYPE (#334) — throwaway. Archived category detail: nothing but a
+	// disclaimer + restore, mirroring account-archived-notice.svelte. Restoring
+	// refreshes getCategoryById, so the regular detail view returns in place.
+	import { Button } from '$lib/components/ui/button';
+	import { m } from '$lib/paraglide/messages';
+	import { restoreCategory } from '$lib/remote-functions/category.remote';
+	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
+	import ArchiveIcon from '~icons/ph/archive';
+	import HandWithdrawIcon from '~icons/ph/hand-withdraw';
+
+	let { categoryId }: { categoryId: string } = $props();
+
+	const form = $derived(restoreCategory.for(categoryId));
+	const submit = createFormSubmit(() => form, { toast: {} });
+</script>
+
+<section
+	class="flex flex-col items-center gap-3 rounded-md border border-muted/20 bg-muted/5 p-8 text-center"
+>
+	<ArchiveIcon class="size-10 text-muted" />
+
+	<h2 class="text-lg font-semibold">{m.category_archived_notice_title()}</h2>
+
+	<p class="max-w-prose text-muted">{m.category_archived_notice_description()}</p>
+
+	<form {...submit.attrs}>
+		<input {...form.fields.categoryId.as('hidden', categoryId)} />
+		<Button type="submit" loading={submit.pending} {@attach submit.anchor}>
+			<HandWithdrawIcon class="size-4" />
+			{m.category_archive_restore_button()}
+		</Button>
+	</form>
+</section>


### PR DESCRIPTION
Prototype branch for the archive UX locked in #334 (resolution comment there has the full design); implementation ticket: #337.

## What's in here

- **Categories, desktop:** archive popover in the budget-table column header — anchor-overlay chrome consistent with the category/assignment popovers (tinted header strip, pixel-locked icon, muted count), slim rows with text-link Restore, `max-h-48` scroll.
- **Categories, mobile:** the `@max-3xl` action-row button opens a bottom drawer with the same rows.
- **Accounts:** archive button next to the create (+) button in budget settings, opening a dialog stacked over settings (Add-Account pattern); on mobile it stacks over the settings drawer.
- **Zero-state:** every affordance hides when nothing is archived; open surfaces close themselves when the last item is restored.
- **Archived detail pages** show only a disclaimer + restore (category loses its redirect, account loses the balances block); new `category_archived_notice_*` messages (en+de).
- `PROTOTYPE-NOTES.md` carries the round-by-round decision log (8 HITL rounds); `history/*.svelte.bak` are round snapshots.

## Notes for review

- This is **throwaway prototype code** (components marked `prototype-*`, variant switcher, stale variants A/B kept for reference) — the production pass in #337 replaces it and deletes the two `archived` routes.
- `npm run check` green; restore flows verified live in both viewports.