### PR TITLE
restyle: strip in-page shadows on tutorial card & API-token rows (#341)

### DIFF
--- a/src/lib/components/features/api-tokens/api-token-manager.svelte
+++ b/src/lib/components/features/api-tokens/api-token-manager.svelte
@@ -90,9 +90,7 @@
 {:else}
 	<ul aria-label={m.settings_api_tokens()} class="grid gap-2">
 		{#each tokens as token (token.id)}
-			<li
-				class="flex items-center gap-3 rounded-lg border border-muted/20 bg-surface-high p-3 shadow-xs"
-			>
+			<li class="flex items-center gap-3 rounded-lg border border-muted/20 bg-surface p-3">
 				<div class="min-w-0">
 					<div class="truncate font-medium">{token.name}</div>
 					<div class="text-sm text-muted">

--- a/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
@@ -61,7 +61,7 @@
 {#if accounts.length === 0 || categories.length === 0}
 	<section
 		aria-label={m.tutorial_card_title()}
-		class="flex flex-col gap-3 rounded-md border border-info/30 bg-info/5 p-4 shadow-xs shadow-info/15"
+		class="flex flex-col gap-3 rounded-md border border-info/30 bg-info/5 p-4"
 	>
 		<div class="flex flex-col gap-1">
 			<h2 class="text-lg font-semibold">{m.tutorial_card_title()}</h2>


### PR DESCRIPTION
Fixes the P2-flat findings from the design-language conformance audit (#323), resolving #341:

- `tutorial-card.svelte` — drop `shadow-xs shadow-info/15` from the in-page tinted panel; border + tint alone is the language.
- `api-token-manager.svelte` — drop `shadow-xs` from token list rows and move `bg-surface-high` → `bg-surface` (the overlay-only token).

Bar: `npm run check` 0 errors, lint clean, 659 unit tests pass, e2e green (3 known-flaky specs pass on re-run).

Part of #316.