### PR TITLE
restyle(ui): compose shared hoverOutline const; drop dead kbd radius (#344)

### DIFF
--- a/src/lib/components/features/transaction/transaction-table-cols.ts
+++ b/src/lib/components/features/transaction/transaction-table-cols.ts
@@ -1,3 +1,5 @@
+import { hoverOutline } from '$lib/components/ui/focus-ring';
+
 // Read and edit modes share these tracks and the px-2 text inset so toggling
 // edit moves nothing. minmax(0,…) instead of bare 1fr: the edit controls'
 // min-content width would otherwise shift the columns between modes.
@@ -15,13 +17,11 @@ export const cellClass =
 // Read-mode click-to-edit trigger. Focus lifts above hover (z-20 vs z-10) so a
 // hovered neighbour's surface fill never paints over the focused cell's
 // outline where the ring overlaps the shared cell edge.
-export const cellTriggerClass =
-	'relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
+export const cellTriggerClass = `relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface ${hoverOutline} focus-visible:z-20`;
 
 // Edit-mode control: keeps the trigger's px-2 (pixel-lock) and mirrors its
 // hover/focus layering.
-export const editInputClass =
-	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
+export const editInputClass = `h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface ${hoverOutline} focus-visible:z-20`;
 
 // Open-row footer actions rest at size="xs" (24px) — too small to tap. Grown
 // to 44px in the nav-hidden band, back to xs geometry ≥7xl (pointer).

--- a/src/lib/components/ui/input-group/input-group-addon.svelte
+++ b/src/lib/components/ui/input-group/input-group-addon.svelte
@@ -2,7 +2,7 @@
 	import { cn, tv, type VariantProps } from 'tailwind-variants';
 
 	export const inputGroupAddonVariants = tv({
-		base: "text-muted h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-6 flex cursor-text items-center justify-center select-none",
+		base: "text-muted h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>svg:not([class*='size-'])]:size-6 flex cursor-text items-center justify-center select-none",
 		defaultVariants: {
 			align: 'inline-start'
 		},

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Month } from '$lib/utils/month';
 
+	import { hoverOutline } from '$lib/components/ui/focus-ring';
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import { PopoverForm } from '$lib/components/ui/popover-form';
 	import { m } from '$lib/paraglide/messages';
@@ -50,7 +51,8 @@ button during flight; the optimistic-override feedback model stays untouched. --
 		<button
 			{...props}
 			class={cn(
-				'h-full w-full cursor-pointer px-2 py-1 text-right font-currency hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50',
+				'h-full w-full cursor-pointer px-2 py-1 text-right font-currency hover:bg-surface',
+				hoverOutline,
 				open && 'hidden'
 			)}
 			aria-label={m.budget_monthly_table_header_amount()}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-popover.svelte
@@ -10,6 +10,7 @@
 	import { resolve } from '$app/paths';
 	import { CategoryStatsLedger } from '$lib/components/features/category';
 	import { Button } from '$lib/components/ui/button';
+	import { hoverOutline } from '$lib/components/ui/focus-ring';
 	import * as Popover from '$lib/components/ui/popover';
 	import { m } from '$lib/paraglide/messages';
 	import { getCategoryStats } from '$lib/remote-functions/category.remote';
@@ -59,7 +60,7 @@
 	     progress bar that overlays the cell's bottom edge. -->
 	<Popover.Trigger
 		bind:ref={triggerEl}
-		class="relative flex size-full cursor-pointer items-center px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10"
+		class={`relative flex size-full cursor-pointer items-center px-2 text-left hover:z-10 hover:bg-surface ${hoverOutline} focus-visible:z-10`}
 		onpointerenter={prefetch}
 		onfocus={prefetch}
 	>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -5,6 +5,7 @@
 	import type { Month } from '$lib/utils/month';
 
 	import { Button } from '$lib/components/ui/button';
+	import { hoverOutline } from '$lib/components/ui/focus-ring';
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import * as Popover from '$lib/components/ui/popover';
 	import { SelectCategory } from '$lib/components/ui/select-category';
@@ -86,7 +87,8 @@
 		aria-disabled={remaining === 0}
 		aria-label={m.reassignment_trigger_label({ name: categoryName })}
 		class={cn(
-			'flex size-full cursor-pointer items-center justify-end px-2 text-right font-currency font-medium hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-10',
+			'flex size-full cursor-pointer items-center justify-end px-2 text-right font-currency font-medium hover:z-10 hover:bg-surface focus-visible:z-10',
+			hoverOutline,
 			remaining < 0 && 'text-error',
 			remaining === 0 &&
 				'cursor-default font-normal text-muted hover:bg-transparent hover:outline-none'

--- a/src/routes/(app)/[budgetId=id]/[month=month]/unassigned-summary.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/unassigned-summary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { focusRing } from '$lib/components/ui/focus-ring';
+	import { focusRing, hoverOutline } from '$lib/components/ui/focus-ring';
 	import * as Popover from '$lib/components/ui/popover';
 	import { m } from '$lib/paraglide/messages';
 	import { getBudget, getUnassigned } from '$lib/remote-functions/budget.remote';
@@ -71,7 +71,8 @@
 <Popover.Root bind:open>
 	<Popover.Trigger
 		class={cn(
-			'ml-auto flex h-11 w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 @3xl/main:h-7 @3xl/main:w-auto @3xl/main:justify-start',
+			'ml-auto flex h-11 w-full cursor-pointer items-center justify-between gap-2 rounded-lg px-2 @3xl/main:h-7 @3xl/main:w-auto @3xl/main:justify-start',
+			hoverOutline,
 			focusRing,
 			unassigned === 0
 				? 'bg-muted/10 text-muted'


### PR DESCRIPTION
Closes #344. Part of the restyle sweeps map #316.

- Compose `hoverOutline` from `$lib/components/ui/focus-ring` at the five sites that restated the P7 hover-outline string verbatim: `cellTriggerClass`/`editInputClass` in `transaction-table-cols.ts`, plus `category-assignment-form`, `unassigned-summary`, `category-popover`, and `reassignment-popup` in the month route. (`calendar-day`/`date-picker` stay hand-rolled under their different variant prefixes, per the ticket.)
- Drop the dead `[&>kbd]:rounded-[calc(var(--radius)-5px)]` class from `input-group-addon.svelte` — bare `--radius` is undefined (tokens are `--radius-xs`…`xl`) and no `<kbd>` is rendered anywhere in `src`.

Bar: `npm run check` 0 errors, lint clean, unit 659/659, e2e 113/114 — the one failure is the pre-existing theme-toggle hydration flake (fails ~1-in-12 in isolation on an untouched page), filed off-map as #350.