### PR TITLE
restyle(error): poster layout for the error page (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- The error page dropped its tinted panel for a plain poster layout: the
+  status code stands directly on the page as a large serif numeral, with the
+  error message, log ID, and home link beneath it.
 - Archived categories and accounts moved out of their dedicated pages into
   lightweight surfaces with inline restore: categories open in a popover next
   to the budget table's create button (a bottom drawer on small screens), and

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -4,20 +4,17 @@
 	import * as m from '$lib/paraglide/messages';
 </script>
 
-<div class="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
-	<div class="flex max-w-md flex-col gap-3 rounded-lg bg-error/5 p-6 text-center">
-		<p class="text-6xl font-bold tracking-tighter">
-			{page.status}
+<div class="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+	<p class="font-display text-8xl font-bold">
+		{page.status}
+	</p>
+	<p class="font-medium text-error">
+		{page.error?.message ?? m.error_page_unexpected()}
+	</p>
+	{#if page.error?.logId}
+		<p class="text-sm text-muted">
+			{m.error_page_log_id()} <span class="font-mono">{page.error.logId}</span>
 		</p>
-		<p class="font-medium text-error">
-			{page.error?.message ?? m.error_page_unexpected()}
-		</p>
-		{#if page.error?.logId}
-			<p class="text-sm text-muted">
-				{m.error_page_log_id()} <span class="font-mono">{page.error.logId}</span>
-			</p>
-		{/if}
-	</div>
-
-	<a href={resolve('/(app)')} class="link text-sm">{m.error_page_go_home()}</a>
+	{/if}
+	<a href={resolve('/(app)')} class="link mt-4 text-sm">{m.error_page_go_home()}</a>
 </div>


### PR DESCRIPTION
Resolves #335 (widened live from the status number to the whole page).

The error page drops its `bg-error/5` panel for a poster layout: the status code stands directly on the page background as a large display numeral (`font-display text-8xl font-bold`, natural tracking — no `tracking-tighter` on the serif), with the error-ink message, muted log ID, and `.link` home link beneath.

Locked HITL via a 4-variant whole-page prototype switch (poster / empty-state / login-sibling / open-ledger); "poster" won. Verified live in both modes; `npm run check`, lint, unit (659), e2e (114) green.