### PR TITLE
fix(a11y): label clear-filter buttons on transaction register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and dependency bumps get no entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- The clear-all-filters button and the per-filter remove buttons on the
+  transaction register now expose accessible names, so screen readers announce
+  them instead of unlabelled buttons.
+
 ## [2026.07.6] - 2026-07-30
 
 ### Changed

--- a/messages/de.json
+++ b/messages/de.json
@@ -179,6 +179,8 @@
 	"account_balance_pending": "Ausstehend",
 	"account_balance": "Kontostand",
 	"transaction_filter_title": "Filter",
+	"transaction_filter_clear_all": "Alle Filter entfernen",
+	"transaction_filter_remove": "Filter entfernen",
 	"transaction_filter_category_title": "Kategorienfilter",
 	"transaction_filter_category_description": "Nur Transaktionen der gewählten Kategorien anzeigen.",
 	"transaction_filter_category_empty": "Alle Kategorien",

--- a/messages/en.json
+++ b/messages/en.json
@@ -178,6 +178,8 @@
 	"account_balance": "Balance",
 	"delete": "Delete",
 	"transaction_filter_title": "Filter",
+	"transaction_filter_clear_all": "Clear all filters",
+	"transaction_filter_remove": "Remove filter",
 	"transaction_filter_category_title": "Category Filter",
 	"transaction_filter_category_description": "Only show transactions of selected categories.",
 	"transaction_filter_category_empty": "All Categories",

--- a/src/lib/components/features/transaction/transaction-table-filter.svelte
+++ b/src/lib/components/features/transaction/transaction-table-filter.svelte
@@ -88,6 +88,7 @@
 						variant="destructive"
 						size="icon"
 						class="@3xl/main:size-11 @7xl/main:size-9"
+						aria-label={m.transaction_filter_clear_all()}
 						onclick={() => onClearAllFilters()}
 					>
 						<XIcon />
@@ -123,7 +124,12 @@
 					/>
 				{/if}
 
-				<Button size="icon" variant="ghost" onclick={() => onClearFilter(f.type)}>
+				<Button
+					size="icon"
+					variant="ghost"
+					aria-label={m.transaction_filter_remove()}
+					onclick={() => onClearFilter(f.type)}
+				>
 					<XIcon />
 				</Button>
 			</div>

--- a/tests/playwright/a11y.spec.ts
+++ b/tests/playwright/a11y.spec.ts
@@ -232,6 +232,17 @@ for (const theme of THEMES) {
 			).toBeVisible();
 			await expectAxeClean(page);
 
+			// Filter active: opening a filter reveals the icon-only clear-all control,
+			// which must carry an accessible name (#286). Scan the register in that state.
+			await page.getByRole('button', { exact: true, name: 'Filter' }).click();
+			await page.getByRole('menuitem', { name: 'Notes Filter' }).click();
+			const clearAll = page.getByRole('button', { name: 'Clear all filters' });
+			await expect(clearAll).toBeVisible();
+			await expectAxeClean(page);
+			// Restore the unfiltered register for the states below.
+			await clearAll.click();
+			await expect(clearAll).not.toBeVisible();
+
 			// Create: the inline transaction create row.
 			await page.getByRole('button', { name: 'New Transaction' }).click();
 			await expect(page.getByRole('row', { name: 'New Transaction' })).toBeVisible();


### PR DESCRIPTION
## What

The icon-only **clear-all-filters** button on the transaction register — and the per-filter **remove** (`✕`) buttons that appear beside each active filter chip — had no accessible name, so screen readers announced them as unlabelled buttons.

Both now carry an `aria-label` sourced from new Paraglide messages:

- `transaction_filter_clear_all` — "Clear all filters" / "Alle Filter entfernen"
- `transaction_filter_remove` — "Remove filter" / "Filter entfernen"

A dedicated message is used for clear-all rather than reusing the empty-state `transactions_filtered_empty_action` ("Clear filters"), as the issue requested.

## Why the per-filter button too

Acceptance criterion 3 requires a clean axe run on the account screen **with an active filter**. Activating any filter reveals both the clear-all button and the active-filter chip's own icon-only remove button — the latter was equally unlabelled, so it had to be labelled for the axe check to pass.

## Tests

Extends the existing a11y Playwright suite (`tests/playwright/a11y.spec.ts`): the transaction-register flow now opens a filter, asserts the labelled clear-all control is present, and runs `expectAxeClean` in that state before clearing the filter. Passes in both themes and both viewports.

Closes #286
