### PR TITLE
restyle(ui): hover & highlight tints back to neutral (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- Hover and list-highlight feedback is neutral everywhere: the budget
+  settings, budget members, and account settings icon buttons no longer
+  deepen their tint on hover, and the reassignment popup's category list
+  highlights with the standard neutral fill instead of blue. Positive
+  balances in that list render as plain text — green stays reserved for
+  target progress.
+
 - The error page dropped its tinted panel for a plain poster layout: the
   status code stands directly on the page as a large serif numeral, with the
   error message, log ID, and home link beneath it.

--- a/src/lib/components/features/budget-settings/budget-settings.svelte
+++ b/src/lib/components/features/budget-settings/budget-settings.svelte
@@ -47,7 +47,7 @@
 <ResponsiveModal.Root bind:open>
 	<ResponsiveModal.Trigger>
 		{#snippet child({ props })}
-			<Button {...props} variant="ghost" size="icon" class="bg-muted/10 hover:bg-muted/20">
+			<Button {...props} variant="ghost" size="icon">
 				<PencilIcon />
 				<span class="sr-only">{m.budget_settings_title()}</span>
 			</Button>

--- a/src/lib/components/features/budget-user-manager/budget-user-manager.svelte
+++ b/src/lib/components/features/budget-user-manager/budget-user-manager.svelte
@@ -23,13 +23,7 @@
 <ResponsiveModal.Root dismissible={false}>
 	<ResponsiveModal.Trigger>
 		{#snippet child({ props })}
-			<Button
-				{...props}
-				variant="ghost"
-				size="icon"
-				aria-label={m.budget_users_dialog_title()}
-				class="bg-muted/10 hover:bg-muted/20"
-			>
+			<Button {...props} variant="ghost" size="icon" aria-label={m.budget_users_dialog_title()}>
 				{#if budgetUsers.length > 1}
 					<UsersThreeIcon />
 				{:else}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -183,13 +183,12 @@
 	<Combobox.Item
 		value={item.id}
 		label={item.label}
-		class="flex w-full cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-highlighted:bg-info/5 data-highlighted:text-info data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+		class="flex w-full cursor-default items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-highlighted:bg-muted/10 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 	>
 		<div>{item.label}</div>
 		<div
 			class={cn(
 				'rounded-sm p-0.5 px-2 font-currency text-xs text-foreground',
-				item.balance > 0 && 'bg-success/20',
 				item.balance < 0 && 'bg-error/20 text-error'
 			)}
 		>

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -102,7 +102,6 @@
 			<Button
 				variant="ghost"
 				size="icon"
-				class="bg-muted/10 hover:bg-muted/20"
 				href={resolve('/(app)/[budgetId=id]/accounts/[accountId=id]/settings', {
 					accountId: accountId(),
 					budgetId: budgetId()


### PR DESCRIPTION
Closes #343. Part of the consistency sweeps on map #316.

- Drop the `bg-muted/10 hover:bg-muted/20` overrides on the ghost icon triggers — budget settings pencil, budget members, and account settings gear (the latter two were identical audit misses); ghost's own neutral hover is the language (P7).
- Reassignment combobox highlight moves from `data-highlighted:bg-info/5 data-highlighted:text-info` to the standard neutral `data-highlighted:bg-muted/10` (matches `select-item.svelte`).
- Positive balances in the reassignment rows lose the `bg-success/20` chip per P1 — positive is plain ink, green stays target-progress only; the negative `bg-error/20 text-error` chip is unchanged.
- Changelog entry under Unreleased → Changed.

Verified: `npm run check`, lint, 659 unit tests, full Playwright suite green (isolated `E2E_PORT=3343`); both surfaces walked live in light and dark against the seeded demo fixture.