### PR TITLE
fix(transactions): refresh account balances after mutations (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- Account balance figures now update immediately after any transaction change —
+  creating, editing, transferring, and batch delete/validate — instead of
+  staying stale until a manual page reload. Both accounts in a transfer refresh,
+  so the counterpart's balance updates too.
 - The clear-all-filters button and the per-filter remove buttons on the
   transaction register now expose accessible names, so screen readers announce
   them instead of unlabelled buttons.

--- a/src/lib/components/features/transaction/transaction-create-modal.svelte
+++ b/src/lib/components/features/transaction/transaction-create-modal.svelte
@@ -10,6 +10,7 @@
 	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
+	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 	import { createTransaction, listTransactions } from '$lib/remote-functions/transaction.remote';
@@ -42,7 +43,11 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions({ accountId, ...urlParams })]
+		updates: () => [
+			listTransactions({ accountId, ...urlParams }),
+			getAccount(accountId),
+			getAccountBalances(accountId)
+		]
 	});
 
 	// The draft is scoped to one account (carried as the hidden accountId), so it

--- a/src/lib/components/features/transaction/transaction-edit-modal.svelte
+++ b/src/lib/components/features/transaction/transaction-edit-modal.svelte
@@ -11,6 +11,7 @@
 	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
+	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 	import {
 		batchDeleteTransactions,
@@ -55,7 +56,11 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [
+			listTransactions,
+			getAccount(transaction!.accountId),
+			getAccountBalances(transaction!.accountId)
+		]
 	});
 
 	// Unlike the inline row (which unmounts on success), the sheet must close
@@ -65,7 +70,11 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [
+			listTransactions,
+			getAccount(transaction!.accountId),
+			getAccountBalances(transaction!.accountId)
+		]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/components/features/transaction/transaction-list-mobile.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-list-mobile.svelte.test.ts
@@ -18,6 +18,13 @@ vi.mock('$lib/remote-functions/transaction.remote', () => ({
 		})
 	}
 }));
+// The validate toggle rendered per row refreshes account-balance queries, so
+// its account.remote import loads too; stub it to keep this suite off the real
+// remote module (which pulls $app/paths).
+vi.mock('$lib/remote-functions/account.remote', () => ({
+	getAccount: vi.fn(),
+	getAccountBalances: vi.fn()
+}));
 
 import TransactionListMobile from './transaction-list-mobile.svelte';
 

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte
@@ -8,6 +8,7 @@
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
+	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 	import { createTransaction, listTransactions } from '$lib/remote-functions/transaction.remote';
@@ -63,7 +64,11 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions({ accountId, ...urlParams })]
+		updates: () => [
+			listTransactions({ accountId, ...urlParams }),
+			getAccount(accountId),
+			getAccountBalances(accountId)
+		]
 	});
 
 	const submitWithKeyboard: Attachment<HTMLFormElement> = (node) => {

--- a/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row-create.svelte.test.ts
@@ -70,6 +70,8 @@ const remote = vi.hoisted(() => {
 			pending: 0
 		},
 		fieldState: () => fieldState,
+		getAccount: vi.fn((accountId: unknown) => ({ account: accountId })),
+		getAccountBalances: vi.fn((accountId: unknown) => ({ balances: accountId })),
 		getBudget: vi.fn(async () => ({ currency: 'EUR', id: 'budget-1', name: 'Budget' })),
 		getCategories: vi.fn(async () => [
 			{ id: 'category-1', name: 'Groceries' },
@@ -99,6 +101,10 @@ const remote = vi.hoisted(() => {
 vi.mock('$lib/remote-functions/transaction.remote', () => ({
 	createTransaction: remote.createTransaction,
 	listTransactions: remote.listTransactions
+}));
+vi.mock('$lib/remote-functions/account.remote', () => ({
+	getAccount: remote.getAccount,
+	getAccountBalances: remote.getAccountBalances
 }));
 vi.mock('$lib/remote-functions/budget.remote', () => ({ getBudget: remote.getBudget }));
 vi.mock('$lib/remote-functions/category.remote', () => ({ getCategories: remote.getCategories }));
@@ -178,14 +184,16 @@ describe('TableRowCreate', () => {
 		expect(screen.getByRole('row')).toBeInTheDocument();
 	});
 
-	it('updates the transaction list for the account and url params on submit', async () => {
+	it('updates the transaction list and account balances for the account on submit', async () => {
 		const user = userEvent.setup();
 		await renderRow();
 
 		await user.click(screen.getByRole('button', { name: 'Save' }));
 
 		expect(remote.listTransactions).toHaveBeenCalledWith({ accountId: 'account-1', ...urlParams });
-		expect(remote.updatedQueries).toHaveLength(1);
+		expect(remote.getAccount).toHaveBeenCalledWith('account-1');
+		expect(remote.getAccountBalances).toHaveBeenCalledWith('account-1');
+		expect(remote.updatedQueries).toHaveLength(3);
 	});
 
 	it('closes the popover after saving with the save button', async () => {

--- a/src/lib/components/features/transaction/transaction-table-row.svelte
+++ b/src/lib/components/features/transaction/transaction-table-row.svelte
@@ -8,6 +8,7 @@
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
+	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getCategories } from '$lib/remote-functions/category.remote';
 	import {
 		batchDeleteTransactions,
@@ -72,13 +73,21 @@
 	const submit = createFormSubmit(() => form, {
 		onSuccess: () => cancelEditing(),
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [
+			listTransactions,
+			getAccount(transaction.accountId),
+			getAccountBalances(transaction.accountId)
+		]
 	});
 
 	// No onSuccess: the refreshed list unmounting this row is the success signal.
 	const deleteSubmit = createFormSubmit(() => deleteForm, {
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [
+			listTransactions,
+			getAccount(transaction.accountId),
+			getAccountBalances(transaction.accountId)
+		]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/components/features/transaction/transaction-table-row.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-table-row.svelte.test.ts
@@ -111,6 +111,8 @@ const remote = vi.hoisted(() => {
 	return {
 		deleteForm,
 		editForm,
+		getAccount: vi.fn(),
+		getAccountBalances: vi.fn(),
 		getCategories: vi.fn(async () => [
 			{ id: 'category-1', name: 'Groceries' },
 			{ id: 'category-2', name: 'Rent' }
@@ -123,6 +125,10 @@ vi.mock('$lib/remote-functions/transaction.remote', () => ({
 	batchDeleteTransactions: { for: () => remote.deleteForm.form },
 	editTransaction: { for: () => remote.editForm.form },
 	listTransactions: remote.listTransactions
+}));
+vi.mock('$lib/remote-functions/account.remote', () => ({
+	getAccount: remote.getAccount,
+	getAccountBalances: remote.getAccountBalances
 }));
 vi.mock('$lib/remote-functions/category.remote', () => ({ getCategories: remote.getCategories }));
 
@@ -185,13 +191,17 @@ describe('TransactionTableRow (edit mode) — submit lifecycle', () => {
 		await waitFor(() => expect(cancelEditing).toHaveBeenCalledTimes(1));
 	});
 
-	it('chains the transaction list refresh into the submit', async () => {
+	it('chains the transaction list and account-balance refreshes into the submit', async () => {
 		const user = userEvent.setup();
 		await renderRow();
 
 		await user.click(saveButton());
 
 		await waitFor(() => expect(remote.editForm.updatedQueries).toContain(remote.listTransactions));
+		// The account's total (getAccount) and validated/pending split
+		// (getAccountBalances) go stale with the register, so both refresh too.
+		expect(remote.getAccount).toHaveBeenCalledWith(transaction.accountId);
+		expect(remote.getAccountBalances).toHaveBeenCalledWith(transaction.accountId);
 	});
 
 	it('stays in edit mode when the submit reports validation issues', async () => {

--- a/src/lib/components/features/transaction/transaction-validate-toggle.svelte
+++ b/src/lib/components/features/transaction/transaction-validate-toggle.svelte
@@ -3,6 +3,7 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { m } from '$lib/paraglide/messages';
+	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import {
 		batchValidateTransactions,
 		listTransactions
@@ -31,7 +32,11 @@
 	// refreshed list is the success signal; thrown errors go to the toast.
 	const submit = createFormSubmit(() => form, {
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [
+			listTransactions,
+			getAccount(transaction.accountId),
+			getAccountBalances(transaction.accountId)
+		]
 	});
 </script>
 

--- a/src/lib/components/features/transaction/transfer-create-modal.svelte
+++ b/src/lib/components/features/transaction/transfer-create-modal.svelte
@@ -9,7 +9,11 @@
 	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
-	import { getAccounts } from '$lib/remote-functions/account.remote';
+	import {
+		getAccount,
+		getAccountBalances,
+		getAccounts
+	} from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { createTransfer, listTransactions } from '$lib/remote-functions/transaction.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
@@ -41,9 +45,10 @@
 		},
 		toast: {},
 		// A transfer writes a leg into each account, so refresh every live
-		// listTransactions instance (both legs' registers) rather than just the
-		// viewed account's — otherwise the counterpart stays stale until reload.
-		updates: () => [listTransactions]
+		// listTransactions instance and both accounts' balance queries (both legs'
+		// registers and summaries) rather than just the viewed account's —
+		// otherwise the counterpart stays stale until reload.
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	// The draft is scoped to one account (carried as the hidden accountId), so it

--- a/src/lib/components/features/transaction/transfer-edit-modal.svelte
+++ b/src/lib/components/features/transaction/transfer-edit-modal.svelte
@@ -11,7 +11,11 @@
 	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
-	import { getAccounts } from '$lib/remote-functions/account.remote';
+	import {
+		getAccount,
+		getAccountBalances,
+		getAccounts
+	} from '$lib/remote-functions/account.remote';
 	import {
 		batchDeleteTransactions,
 		editTransfer,
@@ -56,7 +60,7 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	// Deleting either leg removes the whole transfer server-side (ADR-0015);
@@ -66,7 +70,7 @@
 			open = false;
 		},
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/components/features/transaction/transfer-table-row-create.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row-create.svelte
@@ -7,7 +7,11 @@
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
-	import { getAccounts } from '$lib/remote-functions/account.remote';
+	import {
+		getAccount,
+		getAccountBalances,
+		getAccounts
+	} from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
 	import { createTransfer, listTransactions } from '$lib/remote-functions/transaction.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
@@ -61,9 +65,10 @@
 		},
 		toast: {},
 		// A transfer writes a leg into each account, so refresh every live
-		// listTransactions instance (both legs' registers) rather than just the
-		// viewed account's — otherwise the counterpart stays stale until reload.
-		updates: () => [listTransactions]
+		// listTransactions instance and both accounts' balance queries (both legs'
+		// registers and summaries) rather than just the viewed account's —
+		// otherwise the counterpart stays stale until reload.
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	const submitWithKeyboard: Attachment<HTMLFormElement> = (node) => {

--- a/src/lib/components/features/transaction/transfer-table-row.svelte
+++ b/src/lib/components/features/transaction/transfer-table-row.svelte
@@ -8,7 +8,11 @@
 	import { InputMoney } from '$lib/components/ui/input-money';
 	import { SelectCategory } from '$lib/components/ui/select-category';
 	import { m } from '$lib/paraglide/messages';
-	import { getAccounts } from '$lib/remote-functions/account.remote';
+	import {
+		getAccount,
+		getAccountBalances,
+		getAccounts
+	} from '$lib/remote-functions/account.remote';
 	import {
 		batchDeleteTransactions,
 		editTransfer,
@@ -74,14 +78,14 @@
 	const submit = createFormSubmit(() => form, {
 		onSuccess: () => cancelEditing(),
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	// Deleting either leg removes the whole transfer server-side (ADR-0015);
 	// the refreshed list unmounting this row is the success signal.
 	const deleteSubmit = createFormSubmit(() => deleteForm, {
 		toast: {},
-		updates: () => [listTransactions]
+		updates: () => [listTransactions, getAccount, getAccountBalances]
 	});
 
 	const pending = $derived(submit.pending || deleteSubmit.pending);

--- a/src/lib/remote-functions/transaction.remote.ts
+++ b/src/lib/remote-functions/transaction.remote.ts
@@ -15,7 +15,21 @@ import {
 } from '$lib/schemas/transaction';
 import { guardedForm, guardedQuery } from '$server/utils/remote-guard';
 
+import { getAccount, getAccountBalances } from './account.remote';
 import { REFRESH_LIMIT } from './remote.utils';
+
+// Every transaction mutation moves money in one or two accounts, so the
+// balance figures (`getAccount.balance` for the total, `getAccountBalances`
+// for the validated/pending split) go stale alongside the register. Refresh
+// all three together; the client's `.updates(...)` declares which instances
+// each surface holds (see docs/dev/remote-functions.md).
+function refreshRegisters() {
+	return Promise.all([
+		requested(listTransactions, REFRESH_LIMIT).refreshAll(),
+		requested(getAccount, REFRESH_LIMIT).refreshAll(),
+		requested(getAccountBalances, REFRESH_LIMIT).refreshAll()
+	]);
+}
 
 export const listTransactions = guardedQuery(
 	ListTransactionsSchema,
@@ -70,7 +84,7 @@ export const createTransaction = guardedForm(
 			notes: data.notes || null,
 			validated: data.validated
 		});
-		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+		await refreshRegisters();
 	}
 );
 
@@ -84,7 +98,7 @@ export const editTransaction = guardedForm(
 			validated: rest.validated
 		};
 		ctx.transaction.edit(transactionId, update);
-		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+		await refreshRegisters();
 	}
 );
 
@@ -107,7 +121,7 @@ export const createTransfer = guardedForm(TransferCreateSchema, async (data, { c
 		notes: data.notes || null,
 		...transferDirection(data)
 	});
-	await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+	await refreshRegisters();
 });
 
 export const editTransfer = guardedForm(TransferEditSchema, async (data, { ctx }) => {
@@ -117,14 +131,14 @@ export const editTransfer = guardedForm(TransferEditSchema, async (data, { ctx }
 		notes: data.notes === undefined ? undefined : data.notes || null,
 		...transferDirection(data)
 	});
-	await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+	await refreshRegisters();
 });
 
 export const batchDeleteTransactions = guardedForm(
 	BatchTransactionIdsSchema,
 	async ({ ids }, { ctx }) => {
 		ctx.transaction.delete(ids);
-		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+		await refreshRegisters();
 	}
 );
 
@@ -132,6 +146,6 @@ export const batchValidateTransactions = guardedForm(
 	BatchValidateSchema,
 	async ({ ids, validated }, { ctx }) => {
 		ctx.transaction.validate(ids, validated);
-		await requested(listTransactions, REFRESH_LIMIT).refreshAll();
+		await refreshRegisters();
 	}
 );

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -44,6 +44,20 @@ export class AccountPage extends BasePage {
 		await expect(this.page.getByText('This account is archived')).toBeVisible();
 	}
 
+	/**
+	 * One figure from the balance summary strip at the top of the register
+	 * (`Balance` total, `Validated`, or `Pending`). Each figure is a small block
+	 * pairing the exact label with a `font-currency` amount as a *direct* child;
+	 * the register's own amounts nest their `font-currency` inside a cell button,
+	 * and the "Validated" column header carries no amount — so keying on a direct
+	 * `font-currency` child plus the exact label isolates the summary block.
+	 */
+	balanceFigure(label: 'Balance' | 'Pending' | 'Validated'): Locator {
+		return this.page
+			.locator('div:has(> .font-currency)')
+			.filter({ has: this.page.getByText(label, { exact: true }) });
+	}
+
 	/** The filtered-empty state's clear-filters action. */
 	clearFiltersAction(): Locator {
 		return this.page.getByRole('button', { name: 'Clear filters' });

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -1,7 +1,10 @@
+import { asMoney, formatMoney } from '$lib/utils/money';
 import { faker } from '@faker-js/faker';
 
 import { expect, test } from './fixture';
 import { uniqueName } from './unique-name';
+
+const eur = (value: number) => formatMoney({ currency: 'EUR', money: asMoney(value) });
 
 test('Create Transaction', async ({ pages }) => {
 	await pages.auth.createUserAndLogin();
@@ -97,6 +100,107 @@ test('Toggle Validated', async ({ pages }) => {
 	});
 
 	await pages.account.toggleValidated();
+});
+
+test('Creating a transaction updates the balance summary without reload', async ({ pages }) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	// Start from a non-zero balance so the post-create total is distinct from the
+	// single transaction's amount (100 + 42 = 142, not just 42).
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName, '100');
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	await pages.account.goto(accountName);
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(10000));
+
+	await pages.account.createTransaction({ amount: '42', category: categoryName, validated: true });
+
+	// The summary must reflect the new transaction with no manual reload.
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(14200));
+	await expect(pages.account.balanceFigure('Validated')).toContainText(eur(14200));
+	await expect(pages.account.balanceFigure('Pending')).toContainText(eur(0));
+});
+
+test('Validating, editing, and deleting a transaction each update the balance summary without reload', async ({
+	pages
+}) => {
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const accountName = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountName);
+
+	const categoryName = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(categoryName);
+
+	await pages.account.goto(accountName);
+
+	// A pending transaction: it counts toward the total but sits in `Pending`.
+	await pages.account.createTransaction({ amount: '42', category: categoryName, validated: false });
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(4200));
+	await expect(pages.account.balanceFigure('Pending')).toContainText(eur(4200));
+	await expect(pages.account.balanceFigure('Validated')).toContainText(eur(0));
+
+	// Validating moves it from pending to validated.
+	await pages.account.toggleValidated();
+	await expect(pages.account.balanceFigure('Validated')).toContainText(eur(4200));
+	await expect(pages.account.balanceFigure('Pending')).toContainText(eur(0));
+
+	// Editing the amount reflects in the total (validated stays on).
+	await pages.account.editTransaction({ amount: '99' });
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(9900));
+	await expect(pages.account.balanceFigure('Validated')).toContainText(eur(9900));
+
+	// Deleting it clears the balance back to zero.
+	await pages.account.deleteTransaction();
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(0));
+});
+
+test("Transfer updates the counterpart account's balance summary without reload", async ({
+	page,
+	pages
+}) => {
+	// The desktop side menu (the cross-account switcher used below) only mounts at
+	// the wide breakpoint; pin a desktop viewport so this runs the same way under
+	// the tablet project.
+	await page.setViewportSize({ height: 900, width: 1440 });
+
+	await pages.auth.createUserAndLogin();
+
+	const budgetName = faker.commerce.department();
+	await pages.budget.createBudget(budgetName);
+
+	const accountA = uniqueName(faker.finance.accountName());
+	const accountB = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountA, '100');
+	await pages.budget.createAccount(accountB, '50');
+
+	// Visit account B first so its balance queries are cached client-side; the
+	// bug is that a transfer created from another account fails to refresh this
+	// cached summary, so it stays stale.
+	await pages.account.switchToAccountViaSideMenu(accountB);
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(5000));
+
+	// Create the transfer while viewing account A. A positive amount arrives in
+	// the viewed account (A: 100 → 125) and the counterpart leg leaves B (50 → 25).
+	await pages.account.switchToAccountViaSideMenu(accountA);
+	await pages.account.createTransfer({ amount: '25', counterpartAccount: accountB });
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(12500));
+
+	// Return to B via browser back, which restores B's cached query instances
+	// rather than refetching them (a fresh navigation would refetch and mask the
+	// bug). B's summary must already reflect the counterpart leg.
+	await page.goBack();
+	await expect(page.getByRole('heading', { name: accountB })).toBeVisible();
+	await expect(pages.account.balanceFigure('Balance')).toContainText(eur(2500));
 });
 
 test("Transfer's counterpart leg shows in the other account without reload", async ({


### PR DESCRIPTION
## What & why

Fixes #310. After any transaction mutation that moves money, the account-balance figures at the top of the account page stayed stale until a manual reload.

The summary reads two queries — `getAccount` (the total) and `getAccountBalances` (the validated/pending split). Every mutation form declared only `listTransactions` in its client-side `.updates()`, so the server's `refreshAll()` for the balance queries was a silent no-op (per `docs/dev/remote-functions.md`) and the figures never updated.

## The fix

**Server** (`transaction.remote.ts`): a `refreshRegisters()` helper refreshes `listTransactions`, `getAccount`, and `getAccountBalances` together across all six mutations (create, edit, transfer create/edit, batch delete, batch validate).

**Client**: wired the balance queries into `.updates()` of all nine transaction components.
- Single-account paths (create modal + inline row, edit modal, table row, validate toggle) pass the instance `getAccount(accountId)` / `getAccountBalances(accountId)`, matching the account-creation pattern.
- Transfer paths (create/edit, modal + row) pass the bare query functions so **both legs'** balances refresh — the counterpart account updates too.

**Scope audit**: the only rendered account-balance display is the account-page summary. The side menu, mobile nav, and budget-settings account list show names only, so no other wiring was needed.

## Testing

- `npm run check` clean; `npm run lint` clean
- Unit: 667 passing (updated 3 component test mocks that now transitively load `account.remote`; strengthened the table-row test to assert the balance refreshes)
- E2E: 3 new Playwright tests — create, transfer (counterpart via `goBack` cached-instance path), and a validate → edit → delete sequence — each asserting the summary updates with no reload; full transaction spec green
