### PR TITLE
restyle(a11y): lift both-modes low-contrast text to AA (#355)

### DIFF
--- a/src/lib/components/features/category/category-stats-ledger.svelte
+++ b/src/lib/components/features/category/category-stats-ledger.svelte
@@ -53,7 +53,7 @@
 				})}
 			</dd>
 		</div>
-		<div class="font-currency text-xs text-foreground/60">
+		<div class="font-currency text-xs text-muted">
 			{m.category_stats_delta_breakdown({
 				currentSpend: formatMoney({ currency, money: asMoney(stats.monthSpend) }),
 				previousSpend: formatMoney({ currency, money: asMoney(stats.previousMonthSpend) })

--- a/src/lib/components/features/category/category-stats.svelte
+++ b/src/lib/components/features/category/category-stats.svelte
@@ -94,7 +94,7 @@
 					})}
 				</dd>
 			</div>
-			<div class="font-currency text-xs text-foreground/60">
+			<div class="font-currency text-xs text-muted">
 				{m.category_stats_delta_breakdown({
 					currentSpend: formatMoney({ currency, money: asMoney(stats.monthSpend) }),
 					previousSpend: formatMoney({ currency, money: asMoney(stats.previousMonthSpend) })

--- a/src/lib/components/features/transaction/transaction-table-row.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row.svelte
@@ -175,7 +175,7 @@
 					{transaction.categoryName}
 				{:else}
 					<span
-						class="inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm bg-muted/10 px-1 py-0 text-sm text-muted"
+						class="inline-flex max-w-full min-w-0 items-center gap-1 rounded-sm bg-muted/5 px-1 py-0 text-sm text-muted"
 					>
 						<EmptyIcon class="size-3.5 shrink-0" aria-hidden="true" />
 						<span class="truncate">{m.transaction_table_cell_category_empty()}</span>


### PR DESCRIPTION
Resolves #355 (map #316, graduated from the light/dark/a11y audit #324).

Two opacity-composite text patterns failed AA in both modes:

- **Stats delta fine print** (`category-stats.svelte`, `category-stats-ledger.svelte`): the 12px "€X vs. €Y" line was `text-foreground/60` — 3.43–3.49 light / 4.05–4.17 dark. Now `text-muted`: 5.17+ light / 4.80+ dark on every surface it renders on (category detail page, budget-table category popover).
- **No-Category chip** (`transaction-table-row.svelte`): `text-muted` on `bg-muted/10` was a marginal light-mode fail. Tint drops to `bg-muted/5`; worst composite (chip over hovered row) now 4.82 light / 5.31 dark.

Considered and left: the unassigned-summary `bg-muted/10 text-muted` trigger (audit-scanned live, passes) and `marker:text-muted/50` bullets (decorative, per ticket).

Bar: `npm run check` 0 errors, lint clean, 659 unit tests, 118 Playwright incl. the both-themes axe gate.