### PR TITLE
restyle(typography): align in-page titles and stats mini-headers to tier spec (#345)

### DIFF
--- a/src/lib/components/features/account/account-archived-notice.svelte
+++ b/src/lib/components/features/account/account-archived-notice.svelte
@@ -20,7 +20,7 @@
 >
 	<ArchiveIcon class="size-10 text-muted" />
 
-	<h2 class="text-lg font-semibold">{m.account_archived_notice_title()}</h2>
+	<h2 class="font-semibold">{m.account_archived_notice_title()}</h2>
 
 	<p class="max-w-prose text-muted">{m.account_archived_notice_description()}</p>
 

--- a/src/lib/components/features/category/category-archived-notice.svelte
+++ b/src/lib/components/features/category/category-archived-notice.svelte
@@ -18,7 +18,7 @@
 >
 	<ArchiveIcon class="size-10 text-muted" />
 
-	<h2 class="text-lg font-semibold">{m.category_archived_notice_title()}</h2>
+	<h2 class="font-semibold">{m.category_archived_notice_title()}</h2>
 
 	<p class="max-w-prose text-muted">{m.category_archived_notice_description()}</p>
 

--- a/src/lib/components/features/category/category-stats.svelte
+++ b/src/lib/components/features/category/category-stats.svelte
@@ -65,7 +65,7 @@
 		<figcaption class="text-xs text-muted">{m.category_stats_sparkline_label()}</figcaption>
 	</figure>
 
-	<h3 class="text-xs font-medium tracking-wide text-muted uppercase">
+	<h3 class="text-xs font-medium tracking-wider text-muted uppercase">
 		{formatMonth({ month, options: { month: 'long', year: 'numeric' } })}
 	</h3>
 
@@ -116,7 +116,7 @@
 		{/if}
 	</dl>
 
-	<h3 class="mt-2 text-xs font-medium tracking-wide text-muted uppercase">
+	<h3 class="mt-2 text-xs font-medium tracking-wider text-muted uppercase">
 		{m.category_stats_group_all_time()}
 	</h3>
 

--- a/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/tutorial-card.svelte
@@ -64,7 +64,7 @@
 		class="flex flex-col gap-3 rounded-md border border-info/30 bg-info/5 p-4 shadow-xs shadow-info/15"
 	>
 		<div class="flex flex-col gap-1">
-			<h2 class="text-lg font-semibold">{m.tutorial_card_title()}</h2>
+			<h2 class="font-semibold">{m.tutorial_card_title()}</h2>
 			<p class="text-sm text-muted">{m.tutorial_card_description()}</p>
 		</div>
 


### PR DESCRIPTION
Closes #345.

Drops the modal-tier `text-lg` from the two archived-notice headings and the tutorial-card heading — in-page section titles sit at the base 16px `font-display font-semibold` (`font-display` comes from the `h1`–`h3` base-layer rule). Bumps the category-stats mini-headers from `tracking-wide` to the quiet-chrome `tracking-wider`; being `h3`s they already carry `font-display font-medium`, so no exemption was needed.

Verified: `npm run check` 0 errors, lint clean, 659 unit tests pass, full Playwright suite (114, tablet + desktop) green on an isolated `E2E_PORT`. Purely typographic — identical in both colour modes.