### PR TITLE
docs(changelog): consolidate the restyle entries into one release note (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,119 +12,76 @@ and dependency bumps get no entry.
 
 ### Changed
 
-- Floating panels now share one consistent chrome: the date-picker calendar,
-  select menus, and the budget table's assignment error flyout wear the same
-  hairline outline and shadow as every other overlay, and the mobile
-  navigation button casts the standard overlay shadow instead of a heavier
-  one.
-- Hover and list-highlight feedback is neutral everywhere: the budget
-  settings, budget members, and account settings icon buttons no longer
-  deepen their tint on hover, and the reassignment popup's category list
-  highlights with the standard neutral fill instead of blue. Positive
-  balances in that list render as plain text — green stays reserved for
-  target progress.
-
-- The error page dropped its tinted panel for a plain poster layout: the
-  status code stands directly on the page as a large serif numeral, with the
-  error message, log ID, and home link beneath it.
+- genug has been redesigned end to end on a single design language, in light
+  and dark: calm flat pages without stacked panels or in-page shadows, one
+  small corner radius, quiet compact tables, and color reserved for meaning —
+  red marks problems, gold marks keyboard focus, and green stays on target
+  progress. Hovering interactive elements shows a thin neutral outline, and
+  positive amounts render as plain ink instead of green.
+- The budget month view is a quiet open ledger: compact zebra-striped rows
+  directly on the page with a filled header bar, small quiet column labels, a
+  flat Unallocated chip, and remaining amounts in a medium weight that
+  anchors each row without dominating the quieter secondary numbers. Mobile
+  category cards keep their bordered look.
+- The transaction register got its own spreadsheet-like look: a framed grid
+  with row and column hairlines, a quiet floating header and a flat
+  pagination line. Clicking a cell switches the row into edit mode with the
+  clicked field focused and preselected while every value stays exactly in
+  place; open edit and create rows are tinted like a form and animate open
+  and closed. Generic tables and pagination share the same quiet striped
+  look, and empty states got a lighter dashed frame.
+- The navigation sidebar is a narrower, quieter rail: budget names anchor
+  their accounts in ink, the current budget or account is marked with a small
+  colored dot or tinted arrow instead of a filled highlight, secondary
+  actions moved behind a hairline with small muted icons, and the reorder
+  grips are subtle hover-revealed handles. The mobile navigation drawer uses
+  the same idiom on flat bordered cards.
+- Settings, admin, login and the error page follow the same calm rhythm:
+  sections sit directly on the page, separated by hairline dividers that hug
+  the heading they introduce; the admin screen's per-user reset-password and
+  delete actions moved from hover-only icons into an always-visible overflow
+  menu so they stay reachable on touch; the login and first-login screens
+  joined the new look; and the error page shows the status code as a large
+  serif numeral directly on the page, with the error message, log ID and
+  home link beneath it.
 - Archived categories and accounts moved out of their dedicated pages into
   lightweight surfaces with inline restore: categories open in a popover next
   to the budget table's create button (a bottom drawer on small screens), and
-  accounts in a small dialog next to the create button in budget settings.
-  Restored items reappear in their list immediately, and the archive
-  affordance hides itself while nothing is archived. Visiting an archived
-  category or account directly now shows only a short notice with a restore
-  button — restoring an account brings its register back in place, restoring
-  a category returns to the budget table.
-- The budget table's remaining amounts now render in a medium weight rather
-  than semibold, so the figure still anchors each row without dominating the
-  quieter secondary numbers.
-- The settings page dropped its stacked tinted panels for a calmer layout:
-  each section sits directly on the page, separated by hairline dividers that
-  hug the heading they introduce. Dialogs now use a slightly darker surface so
-  they no longer read as too bright in dark mode.
-- The navigation sidebar follows the design language now: a narrower, quieter
-  rail at the tables' compact density. The "Budgets" heading is gone — budget
-  names anchor their accounts in ink, and the current budget or account is
-  marked in color (a small dot for budgets, the tinted arrow for accounts)
-  instead of a filled highlight. Create/settings/sign-out moved behind a
-  hairline with small muted icons, and the reorder grips are now subtle
-  hover-revealed handles. The mobile navigation drawer uses the same idiom
-  on flat bordered cards, and page sections sit a step tighter everywhere.
-- The budget month table dropped its bordered row slabs for a quiet open
-  ledger: rows sit directly on the page with subtle zebra stripes and a
-  filled header bar, keeping the compact density. Mobile category cards
-  keep their bordered look.
-- The transaction register has a new look on the design language, visually
-  distinct from the budget table: a framed spreadsheet-like grid with row and
-  column hairlines, a quiet floating header and a flat pagination line.
-  Clicking a cell now switches the row into edit mode with the clicked
-  field focused and preselected, while every value stays exactly in place —
-  the inputs fill their cells. Open edit and create rows are tinted like a
-  form, marked with a light ring, use compact action buttons, and animate
-  open and closed.
-- Data-display primitives now follow the design language: generic tables
-  use the month view's quiet zebra-striped look (striped rows, subtle
-  header and totals bars) instead of heavy borders, the current pagination
-  page is highlighted with the standard interactive button tint, and empty
-  states got a lighter dashed frame with tighter spacing.
+  accounts in a small dialog in budget settings. Restored items reappear in
+  their list immediately, the archive affordance hides itself while nothing
+  is archived, and visiting an archived category or account directly now
+  shows only a short notice with a restore button.
 - All overlays — dialogs, confirmation dialogs, drawers, popovers, dropdown
-  menus, selects and the command palette — now follow the design language:
-  they share the brightest surface tone, a hairline edge plus one soft
-  shadow, and a backdrop that washes the page out in the theme's own
-  background color instead of darkening it. Open/close animations are
-  unified into one quick, springy character (a short directional drop with
-  a slight overshoot, quick fades out); drawers keep their slide but snap
-  noticeably faster. Animations are disabled for reduced-motion users.
-- Form fields (inputs, textareas, selects, checkboxes, toggle groups, the
-  date picker) now use a translucent tint instead of a fixed surface color,
-  so they stay clearly recognizable on any background — including inside
-  dialogs and popovers.
-- Dialogs now have a sensible default width instead of stretching almost
-  full-screen when a caller forgot to cap them, and small phone screens
-  keep an edge margin around every dialog.
-- Drawer and confirmation-dialog buttons are laid out consistently with
-  dialogs: right-aligned in a row on wider screens, stacked full-width on
-  small ones. Destructive menu entries now show a faint red fill when
-  highlighted.
-- Dark mode's secondary text and error color are slightly lighter so text
-  keeps WCAG AA contrast on the brighter overlay surfaces.
-- The admin screen follows the design language now: the same calm section
-  rhythm as the settings page, and each user's reset-password and delete
-  actions moved from hover-only icons into an always-visible overflow menu,
-  so they stay reachable on touch.
+  menus, selects and the command palette — share one chrome: the brightest
+  surface tone, a hairline edge plus one soft shadow, and a backdrop that
+  washes the page out in the theme's own background color instead of
+  darkening it. Open/close animations share one quick, springy character and
+  are disabled for reduced-motion users. Dialogs have a sensible default
+  width and keep an edge margin on small phone screens, footer buttons are
+  laid out consistently, destructive menu entries show a faint red fill when
+  highlighted — and on phones the remaining plain dialogs now open as bottom
+  drawers.
+- Form fields (inputs, textareas, selects, the category picker, checkboxes,
+  toggle groups, the calendar and the date picker) use a translucent tint
+  instead of a fixed surface color, so they stay clearly recognizable on any
+  background — including inside dialogs and popovers. Selected states fill
+  with ink instead of accent tints, today is marked with a subtle frame,
+  invalid fields show a red border plus a soft red halo that steps aside
+  while a field is focused so the gold focus ring stays visible, and
+  disabled controls consistently dim to half opacity.
+- Accessibility rose with the redesign: all text — including tinted chips
+  and the accent colors on elevated surfaces — keeps WCAG AA contrast in
+  both themes, touch targets grow to 44px on phones, tablets and other touch
+  devices, and screen-reader structure was repaired across the budget table,
+  the statistics breakdowns, comboboxes and the password-visibility toggle.
 
 ### Fixed
 
-- The budget members drawer on small screens can be closed again: its Close
-  button and the Escape key work while tapping outside stays disabled, so the
-  drawer no longer traps you until a page reload.
-- Clicking a date in the transaction table no longer shrinks the cell's text:
-  the date-picker trigger now keeps the same font size as the read-only cell
-  it replaces.
-- Dialogs and drawers no longer render their middle section empty in
-  Safari (including iOS home-screen installs) — content such as form
-  fields was collapsing to zero height.
-- The gold keyboard-focus ring and red invalid halo are no longer cut off
-  on fields that touch the edge of a dialog or drawer's scrollable area.
-
-- All form controls now follow the new design language: buttons, inputs,
-  textareas, selects, the category picker, checkboxes, toggle groups, the
-  calendar and the date picker share flat surfaces, one border tone, and the
-  thin neutral hover outline. Selected states fill with ink (checked
-  checkboxes, the active toggle item, the picked calendar day) instead of
-  accent tints, and today is marked with a subtle frame. Invalid fields show
-  the red border plus a soft red halo on every control — and the halo now
-  steps aside while a field is focused so the gold focus ring stays visible.
-  Disabled controls consistently dim to half opacity.
-- The budget month view has a simplified, calmer look — the first screen on
-  the new design language: categories render as compact separated rows
-  without column lines, headers are small quiet labels, the Unallocated chip
-  is flat, and corners share a single small radius. Color now only marks
-  problems: Remaining amounts are plain until they go negative (red);
-  positive amounts are no longer tinted green. Hovering interactive cells
-  shows a thin neutral outline; the gold ring now exclusively marks keyboard
-  focus.
+- Dialogs and drawers no longer render their middle section empty in Safari
+  (including iOS home-screen installs) — content such as form fields was
+  collapsing to zero height.
+- The gold keyboard-focus ring and red invalid halo are no longer cut off on
+  fields that touch the edge of a dialog or drawer's scrollable area.
 
 ## [2026.07.5] - 2026-07-21
 


### PR DESCRIPTION
Assembles the accumulated per-screen `[Unreleased]` bullets into the single consolidated entry #327 calls for: nine thematic **Changed** bullets (design-language lead, month view, register, navigation, page rhythm, archive flow, overlays, forms, accessibility) and two **Fixed**.

Editorial calls, each verified against `main`:

- **Kept as genuine fixes** — the Safari zero-height dialog body and the clipped focus ring / error halo: `main`'s `dialog-body` still carries the `flex-1` and clip-edge defects, so both bugs are user-visible there today.
- **Dropped as branch-internal** — the user-manager drawer trap (#360; `dismissible` doesn't exist on `main`) and the date-cell font shrink (#353; the click-to-edit cell is restyle-new). Introduced and fixed within the branch, never shipped.
- **Folded in** the sweep-era work that deliberately shipped without per-ticket entries: the AA contrast retune, 44px touch targets, ARIA repairs, and the archive UX.

Full green bar on this tree: `npm run check` (0 errors), lint, 667 unit tests, **124 e2e tests** including the both-theme axe scans.

Last blocker before the final `restyle` → `main` PR. Part of #327 / #316.