### PR TITLE
restyle(density): finish ≤1180 touch density — in-table stragglers (#361)

### DIFF
--- a/src/lib/components/features/budget-settings/account-restore-row.svelte
+++ b/src/lib/components/features/budget-settings/account-restore-row.svelte
@@ -14,11 +14,13 @@
 <span class="line-clamp-1">{account.name}</span>
 <form {...submit.attrs}>
 	<input {...form.fields.accountId.as('hidden', account.id)} />
+	<!-- The link treatment is locked (#334) — on touch the tap area grows
+	     invisibly instead (padding cancelled by negative margin). -->
 	<Button
 		type="submit"
 		size="xs"
 		variant="link"
-		class="px-0"
+		class="px-0 pointer-coarse:-mx-2 pointer-coarse:min-h-11 pointer-coarse:px-2"
 		loading={submit.pending}
 		{@attach submit.anchor}
 	>

--- a/src/lib/components/features/budget-settings/account-restore-row.svelte
+++ b/src/lib/components/features/budget-settings/account-restore-row.svelte
@@ -14,8 +14,6 @@
 <span class="line-clamp-1">{account.name}</span>
 <form {...submit.attrs}>
 	<input {...form.fields.accountId.as('hidden', account.id)} />
-	<!-- The link treatment is locked (#334) — on touch the tap area grows
-	     invisibly instead (padding cancelled by negative margin). -->
 	<Button
 		type="submit"
 		size="xs"

--- a/src/lib/components/features/transaction/transaction-table-header.svelte
+++ b/src/lib/components/features/transaction/transaction-table-header.svelte
@@ -38,9 +38,6 @@
 {/snippet}
 
 <div role="rowgroup" class={className}>
-	<!-- Touch band (#297): sort buttons grow to 44px targets in the nav-hidden
-	     band (@3xl→@max-7xl), the row grows with them; ≥7xl (pointer) both snap
-	     back to the resting geometry. -->
 	<div role="row" class={cn(colsClass, 'mb-1 grid h-8 items-center @3xl/main:h-11 @7xl/main:h-8')}>
 		<div
 			role="columnheader"

--- a/src/lib/components/features/transaction/transaction-table-header.svelte
+++ b/src/lib/components/features/transaction/transaction-table-header.svelte
@@ -22,6 +22,9 @@
 		if (sort.column !== column) return 'none';
 		return sort.direction === 'asc' ? 'ascending' : 'descending';
 	}
+
+	const sortButtonClass =
+		'inline-flex items-center justify-center @3xl/main:size-11 @7xl/main:size-auto';
 </script>
 
 {#snippet sortIcon(column: SortColumn)}
@@ -35,7 +38,10 @@
 {/snippet}
 
 <div role="rowgroup" class={className}>
-	<div role="row" class={cn(colsClass, 'mb-1 grid h-8 items-center')}>
+	<!-- Touch band (#297): sort buttons grow to 44px targets in the nav-hidden
+	     band (@3xl→@max-7xl), the row grows with them; ≥7xl (pointer) both snap
+	     back to the resting geometry. -->
+	<div role="row" class={cn(colsClass, 'mb-1 grid h-8 items-center @3xl/main:h-11 @7xl/main:h-8')}>
 		<div
 			role="columnheader"
 			aria-sort={ariaSort('category')}
@@ -43,6 +49,7 @@
 		>
 			{m.transactions_table_header_category()}
 			<button
+				class={sortButtonClass}
 				onclick={() => onToggle('category')}
 				aria-label={m.transactions_table_sort_category()}
 			>
@@ -60,7 +67,11 @@
 			aria-sort={ariaSort('date')}
 			class="flex items-center justify-end gap-1 px-2 font-display text-xs font-medium tracking-wider text-muted uppercase"
 		>
-			<button onclick={() => onToggle('date')} aria-label={m.transactions_table_sort_date()}>
+			<button
+				class={sortButtonClass}
+				onclick={() => onToggle('date')}
+				aria-label={m.transactions_table_sort_date()}
+			>
 				{@render sortIcon('date')}
 			</button>
 			{m.transactions_table_header_date()}
@@ -70,7 +81,11 @@
 			aria-sort={ariaSort('amount')}
 			class="flex items-center justify-end gap-1 px-2 font-display text-xs font-medium tracking-wider text-muted uppercase"
 		>
-			<button onclick={() => onToggle('amount')} aria-label={m.transactions_table_sort_amount()}>
+			<button
+				class={sortButtonClass}
+				onclick={() => onToggle('amount')}
+				aria-label={m.transactions_table_sort_amount()}
+			>
 				{@render sortIcon('amount')}
 			</button>
 			{m.transactions_table_header_amount()}
@@ -81,6 +96,7 @@
 			class="flex items-center justify-end gap-1 px-2 font-display text-xs font-medium tracking-wider text-muted uppercase"
 		>
 			<button
+				class={sortButtonClass}
 				onclick={() => onToggle('validated')}
 				aria-label={m.transactions_table_sort_validated()}
 			>

--- a/src/lib/components/features/transaction/transaction-validate-toggle.svelte
+++ b/src/lib/components/features/transaction/transaction-validate-toggle.svelte
@@ -48,7 +48,10 @@
 		size="icon-lg"
 		variant="ghost"
 		disabled={submit.pending}
-		class={cn('m-auto size-8 rounded-xs hover:bg-transparent', className)}
+		class={cn(
+			'm-auto size-8 rounded-xs hover:bg-transparent @3xl/main:size-11 @7xl/main:size-8',
+			className
+		)}
 		aria-label={m.transactions_table_toggle_validated()}
 		{@attach submit.anchor}
 	>

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -54,7 +54,10 @@ get along, so we shut typescript up by casting `value` to `never`.
 	{weekdayFormat}
 	{disableDaysOutsideMonth}
 	class={cn(
-		'group/calendar bg-surface p-3 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+		// Touch density: the calendar renders in portaled popovers/drawers, outside
+		// @container/main, so pointer-coarse is the touch signal — every
+		// --cell-size consumer (day cells, nav, caption) grows to 44px together.
+		'group/calendar bg-surface p-3 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent pointer-coarse:[--cell-size:--spacing(11)]',
 		className
 	)}
 	{locale}

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -54,9 +54,8 @@ get along, so we shut typescript up by casting `value` to `never`.
 	{weekdayFormat}
 	{disableDaysOutsideMonth}
 	class={cn(
-		// Touch density: the calendar renders in portaled popovers/drawers, outside
-		// @container/main, so pointer-coarse is the touch signal — every
-		// --cell-size consumer (day cells, nav, caption) grows to 44px together.
+		// Renders in portaled overlays, outside @container/main — touch density
+		// keys on pointer-coarse instead of the band.
 		'group/calendar bg-surface p-3 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent pointer-coarse:[--cell-size:--spacing(11)]',
 		className
 	)}

--- a/src/lib/components/ui/select-category/select-category.svelte
+++ b/src/lib/components/ui/select-category/select-category.svelte
@@ -137,7 +137,7 @@
 			oninput={handleInput}
 		/>
 		<Combobox.Trigger
-			class="flex h-full items-center px-2 text-muted hover:text-foreground"
+			class="flex h-full items-center px-2 text-muted hover:text-foreground pointer-coarse:px-3.5"
 			aria-label={ariaLabelTrigger}
 		>
 			<CaretUpDownIcon class="size-4" aria-hidden="true" />

--- a/src/routes/(app)/[budgetId=id]/[month=month]/budget-table-header.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/budget-table-header.svelte
@@ -16,7 +16,7 @@
 	role="columnheader"
 	bind:this={ref}
 	class={cn(
-		'flex h-8 items-center justify-end px-2 font-display text-xs font-medium tracking-wider whitespace-nowrap text-muted uppercase first:justify-start',
+		'flex h-8 items-center justify-end px-2 font-display text-xs font-medium tracking-wider whitespace-nowrap text-muted uppercase first:justify-start @3xl/main:h-11 @7xl/main:h-8',
 		className
 	)}
 	{...restProps}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/budget-table-header.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/budget-table-header.svelte
@@ -16,7 +16,7 @@
 	role="columnheader"
 	bind:this={ref}
 	class={cn(
-		'flex h-8 items-center justify-end px-2 font-display text-xs font-medium tracking-wider whitespace-nowrap text-muted uppercase first:justify-start @3xl/main:h-11 @7xl/main:h-8',
+		'flex h-8 items-center justify-end px-2 font-display text-xs font-medium tracking-wider whitespace-nowrap text-muted uppercase first:justify-start',
 		className
 	)}
 	{...restProps}

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-archive-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-archive-popover.svelte
@@ -33,7 +33,7 @@
 			bind:ref={triggerEl}
 			class={cn(
 				buttonVariants({ size: 'xs', variant: 'ghost' }),
-				'@3xl/main:size-11 @7xl/main:h-6 @7xl/main:w-auto'
+				'@3xl/main:w-11 @7xl/main:w-auto'
 			)}
 			aria-label={m.category_archived_link({ amount: categories.length })}
 		>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-archive-popover.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-archive-popover.svelte
@@ -5,6 +5,7 @@
 	import { getArchivedCategories } from '$lib/remote-functions/category.remote';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { flip } from 'svelte/animate';
+	import { cn } from 'tailwind-variants';
 	import ArchiveIcon from '~icons/ph/archive';
 
 	import CategoryRestoreForm from './category-restore-form.svelte';
@@ -30,7 +31,10 @@
 	<Popover.Root>
 		<Popover.Trigger
 			bind:ref={triggerEl}
-			class={buttonVariants({ size: 'xs', variant: 'ghost' })}
+			class={cn(
+				buttonVariants({ size: 'xs', variant: 'ghost' }),
+				'@3xl/main:size-11 @7xl/main:h-6 @7xl/main:w-auto'
+			)}
 			aria-label={m.category_archived_link({ amount: categories.length })}
 		>
 			<ArchiveIcon class="size-4" />

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -116,7 +116,7 @@
 						{m.budget_monthly_table_header_category()}
 						<Button
 							size="xs"
-							class="ml-1 @3xl/main:size-11 @7xl/main:h-6 @7xl/main:w-auto"
+							class="ml-1 @3xl/main:w-11 @7xl/main:w-auto"
 							aria-label={m.category_create_button()}
 							onclick={() => (createDialogOpen = true)}
 						>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-budget-table.svelte
@@ -116,7 +116,7 @@
 						{m.budget_monthly_table_header_category()}
 						<Button
 							size="xs"
-							class="ml-1"
+							class="ml-1 @3xl/main:size-11 @7xl/main:h-6 @7xl/main:w-auto"
 							aria-label={m.category_create_button()}
 							onclick={() => (createDialogOpen = true)}
 						>
@@ -134,7 +134,7 @@
 				<BudgetTableHeader class="w-1/5">
 					{m.budget_monthly_table_header_remaining()}
 				</BudgetTableHeader>
-				<BudgetTableHeader class="w-9">
+				<BudgetTableHeader class="w-9 @3xl/main:w-11 @7xl/main:w-9">
 					<span class="sr-only">{m.budget_monthly_table_header_actions()}</span>
 				</BudgetTableHeader>
 			</div>
@@ -194,9 +194,11 @@
 							/>
 						</BudgetTableCell>
 
-						<BudgetTableCell class="hidden w-9 border-0 last:p-1 @3xl/main:flex">
+						<BudgetTableCell
+							class="hidden w-9 border-0 last:p-1 @3xl/main:flex @3xl/main:w-11 @3xl/main:p-0 @7xl/main:w-9 @7xl/main:px-2 @7xl/main:py-1"
+						>
 							<button
-								class="flex size-7 cursor-grab items-center justify-center text-muted hover:text-interactive"
+								class="flex size-7 cursor-grab items-center justify-center text-muted hover:text-interactive @3xl/main:size-11 @7xl/main:size-7"
 								data-drag-handle="category"
 								aria-label={m.drag_handle_label()}
 							>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-restore-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-restore-form.svelte
@@ -13,8 +13,6 @@
 
 <form {...submit.attrs}>
 	<input {...form.fields.categoryId.as('hidden', category.id)} />
-	<!-- The link treatment is locked (#334) — on touch the tap area grows
-	     invisibly instead (padding cancelled by negative margin). -->
 	<Button
 		type="submit"
 		size="xs"

--- a/src/routes/(app)/[budgetId=id]/[month=month]/category-restore-form.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/category-restore-form.svelte
@@ -13,11 +13,13 @@
 
 <form {...submit.attrs}>
 	<input {...form.fields.categoryId.as('hidden', category.id)} />
+	<!-- The link treatment is locked (#334) — on touch the tap area grows
+	     invisibly instead (padding cancelled by negative margin). -->
 	<Button
 		type="submit"
 		size="xs"
 		variant="link"
-		class="px-0"
+		class="px-0 pointer-coarse:-mx-2 pointer-coarse:min-h-11 pointer-coarse:px-2"
 		loading={submit.pending}
 		{@attach submit.anchor}
 	>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -127,6 +127,9 @@
 			</span>
 		</div>
 
+		<!-- Touch density: the panel portals to <body>, outside @container/main, so
+		     the #297 band hook can't reach it — pointer-coarse is the touch signal
+		     for portaled overlay controls. -->
 		<form {...submit.attrs} class="flex flex-col gap-3 p-3">
 			<input {...form.fields.budgetId.as('hidden', budgetId())} />
 			<input type="hidden" name={form.fields.month.as('number').name} value={month} />
@@ -138,7 +141,7 @@
 					aria-label={m.reassignment_amount()}
 					bind:value={() => form.fields.amount.value(), (v) => form.fields.amount.set(v)}
 					currency={budget.currency}
-					class="px-2 text-right font-currency"
+					class="px-2 text-right font-currency pointer-coarse:h-11"
 					selectOnFocus
 				/>
 			{:else}
@@ -146,6 +149,7 @@
 			{/if}
 
 			<SelectCategory
+				class="pointer-coarse:h-11"
 				name={form.fields.targetCategoryId.as('select').name}
 				bind:value={
 					() => form.fields.targetCategoryId.value() ?? '',
@@ -172,10 +176,22 @@
 			{/if}
 
 			<div class="flex justify-end gap-2">
-				<Button variant="ghost" size="sm" onclick={() => (open = false)}>
+				<Button
+					variant="ghost"
+					size="sm"
+					class="pointer-coarse:h-11"
+					onclick={() => (open = false)}
+				>
 					{m.reassignment_cancel()}
 				</Button>
-				<Button type="submit" size="sm" loading={submit.pending}>{m.reassignment_ok()}</Button>
+				<Button
+					type="submit"
+					size="sm"
+					class="pointer-coarse:h-11 pointer-coarse:px-4"
+					loading={submit.pending}
+				>
+					{m.reassignment_ok()}
+				</Button>
 			</div>
 		</form>
 	</Popover.Content>

--- a/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
+++ b/src/routes/(app)/[budgetId=id]/[month=month]/reassignment-popup.svelte
@@ -127,9 +127,8 @@
 			</span>
 		</div>
 
-		<!-- Touch density: the panel portals to <body>, outside @container/main, so
-		     the #297 band hook can't reach it — pointer-coarse is the touch signal
-		     for portaled overlay controls. -->
+		<!-- The panel portals to <body>, outside @container/main — touch density
+		     keys on pointer-coarse instead of the band. -->
 		<form {...submit.attrs} class="flex flex-col gap-3 p-3">
 			<input {...form.fields.budgetId.as('hidden', budgetId())} />
 			<input type="hidden" name={form.fields.month.as('number').name} value={month} />


### PR DESCRIPTION
Resolves #361 — the in-table controls #297's touch band missed, plus the overlay-hosted ones its container hook can't reach.

## In-table (band hook, `@3xl/main:` grow → `@7xl/main:` snap back)

- Register sort-header buttons (16px → 44px) and per-row validated toggle (32px → 44px); header row grows with them.
- Month-table header "+" create trigger and "N archived" popover trigger (24px → 44px); `BudgetTableHeader` carries the band height.
- Month-table drag handle → 44px; the actions column widens to `w-11` with band-zero padding. The pre-existing `last:p-1` classes on that cell are dead (`:last-child` is the hidden mobile card, not the cell) — the resting padding was flex-squeezing the handle, so the band overrides use plain `p-*`.

## Overlay-hosted (pointer-coarse hook)

Popover content portals to `<body>`, outside `@container/main`, so the band hook can't reach it. These key on `pointer-coarse:` — touch devices grow, desktop pointers keep resting density:

- Reassignment flyout: amount input, category select + caret trigger, Cancel/OK → 44px.
- Date-picker calendar: `--cell-size` 32 → 44px, covering the register popover and the phone drawer alike.
- Archive Restore text-links (category popover/drawer + accounts dialog): keep the #334-locked link look, tap area grows invisibly to 44px (padding cancelled by negative margin).

## Verification

- `npm run check` 0 errors, lint clean, 667 unit, 124 e2e incl. the `tablet` project.
- Live at 1180×820 (touch emulated): every listed control measures ≥44px, both modes.
- Live at 1440×900 (fine pointer): resting geometry byte-identical (16px sort buttons, 32px toggle, h-8 header, 32px calendar cells).

No CHANGELOG entry — the restyle effort ships one consolidated entry at the final restyle→main PR.