### PR TITLE
restyle(overlay): align overlay chrome — date-picker, selects, FAB, assignment flyout (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and dependency bumps get no entry.
 
 ### Changed
 
+- Floating panels now share one consistent chrome: the date-picker calendar,
+  select menus, and the budget table's assignment error flyout wear the same
+  hairline outline and shadow as every other overlay, and the mobile
+  navigation button casts the standard overlay shadow instead of a heavier
+  one.
 - The error page dropped its tinted panel for a plain poster layout: the
   status code stands directly on the page as a large serif numeral, with the
   error message, log ID, and home link beneath it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and dependency bumps get no entry.
   hairline outline and shadow as every other overlay, and the mobile
   navigation button casts the standard overlay shadow instead of a heavier
   one.
+
+### Fixed
+
+- Clicking a date in the transaction table no longer shrinks the cell's text:
+  the date-picker trigger now keeps the same font size as the read-only cell
+  it replaces.
 - The error page dropped its tinted panel for a plain poster layout: the
   status code stands directly on the page as a large serif numeral, with the
   error message, log ID, and home link beneath it.

--- a/docs/dev/design-language.md
+++ b/docs/dev/design-language.md
@@ -96,6 +96,12 @@ Dialog, alert-dialog(-form), drawer, responsive-modal, popover
 - **Chrome: hairline + one shadow.** Panels carry `ring-1 ring-foreground/10`
   (the drawer its directional `border-muted/20` edge) plus `shadow-md` —
   the single overlay shadow step (P2: shadows are overlay-only).
+- **Anchored cell overlays are the exception.** Popovers that unfold a
+  ledger cell or header in place (`category-popover`, `reassignment-popup`,
+  `category-archive-popover` in the month view) wear
+  `rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30` with
+  anchor-matched width — a cell opening on the page's own surface token
+  with the flattest shadow, not a detached `bg-surface-high` layer.
 - **Scrim is a veil, not a dimmer:** `bg-background/75` +
   `supports-backdrop-filter:backdrop-blur-xs` on dialog/alert-dialog/drawer
   overlays — the page washes out into the theme's own background token

--- a/src/lib/components/features/transaction/transaction-table-cols.ts
+++ b/src/lib/components/features/transaction/transaction-table-cols.ts
@@ -19,9 +19,11 @@ export const cellTriggerClass =
 	'relative flex size-full cursor-pointer items-center justify-start px-2 text-left hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
 // Edit-mode control: keeps the trigger's px-2 (pixel-lock) and mirrors its
-// hover/focus layering.
+// hover/focus layering. text-base pins the read-mode (inherited) font size —
+// Button-based controls like DatePicker would otherwise drop to the Button
+// base's text-sm when the cell enters edit mode.
 export const editInputClass =
-	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
+	'h-full w-full justify-start rounded-none border-0 bg-transparent px-2 text-base shadow-none hover:z-10 hover:bg-surface hover:outline-1 hover:-outline-offset-1 hover:outline-foreground/50 focus-visible:z-20';
 
 // Open-row footer actions rest at size="xs" (24px) — too small to tap. Grown
 // to 44px in the nav-hidden band, back to xs geometry ≥7xl (pointer).

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -109,7 +109,7 @@
 			{placeholder}
 			{locale}
 			onValueChange={closeAndFocusTrigger}
-			class="rounded-xl border border-muted/20 bg-surface-high shadow"
+			class="rounded-xl bg-surface-high shadow-md ring-1 ring-foreground/10"
 		/>
 	</Popover.Content>
 </Popover.Root>

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -136,7 +136,7 @@
 		customAnchor={containerRef}
 		sideOffset={6}
 		class={cn(
-			'w-(--bits-combobox-anchor-width) overflow-hidden rounded-md bg-surface-high p-1 shadow-md ring-1 ring-muted/20',
+			'w-(--bits-combobox-anchor-width) overflow-hidden rounded-md bg-surface-high p-1 shadow-md ring-1 ring-foreground/10',
 			contentProps?.class
 		)}
 	>

--- a/src/lib/components/ui/select/select-content.svelte
+++ b/src/lib/components/ui/select/select-content.svelte
@@ -38,7 +38,7 @@
 						bind:this={ref}
 						{...props}
 						class={cn(
-							'relative isolate z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-md bg-surface-high shadow-md ring-1 ring-muted/20',
+							'relative isolate z-50 min-w-36 overflow-x-hidden overflow-y-auto rounded-md bg-surface-high shadow-md ring-1 ring-foreground/10',
 							className
 						)}
 						in:floatingIn={{ side: props['data-side'] }}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-assignment-form.svelte
@@ -81,7 +81,7 @@ button during flight; the optimistic-override feedback model stays untouched. --
 
 	{#snippet errors(error)}
 		<p
-			class="absolute inset-x-0 top-full z-10 bg-surface-high p-1 text-right text-xs text-error shadow-md"
+			class="absolute inset-x-0 top-full z-10 bg-surface-high p-1 text-right text-xs text-error shadow-md ring-1 ring-foreground/10"
 			role="alert"
 		>
 			{error.message}

--- a/src/routes/(app)/navigation-mobile.svelte
+++ b/src/routes/(app)/navigation-mobile.svelte
@@ -52,7 +52,7 @@
 			<!-- Bottom-right so it never covers the page heading or its action
 			     buttons; z-40 keeps it underneath every drawer/dialog (z-50). -->
 			<div
-				class="fixed right-4 bottom-4 z-40 flex rounded-xl border border-muted/10 bg-foreground p-1 text-background shadow-lg @7xl/main:hidden"
+				class="fixed right-4 bottom-4 z-40 flex rounded-xl border border-muted/10 bg-foreground p-1 text-background shadow-md @7xl/main:hidden"
 			>
 				<Button {...props} size="icon" variant="ghost" class="size-11">
 					<span class="sr-only">Toggle Navigation</span>


### PR DESCRIPTION
Closes #342. Part of map #316.

## Fixes

- `date-picker.svelte` — the Calendar panel (raw bits-ui popover, so its class is the panel chrome) drops `border border-muted/20` + bare `shadow` for the canonical `shadow-md ring-1 ring-foreground/10`.
- `select-content.svelte`, `select-category.svelte` — hairline `ring-muted/20` → `ring-foreground/10`.
- `navigation-mobile.svelte` — the floating nav FAB drops `shadow-lg` to `shadow-md`, the single overlay shadow step.
- `category-assignment-form.svelte` — the error flyout gains `ring-1 ring-foreground/10`.

## Folded-in decision

The three month-view anchored popovers keep their `rounded-xs bg-surface p-0 shadow-sm ring-1 ring-muted/30` chrome; `docs/dev/design-language.md` now codifies it as the anchored-cell-overlay exception in the Overlay family. They are the doc's named reference implementation, and #334 locked exactly this chrome via HITL prototype (shipped in #337) — the flat anchor-width chrome reads as a cell unfolding in place, not a detached `bg-surface-high` layer.

## Verification

`npm run check`, lint, 659 unit tests, e2e 114/114 (isolated port via `E2E_PORT`), plus a scripted light/dark browser walk over the date-picker popover, select surfaces, and the FAB. CHANGELOG entry added.