### PR TITLE
fix(invitations): refresh invitation list after accept/decline (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- The "You have an invitation" nav indicator now disappears immediately after
+  you accept or decline a budget invitation, instead of lingering until the
+  next navigation. Accepting also surfaces the newly-joined budget in the nav
+  without a reload.
 - Account balance figures now update immediately after any transaction change —
   creating, editing, transferring, and batch delete/validate — instead of
   staying stale until a manual page reload. Both accounts in a transfer refresh,

--- a/src/lib/remote-functions/budget.remote.ts
+++ b/src/lib/remote-functions/budget.remote.ts
@@ -39,6 +39,9 @@ export const removeUser = guardedForm(
 	async ({ budgetId, userId }, { ctx }) => {
 		ctx.budget.removeUser(budgetId, userId);
 		void getBudgetUsers(budgetId).refresh();
+		// Declining an invitation is a self-removal, so the nav's invitation
+		// indicator must drop the row too (see docs/dev/remote-functions.md).
+		void requested(getInvitations, REFRESH_LIMIT).refreshAll();
 	}
 );
 
@@ -82,8 +85,11 @@ export const reorderBudgets = guardedCommand(OrderedIdsSchema, async (orderedIds
 
 export const acceptInvite = guardedForm(BudgetAndUserIdSchema, async ({ budgetId }, { ctx }) => {
 	ctx.budget.acceptInvite(budgetId);
+	// Surface the newly-joined budget in the nav and drop the now-consumed
+	// invitation indicator, both without a manual reload.
 	void getBudgets().refresh();
 	void getBudget(budgetId).refresh();
+	void requested(getInvitations, REFRESH_LIMIT).refreshAll();
 });
 
 export const reassignment = guardedForm(ReassignmentSchema, async (data, { ctx }) => {

--- a/src/routes/(app)/invitation.svelte
+++ b/src/routes/(app)/invitation.svelte
@@ -4,7 +4,12 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as ResponsiveModal from '$lib/components/ui/responsive-modal';
 	import { m } from '$lib/paraglide/messages';
-	import { acceptInvite, getInvitations, removeUser } from '$lib/remote-functions/budget.remote';
+	import {
+		acceptInvite,
+		getBudgets,
+		getInvitations,
+		removeUser
+	} from '$lib/remote-functions/budget.remote';
 	import { getUser } from '$lib/remote-functions/user.remote';
 	import { createFormSubmit } from '$lib/utils/form-submit.svelte';
 	import { ParaglideMessage } from '@inlang/paraglide-js-svelte';
@@ -22,7 +27,10 @@
 		onSuccess: () => {
 			open = false;
 		},
-		toast: {}
+		toast: {},
+		// Drop the nav invitation indicator and surface the newly-joined budget,
+		// both without a reload (see docs/dev/remote-functions.md).
+		updates: () => [getInvitations(), getBudgets()]
 	});
 </script>
 
@@ -60,6 +68,7 @@
 				onSuccess={() => {
 					open = false;
 				}}
+				updates={() => [getInvitations()]}
 			>
 				{#snippet trigger(props)}
 					<Button {...props} variant="ghost">{m.invitation_decline_button()}</Button>

--- a/src/routes/(app)/invitation.svelte.test.ts
+++ b/src/routes/(app)/invitation.svelte.test.ts
@@ -1,0 +1,155 @@
+import { m } from '$lib/paraglide/messages';
+import { toasts } from '$lib/utils/anchored-toast.svelte';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+const remote = vi.hoisted(() => {
+	/**
+	 * A remote-form double: `enhance` plays submits through the component's
+	 * lifecycle, `fields` serves the template's field accessors, and every query
+	 * handed to `submit().updates(...)` is recorded in `updatedQueries` so a test
+	 * can assert which caches the mutation refreshes.
+	 */
+	function makeForm(fieldNames: readonly string[]) {
+		const updatedQueries: unknown[] = [];
+
+		const field = (name: string): Record<string, unknown> => ({
+			as: (type: string, value?: unknown) => ({ name, type, value })
+		});
+
+		const form = {
+			enhance: (callback: (instance: unknown) => Promise<void>) => ({
+				onsubmit: (event: SubmitEvent) => {
+					event.preventDefault();
+					void callback({
+						element: event.target as HTMLFormElement,
+						submit: () => {
+							const promise = Promise.resolve(true) as Promise<boolean> & {
+								updates: (...queries: unknown[]) => Promise<boolean>;
+							};
+							promise.updates = (...queries: unknown[]) => {
+								updatedQueries.push(...queries);
+								return promise;
+							};
+							return promise;
+						}
+					});
+				}
+			}),
+			fields: Object.fromEntries(fieldNames.map((name) => [name, field(name)])),
+			pending: 0
+		};
+
+		return { form, updatedQueries };
+	}
+
+	// Distinct sentinels so a test can tell the invitation list refresh apart
+	// from the budget list refresh in the recorded `updates(...)` arguments.
+	const invitationsQuery = { query: 'getInvitations' };
+	const budgetsQuery = { query: 'getBudgets' };
+
+	return {
+		acceptForm: makeForm(['budgetId', 'userId']),
+		budgetsQuery,
+		getBudgets: vi.fn(() => budgetsQuery),
+		getInvitations: vi.fn(() => invitationsQuery),
+		invitationsQuery,
+		removeForm: makeForm(['budgetId', 'userId'])
+	};
+});
+
+vi.mock('$lib/remote-functions/budget.remote', () => ({
+	acceptInvite: remote.acceptForm.form,
+	getBudgets: remote.getBudgets,
+	getInvitations: remote.getInvitations,
+	removeUser: remote.removeForm.form
+}));
+vi.mock('$lib/remote-functions/user.remote', () => ({
+	getUser: vi.fn(async () => ({ id: 'user-1' }))
+}));
+
+import Invitation from './invitation.svelte';
+
+// The modal renders as a Dialog above the desktop breakpoint; jsdom has no
+// matchMedia, so report "desktop" to exercise the Dialog variant.
+beforeAll(() => {
+	window.matchMedia = (query: string) =>
+		({
+			addEventListener: () => {},
+			matches: true,
+			media: query,
+			removeEventListener: () => {}
+		}) as unknown as MediaQueryList;
+
+	// jsdom lacks the Web Animations API the dialog's exit transition calls into;
+	// resolve `onfinish` immediately so closing outros settle.
+	Element.prototype.animate ??= function () {
+		const animation = { cancel() {}, finished: Promise.resolve() };
+		Object.defineProperty(animation, 'onfinish', {
+			configurable: true,
+			set: (cb: () => void) => queueMicrotask(cb)
+		});
+		return animation as unknown as Animation;
+	};
+});
+
+// Opening the modal makes bits-ui lock body scroll; unmounting schedules a
+// delayed cleanup that touches `document.body`. Unmount eagerly and wait past
+// the delay so the cleanup runs while document is alive.
+afterEach(async () => {
+	[...toasts].forEach((toast) => toast.dismiss());
+	cleanup();
+	await new Promise((resolve) => setTimeout(resolve, 50));
+});
+
+const invitation = {
+	budgetId: 'budget-1',
+	budgetName: 'Household',
+	inviterName: 'alice'
+};
+
+async function openModal() {
+	remote.acceptForm.updatedQueries.length = 0;
+	remote.removeForm.updatedQueries.length = 0;
+	remote.getInvitations.mockClear();
+	remote.getBudgets.mockClear();
+
+	render(Invitation, { props: { invitation } });
+
+	const trigger = await screen.findByRole('button', { name: m.invitation_button_label() });
+	await userEvent.click(trigger);
+	await screen.findByRole('button', { name: m.invitation_accept_button() });
+}
+
+describe('Invitation — cache refresh wiring', () => {
+	it('refreshes the invitation list and budget list when accepting', async () => {
+		await openModal();
+
+		await userEvent.click(screen.getByRole('button', { name: m.invitation_accept_button() }));
+
+		await waitFor(() =>
+			expect(remote.acceptForm.updatedQueries).toContain(remote.invitationsQuery)
+		);
+		// The newly-joined budget must appear in the nav without a reload, so the
+		// budget list refreshes alongside the invitation indicator.
+		expect(remote.acceptForm.updatedQueries).toContain(remote.budgetsQuery);
+	});
+
+	it('refreshes the invitation list when declining', async () => {
+		await openModal();
+
+		await userEvent.click(screen.getByRole('button', { name: m.invitation_decline_button() }));
+
+		const confirm = await screen.findByRole('alertdialog');
+		await userEvent.click(
+			within(confirm).getByRole('button', { name: m.invitation_decline_confirm_action() })
+		);
+
+		await waitFor(() =>
+			expect(remote.removeForm.updatedQueries).toContain(remote.invitationsQuery)
+		);
+		// Declining only clears the indicator; it never touches the budget list.
+		expect(remote.removeForm.updatedQueries).not.toContain(remote.budgetsQuery);
+	});
+});


### PR DESCRIPTION
## What & why

Fixes #314. After a user accepts or declines a budget invitation, the "You have an invitation" nav indicator lingered until the next navigation — the invitation mutations removed the row but never refreshed the `getInvitations` query.

## Changes

- **`budget.remote.ts`** — `removeUser` (decline) and `acceptInvite` now call `requested(getInvitations, REFRESH_LIMIT).refreshAll()`. Accept continues to refresh the budget list so the newly-joined budget appears in the nav.
- **`invitation.svelte`** — the accept form declares `.updates(() => [getInvitations(), getBudgets()])`; the decline `AlertDialogForm` declares `updates={() => [getInvitations()]}`. This follows the documented server-`refreshAll()` + client-`.updates()` pattern (same shape as #310), so the fix no longer relies on the `invalidateAll()` fallback.
- **`invitation.svelte.test.ts`** — new component test asserting accept chains both the invitation-list and budget-list refreshes into its submit, and decline chains only the invitation-list refresh.
- **`CHANGELOG.md`** — `Fixed` entry under `## [Unreleased]`.

## Acceptance criteria

- [x] Declining removes the nav indicator immediately, no reload.
- [x] Accepting removes the indicator and surfaces the newly-joined budget in the nav immediately.
- [x] Refresh follows the documented `refreshAll()` + `.updates()` pattern (no `invalidateAll()` fallback).
- [x] CHANGELOG `Fixed` entry added.

## Verification

`npm run check` (0 errors), `npm run lint` (clean), and the full unit suite (669 passed). Reviewed against the repo's coding standards and against the issue's acceptance criteria — both pass.
