### PR TITLE
restyle(overlay): restore explicit closes on non-dismissible drawers (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- The budget members drawer on small screens can be closed again: its Close
+  button and the Escape key work while tapping outside stays disabled, so the
+  drawer no longer traps you until a page reload.
 - Clicking a date in the transaction table no longer shrinks the cell's text:
   the date-picker trigger now keeps the same font size as the read-only cell
   it replaces.

--- a/src/lib/components/ui/responsive-modal/context.ts
+++ b/src/lib/components/ui/responsive-modal/context.ts
@@ -7,6 +7,12 @@ const CONTEXT_KEY = Symbol('responsive-modal');
 
 export type ResponsiveModalContext = {
 	/**
+	 * Closes the modal through the bound `open` state — the only close path
+	 * vaul honours when `dismissible` is `false` (its own Close and Escape
+	 * handling are no-ops then).
+	 */
+	close(): void;
+	/**
 	 * When `false`, interacting outside the modal does not close it — the Dialog
 	 * variant ignores outside clicks, the Drawer variant is non-dismissible.
 	 */

--- a/src/lib/components/ui/responsive-modal/responsive-modal-close.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-close.svelte
@@ -25,7 +25,9 @@
 		{@render children?.()}
 	</Dialog.Close>
 {:else}
-	<Drawer.Close {child} class={className}>
+	<!-- Non-dismissible drawers swallow vaul's built-in close, so close through
+	the bound open state instead. -->
+	<Drawer.Close {child} class={className} onclick={ctx.dismissible ? undefined : () => ctx.close()}>
 		{@render children?.()}
 	</Drawer.Close>
 {/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal-content.svelte
@@ -30,7 +30,12 @@
 		{@render children()}
 	</Dialog.Content>
 {:else}
-	<Drawer.Content class={cn('px-6 pb-6', className)}>
+	<!-- Escape parity with the Dialog variant, which stays escapable when
+	non-dismissible; vaul swallows Escape entirely under dismissible={false}. -->
+	<Drawer.Content
+		class={cn('px-6 pb-6', className)}
+		onEscapeKeydown={ctx.dismissible ? undefined : () => ctx.close()}
+	>
 		{@render children()}
 	</Drawer.Content>
 {/if}

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -30,6 +30,9 @@
 	const media = new MediaQuery(DESKTOP_QUERY, true);
 
 	setResponsiveModalContext({
+		close() {
+			open = false;
+		},
 		get dismissible() {
 			return dismissible;
 		},

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import Fixture from './responsive-modal.test-fixture.svelte';
+
+// jsdom has no matchMedia; report "below the desktop breakpoint" so the shell
+// renders its Drawer variant — the branch where vaul's dismissible={false}
+// used to swallow every close path.
+beforeAll(() => {
+	window.matchMedia = (query: string) =>
+		({
+			addEventListener: () => {},
+			matches: false,
+			media: query,
+			removeEventListener: () => {}
+		}) as unknown as MediaQueryList;
+});
+
+// Opening the modal makes the primitive lock body scroll; unmounting schedules a
+// delayed cleanup that touches `document.body`. Unmount eagerly and wait past
+// the delay so the cleanup runs while document is alive.
+afterEach(async () => {
+	cleanup();
+	await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+describe('ResponsiveModal drawer variant — dismissible={false}', () => {
+	it('closes via the Close button', async () => {
+		render(Fixture, { props: { dismissible: false, open: true } });
+
+		const closeButton = await screen.findByRole('button', { name: 'Close' });
+		await fireEvent.click(closeButton);
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+
+	it('closes via Escape, matching the Dialog variant', async () => {
+		render(Fixture, { props: { dismissible: false, open: true } });
+
+		const drawer = await screen.findByRole('dialog');
+		await fireEvent.keyDown(drawer, { key: 'Escape' });
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+});
+
+describe('ResponsiveModal drawer variant — dismissible (default)', () => {
+	it('still closes via the Close button', async () => {
+		render(Fixture, { props: { open: true } });
+
+		const closeButton = await screen.findByRole('button', { name: 'Close' });
+		await fireEvent.click(closeButton);
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+});

--- a/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import * as ResponsiveModal from './index';
+
+	let {
+		dismissible = true,
+		open = $bindable(false)
+	}: {
+		dismissible?: boolean;
+		open?: boolean;
+	} = $props();
+</script>
+
+<ResponsiveModal.Root {dismissible} bind:open>
+	<ResponsiveModal.Content>
+		<ResponsiveModal.Header>
+			<ResponsiveModal.Title>Manage users</ResponsiveModal.Title>
+			<ResponsiveModal.Description>People with access.</ResponsiveModal.Description>
+		</ResponsiveModal.Header>
+
+		<ResponsiveModal.Footer>
+			<ResponsiveModal.Close>Close</ResponsiveModal.Close>
+		</ResponsiveModal.Footer>
+	</ResponsiveModal.Content>
+</ResponsiveModal.Root>


### PR DESCRIPTION
Closes #360. Part of the restyle sweeps map #316.

## Defect

`ResponsiveModal.Root dismissible={false}` maps to vaul's `dismissible` on the drawer branch, and vaul swallows **every** dialog-driven close under it — `Drawer.Close`, Escape, scrim, drag alike (`onDialogOpenChange` early-returns). The budget-users drawer's only exit is a `ResponsiveModal.Close` button, so at <640px it could not be closed at all — the user had to reload the page.

## Fix

Only a controlled `open` change gets through vaul's guard, so the shell now exposes `close()` on its context (sets the bound `open` to `false`) and wires it up on the drawer branch when `dismissible={false}`:

- `ResponsiveModal.Close` adds an `onclick` that closes through the context (vaul's built-in close is a no-op there).
- `ResponsiveModal.Content` passes `onEscapeKeydown` through to bits-ui, restoring Escape parity with the Dialog variant (which stays escapable under `interactOutsideBehavior="ignore"`).

Outside/scrim/swipe dismissal stays disabled — the intended semantics. Dismissible drawers are untouched (both handlers gate on `!dismissible`).

## Tests

New `responsive-modal.svelte.test.ts` pins the regression: Close and Escape close the drawer variant under `dismissible={false}`, and the default dismissible path still works. All three fail without the component fix.

## Verification

- `npm run check`, lint, unit (667), e2e (124) green.
- Verified live at 375px: Close button closes, Escape closes, outside tap does **not** dismiss; Budget Settings (default dismissible drawer) still dismisses on outside tap.
- Verified live at 1280px: Dialog variant closes as before.