### PR TITLE
restyle(a11y): repair ARIA structure & control wiring (#356)

### DIFF
--- a/src/lib/components/features/category/category-stats-ledger.svelte
+++ b/src/lib/components/features/category/category-stats-ledger.svelte
@@ -36,51 +36,51 @@
 		</dd>
 	</div>
 
-	<div class="{rowChrome} flex flex-col gap-0.5">
-		<div class="flex items-baseline justify-between">
-			<dt class="text-sm text-muted">
-				{m.category_stats_delta({
-					month: formatMonth({
-						month: addMonths(month, -1),
-						options: { month: 'short', year: 'numeric' }
-					})
-				})}
-			</dt>
-			<dd class="font-currency">
-				{stats.spendDelta > 0 ? '+' : ''}{formatMoney({
-					currency,
-					money: asMoney(stats.spendDelta)
-				})}
-			</dd>
-		</div>
-		<div class="font-currency text-xs text-muted">
+	<!-- Grid, not nested row divs: a dl group allows only the one div wrapper
+	     around its dt/dd, so the breakdown line is a second dd spanning both
+	     columns. -->
+	<div class="{rowChrome} grid grid-cols-[auto_auto] items-baseline justify-between gap-y-0.5">
+		<dt class="text-sm text-muted">
+			{m.category_stats_delta({
+				month: formatMonth({
+					month: addMonths(month, -1),
+					options: { month: 'short', year: 'numeric' }
+				})
+			})}
+		</dt>
+		<dd class="font-currency">
+			{stats.spendDelta > 0 ? '+' : ''}{formatMoney({
+				currency,
+				money: asMoney(stats.spendDelta)
+			})}
+		</dd>
+		<dd class="col-span-2 font-currency text-xs text-muted">
 			{m.category_stats_delta_breakdown({
 				currentSpend: formatMoney({ currency, money: asMoney(stats.monthSpend) }),
 				previousSpend: formatMoney({ currency, money: asMoney(stats.previousMonthSpend) })
 			})}
-		</div>
+		</dd>
 	</div>
 
 	{#if stats.currentTargetPercentage !== null && stats.targetBalance !== null}
 		{@const clamped = clamp(stats.currentTargetPercentage, 0, 100)}
 		<!-- Saved-of-target amounts above the bar: the glance shows how much is
-		     set aside, not just a bare percentage. -->
-		<div class="{rowChrome} flex flex-col gap-1">
-			<div class="flex items-baseline justify-between">
-				<dt class="text-sm text-muted">{m.category_stats_target_percentage()}</dt>
-				<dd class="font-currency text-sm">
-					{m.category_stats_target_amount({
-						saved: formatMoney({ currency, money: asMoney(stats.currentTargetSaved) }),
-						target: formatMoney({ currency, money: asMoney(stats.targetBalance) })
-					})}
-				</dd>
-			</div>
-			<div class="flex items-center gap-2">
+		     set aside, not just a bare percentage. Grid for the same dl-wrapper
+		     reason as the delta row; the bar is a second dd spanning both columns. -->
+		<div class="{rowChrome} grid grid-cols-[auto_auto] items-baseline justify-between gap-y-1">
+			<dt class="text-sm text-muted">{m.category_stats_target_percentage()}</dt>
+			<dd class="font-currency text-sm">
+				{m.category_stats_target_amount({
+					saved: formatMoney({ currency, money: asMoney(stats.currentTargetSaved) }),
+					target: formatMoney({ currency, money: asMoney(stats.targetBalance) })
+				})}
+			</dd>
+			<dd class="col-span-2 flex items-center gap-2">
 				<div class="h-1.5 flex-1 overflow-hidden rounded-full bg-muted/20">
 					<div class="h-full bg-success" style="width: {clamped}%"></div>
 				</div>
 				<span class="font-currency text-xs text-muted">{stats.currentTargetPercentage}%</span>
-			</div>
+			</dd>
 		</div>
 	{/if}
 </dl>

--- a/src/lib/components/features/category/category-stats.svelte
+++ b/src/lib/components/features/category/category-stats.svelte
@@ -77,29 +77,30 @@
 				: formatMoney({ currency, money: asMoney(stats.trailingAverageSpend) })
 		)}
 
-		<div class="{rowChrome} flex flex-col gap-0.5">
-			<div class="flex items-baseline justify-between">
-				<dt class="text-sm text-muted">
-					{m.category_stats_delta({
-						month: formatMonth({
-							month: addMonths(month, -1),
-							options: { month: 'short', year: 'numeric' }
-						})
-					})}
-				</dt>
-				<dd class="font-currency">
-					{stats.spendDelta > 0 ? '+' : ''}{formatMoney({
-						currency,
-						money: asMoney(stats.spendDelta)
-					})}
-				</dd>
-			</div>
-			<div class="font-currency text-xs text-muted">
+		<!-- Grid, not nested row divs: a dl group allows only the one div wrapper
+		     around its dt/dd, so the breakdown line is a second dd spanning both
+		     columns. -->
+		<div class="{rowChrome} grid grid-cols-[auto_auto] items-baseline justify-between gap-y-0.5">
+			<dt class="text-sm text-muted">
+				{m.category_stats_delta({
+					month: formatMonth({
+						month: addMonths(month, -1),
+						options: { month: 'short', year: 'numeric' }
+					})
+				})}
+			</dt>
+			<dd class="font-currency">
+				{stats.spendDelta > 0 ? '+' : ''}{formatMoney({
+					currency,
+					money: asMoney(stats.spendDelta)
+				})}
+			</dd>
+			<dd class="col-span-2 font-currency text-xs text-muted">
 				{m.category_stats_delta_breakdown({
 					currentSpend: formatMoney({ currency, money: asMoney(stats.monthSpend) }),
 					previousSpend: formatMoney({ currency, money: asMoney(stats.previousMonthSpend) })
 				})}
-			</div>
+			</dd>
 		</div>
 
 		{#if stats.currentTargetPercentage !== null}

--- a/src/lib/components/ui/date-picker/date-picker.svelte
+++ b/src/lib/components/ui/date-picker/date-picker.svelte
@@ -61,6 +61,19 @@
 
 	const displayValue = $derived(value ? displayFormatter(value) : label);
 
+	// The trigger is a role="combobox" button, which ARIA requires to carry
+	// aria-controls while expanded. bits-ui derives that from the content
+	// node's id, but its id prop never reaches the floating element (every
+	// popper layer destructures it away) — so stamp the id on the node and
+	// wire the trigger by hand.
+	const uid = $props.id();
+	const contentId = `${uid}-content`;
+	let contentRef = $state<HTMLElement | null>(null);
+
+	$effect(() => {
+		if (contentRef) contentRef.id = contentId;
+	});
+
 	function closeAndFocusTrigger() {
 		open = false;
 		tick().then(() => {
@@ -83,6 +96,7 @@
 					className
 				)}
 				role="combobox"
+				aria-controls={open ? contentId : undefined}
 				aria-expanded={open}
 				aria-invalid={ariaInvalid}
 				aria-label={value ? displayFormatter(value) : label}
@@ -93,6 +107,7 @@
 	</Popover.Trigger>
 
 	<Popover.Content
+		bind:ref={contentRef}
 		class="w-full p-0"
 		sideOffset={4}
 		onkeydown={(ev) => {

--- a/src/lib/components/ui/date-picker/date-picker.svelte.test.ts
+++ b/src/lib/components/ui/date-picker/date-picker.svelte.test.ts
@@ -51,3 +51,20 @@ describe('DatePicker — aria-invalid contract', () => {
 		expect(button).not.toHaveAttribute('aria-invalid');
 	});
 });
+
+describe('DatePicker — combobox wiring contract (#356)', () => {
+	it('links the expanded trigger to the calendar popover via aria-controls', async () => {
+		const { button } = renderDatePicker({ open: true });
+
+		await vi.waitFor(() => {
+			expect(button).toHaveAttribute('aria-controls');
+		});
+		const contentId = button.getAttribute('aria-controls')!;
+		expect(document.getElementById(contentId)).not.toBeNull();
+	});
+
+	it('does not set aria-controls while collapsed', () => {
+		const { button } = renderDatePicker();
+		expect(button).not.toHaveAttribute('aria-controls');
+	});
+});

--- a/src/lib/components/ui/input-password/input-password.svelte
+++ b/src/lib/components/ui/input-password/input-password.svelte
@@ -33,12 +33,14 @@
 			onclick={() => (type = type === 'password' ? 'text' : 'password')}
 			class="size-6 p-0 text-foreground [&_svg:not([class*='size-'])]:size-4"
 		>
+			<!-- The label names the action, not the state: while masked, pressing
+			     shows the value. -->
 			{#if type === 'password'}
 				<EyeClosedIcon />
-				<span class="sr-only">{m.login_hide_password()}</span>
+				<span class="sr-only">{m.login_show_password()}</span>
 			{:else}
 				<EyeIcon />
-				<span class="sr-only">{m.login_show_password()}</span>
+				<span class="sr-only">{m.login_hide_password()}</span>
 			{/if}
 		</InputGroup.Button>
 	</InputGroup.Addon>

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -53,6 +53,18 @@
 
 	let searchValue = $state('');
 	let containerRef = $state<HTMLDivElement | null>(null);
+	let contentRef = $state<HTMLElement | null>(null);
+
+	// bits-ui does not link the combobox input to its listbox, so the input
+	// fails ARIA's required aria-controls while expanded — wire it by hand.
+	const uid = $props.id();
+	const listboxId = `${uid}-listbox`;
+
+	// The id prop never reaches the floating listbox element (every popper
+	// layer destructures it away), so stamp it on the node itself.
+	$effect(() => {
+		if (contentRef) contentRef.id = listboxId;
+	});
 
 	const items = $derived(categories.map((c) => ({ label: c.name, value: c.id })));
 
@@ -117,6 +129,7 @@
 		<Combobox.Input
 			{...inputProps}
 			bind:ref={inputRef}
+			aria-controls={open ? listboxId : undefined}
 			aria-invalid={ariaInvalid}
 			aria-label={ariaLabel}
 			class="h-full min-w-0 flex-1 border-0 bg-transparent px-2 py-1 outline-none placeholder:text-muted focus-visible:ring-0"
@@ -133,6 +146,8 @@
 
 	<Combobox.Content
 		{...contentProps}
+		bind:ref={contentRef}
+		aria-label={ariaLabel ?? placeholder}
 		customAnchor={containerRef}
 		sideOffset={6}
 		class={cn(

--- a/src/lib/components/ui/select-category/select-category.svelte.test.ts
+++ b/src/lib/components/ui/select-category/select-category.svelte.test.ts
@@ -234,3 +234,29 @@ describe('SelectCategory — aria-invalid contract', () => {
 		expect(input).not.toHaveAttribute('aria-invalid');
 	});
 });
+
+describe('SelectCategory — listbox wiring contract (#356)', () => {
+	it('links the expanded input to the named listbox via aria-controls', async () => {
+		renderSelectCategory({ open: true });
+		await vi.waitFor(() => {
+			expect(screen.getByRole('listbox', { name: 'Category' })).toBeInTheDocument();
+		});
+
+		const input = screen.getByRole<HTMLInputElement>('combobox', { name: 'Category' });
+		const listbox = screen.getByRole('listbox', { name: 'Category' });
+		expect(listbox.id).not.toBe('');
+		expect(input).toHaveAttribute('aria-controls', listbox.id);
+	});
+
+	it('names the listbox from the placeholder when no ariaLabel is given', async () => {
+		render(SelectCategory, { props: { categories, open: true } });
+		await vi.waitFor(() => {
+			expect(screen.getByRole('listbox', { name: 'Search for category...' })).toBeInTheDocument();
+		});
+	});
+
+	it('does not set aria-controls while collapsed', () => {
+		const { input } = renderSelectCategory();
+		expect(input).not.toHaveAttribute('aria-controls');
+	});
+});

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -95,6 +95,17 @@
 		</EmptyState>
 	{/if}
 {:else}
+	<!-- The desktop column header carries create + archived, but it is hidden
+	     below @3xl — surface the same actions above the cards. Outside the
+	     role="table" element: a bare toolbar is not valid table content. -->
+	<div class="mb-2 flex flex-wrap gap-0.5 @3xl/main:hidden">
+		<Button href={createHref} class="h-11">
+			<PlusIcon class="size-6" />
+			{m.category_create_button()}
+		</Button>
+		<CategoryArchiveDrawer />
+	</div>
+
 	<div role="table">
 		<div role="rowgroup" class="hidden @3xl/main:block">
 			<div role="row" class="flex border-b border-muted/30 bg-muted/3">
@@ -127,16 +138,6 @@
 					<span class="sr-only">{m.budget_monthly_table_header_actions()}</span>
 				</BudgetTableHeader>
 			</div>
-		</div>
-
-		<!-- The desktop column header carries create + archived, but it is hidden
-		     below @3xl — surface the same actions as a row above the cards. -->
-		<div class="mb-2 flex flex-wrap gap-0.5 @3xl/main:hidden">
-			<Button href={createHref} class="h-11">
-				<PlusIcon class="size-6" />
-				{m.category_create_button()}
-			</Button>
-			<CategoryArchiveDrawer />
 		</div>
 
 		<div role="rowgroup" class="grid gap-2 @3xl/main:gap-0" {@attach categorySortable.attach}>

--- a/tests/playwright/a11y.spec.ts
+++ b/tests/playwright/a11y.spec.ts
@@ -259,6 +259,64 @@ for (const theme of THEMES) {
 	});
 }
 
+/**
+ * ARIA structure & control wiring (#356) is mode-independent, so these states
+ * scan once outside the theme loop. They cover what the themed flows above
+ * never reach: the mobile table markup, the stats definition lists, and the
+ * expanded combobox / date-picker popups.
+ */
+test.describe('ARIA structure', () => {
+	test('Month view on a mobile viewport is axe-clean', async ({ page, pages }) => {
+		const { budgetName } = await seedBudget(pages);
+		await pages.budget.goto(budgetName);
+
+		await page.setViewportSize({ height: 720, width: 390 });
+		// The mobile toolbar replaces the desktop column header below @3xl; it
+		// must sit outside the role="table" element to be valid table content.
+		await expect(page.getByRole('link', { name: 'Create Category' })).toBeVisible();
+		await expectAxeClean(page);
+	});
+
+	test('Category stats popover and detail page are axe-clean', async ({ page, pages }) => {
+		const { budgetName, categoryName } = await seedBudget(pages);
+		await pages.budget.goto(budgetName);
+
+		// The monthly-stats popover: its ledger is a <dl> with grouped rows.
+		await pages.category.openPopover(categoryName);
+		await expect(pages.category.popover().getByText('Average Monthly Spend')).toBeVisible();
+		await expectAxeClean(page);
+
+		// The detail page repeats the same dl rows plus the all-time group.
+		await pages.category.popover().getByRole('link', { name: 'Settings' }).click();
+		await expect(page.getByRole('heading', { name: categoryName })).toBeVisible();
+		await expectAxeClean(page);
+	});
+
+	test('Expanded category combobox and date picker are axe-clean', async ({ page, pages }) => {
+		const { accountName } = await seedBudget(pages);
+		await pages.account.goto(accountName);
+
+		await page.getByRole('button', { name: 'New Transaction' }).click();
+		const createRow = page.getByRole('row', { name: 'New Transaction' });
+		await expect(createRow).toBeVisible();
+
+		// Expanded combobox: the listbox needs an accessible name and the input
+		// needs aria-controls — neither fires while collapsed.
+		await createRow.getByRole('button', { name: 'Open category dropdown' }).click();
+		await expect(page.getByRole('listbox', { name: 'Category' })).toBeVisible();
+		await expectAxeClean(page);
+		await page.keyboard.press('Escape');
+
+		// Expanded date picker: the trigger is a role="combobox" button that
+		// needs aria-controls while open. Its accessible name is the selected
+		// date, so target the row's only combobox *button* (the category
+		// combobox is an input).
+		await createRow.locator('button[role="combobox"]').click();
+		await expect(page.getByRole('grid')).toBeVisible();
+		await expectAxeClean(page);
+	});
+});
+
 /** Tabs forward until the given locator holds focus, or throws after `max` hops. */
 async function tabToFocus(page: Page, target: Locator, max = 10) {
 	for (let i = 0; i < max; i++) {


### PR DESCRIPTION
Resolves #356 — the four mode-independent structural/labelling defects from the light/dark/a11y audit (#324). Part of #316.

## Changes

1. **Mobile toolbar out of `role="table"`** — the Create Category + archived strip on the month view was a direct child of the `role="table"` element (axe `aria-required-children`, serious, every mobile viewport). It now sits above the table element; visual order unchanged.
2. **Stats `dl` group nesting** — the delta rows (detail page + popover ledger) and the ledger's target row nested `dt`/`dd` two `<div>` levels below the `<dl>` (axe `definition-list` + `dlitem`, serious). Each group now keeps the single allowed div wrapper as a two-column grid; the fine-print breakdown and the progress bar become a second `dd` spanning both columns. Same rendering, valid grouping. (The ledger's target row had the identical defect beyond the ticket's cited lines — fixed alongside.)
3. **Combobox / date-picker control wiring** — the `Combobox.Content` listbox had no accessible name (axe `aria-input-field-name`) and the expanded combobox input and date-picker trigger lacked `aria-controls` (axe `aria-required-attr`). Root cause for the missing ids: bits-ui destructures the `id` prop away at every popper layer, so it never reaches the floating element — the id is now stamped on the node via `bind:ref`, and `aria-controls` is set while expanded. The listbox is named from `ariaLabel`, falling back to the placeholder. Covers the category selects, the transfer counterpart-account combobox, and every date-picker.
4. **Password toggle labels** — the visibility toggle announced the state ("Hide password" while masked); it now announces the action.

## Verification

- New axe e2e scans (`ARIA structure` block, outside the theme loop since these are mode-independent): mobile month view, stats popover + detail page, expanded combobox + date-picker — states the themed flows never reached. All failed before the fixes, all pass now.
- New unit wiring contracts for `SelectCategory` and `DatePicker` (`aria-controls` ↔ listbox/popover id, listbox naming).
- `npm run check`, lint, unit (664), e2e (124) all green.