### PR TITLE
fix(deps): bump brace-expansion, postcss, fast-uri (transitive security advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "genug",
-	"version": "2026.07.5",
+	"version": "2026.07.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "genug",
-			"version": "2026.07.5",
+			"version": "2026.07.6",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@fontsource-variable/ibm-plex-sans": "^5.3.0",
@@ -3501,16 +3501,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/buffer": {
@@ -4549,9 +4549,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5778,9 +5778,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -6155,9 +6155,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -6175,7 +6175,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},


### PR DESCRIPTION
Lockfile-only bumps within existing semver ranges for the three high-severity Dependabot alerts. All are dev-scope transitives with no Renovate PR (`osvVulnerabilityAlerts` only covers direct deps, see #213):

- `brace-expansion` 5.0.7 → 5.0.9 — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), DoS via unbounded expansion length (via `eslint` → `minimatch`)
- `postcss` 8.5.15 → 8.5.25 — [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), path traversal via source-map auto-loading (via `vite` / `eslint-plugin-svelte`)
- `fast-uri` 3.1.3 → 3.1.4 — [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx), host confusion via literal backslash authority delimiter (via `ajv`)

Also catches the lockfile version stamp up to `2026.07.6`, which the release commit bumped only in `package.json`.

Verified locally: lint clean, 667/667 unit tests pass. `npm audit` afterwards reports only the @sveltejs/kit advisories fixed by #270.