### PR TITLE
test: speed up money roundtrip test to avoid CI timeout

### DIFF
--- a/src/lib/utils/money.test.ts
+++ b/src/lib/utils/money.test.ts
@@ -73,10 +73,13 @@ describe('asMoney', () => {
 
 describe('parseMoney ↔ unwrapMoney roundtrip', () => {
 	it('preserves the cent value through parse → unwrap', () => {
+		// Plain comparison in the loop; per-iteration expect() calls are too
+		// slow for 200k iterations and time out on CI.
 		for (let cents = -100000; cents <= 100000; cents++) {
 			const money = parseMoney(cents);
-			expect(money).not.toBeNull();
-			expect(unwrapMoney(money!)).toBe(cents);
+			if (money === null || unwrapMoney(money) !== cents) {
+				expect.fail(`roundtrip failed for ${cents}: got ${money}`);
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary

The `unit-test` job on main is failing ([run](https://github.com/lj-n/genug/actions/runs/30535979856/job/90849274095)): `money.test.ts > parseMoney ↔ unwrapMoney roundtrip > preserves the cent value through parse → unwrap` hits vitest's 5s timeout on CI runners (6012ms).

The test loops over every cent value from -100,000 to 100,000 with two `expect()` calls per iteration — the overhead of ~400k assertion calls is what makes it slow, not the code under test.

## Fix

Keep the exhaustive range but use a plain comparison inside the loop and only invoke `expect.fail` on an actual mismatch. Same coverage; the whole file now runs in ~135ms locally.

Test-only change, so no changelog entry.