### PR TITLE
fix(transactions): reset table filter/sort/page when switching accounts (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and dependency bumps get no entry.
 - The clear-all-filters button and the per-filter remove buttons on the
   transaction register now expose accessible names, so screen readers announce
   them instead of unlabelled buttons.
+- Switching to another account from the side menu now starts with a clean
+  transaction table — no leftover filter, sort, or pagination from the previous
+  account, and no stale query params in the URL. This includes switching to an
+  account in a different budget, whose filters previously carried over. Reloading
+  or deep-linking an account URL with those params still restores that state.
 
 ## [2026.07.6] - 2026-07-30
 

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -15,6 +15,7 @@
 	import { TransactionsURLParamsSchema } from '$lib/schemas/transaction';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
 	import { stickyParam } from '$lib/utils/sticky-param';
+	import { untrack } from 'svelte';
 	import * as v from 'valibot';
 	import GearSixIcon from '~icons/ph/gear-six';
 
@@ -65,7 +66,19 @@
 		return searchParams.toString();
 	}
 
-	const tableState = new TableState(parseURLParams(page.url));
+	// One table state per account. The route component is shared across all
+	// account pages and reused on navigation, so a single state object would carry
+	// account A's filters onto account B and the URL bridge below would stamp those
+	// stale params onto B's clean URL (#371). Rebuild it whenever the account
+	// changes. The intermediate derived only *changes value* on a real switch, so
+	// query-only navigations (in-page filter/sort/page changes) keep the instance
+	// instead of fighting the URL bridge. The URL is read untracked, so a full
+	// load or reload still hydrates from it (deep links).
+	const currentAccountId = $derived(accountId());
+	const tableState = $derived.by(() => {
+		const _accountId = currentAccountId;
+		return new TableState(untrack(() => parseURLParams(page.url)));
+	});
 
 	const result = $derived(await listTransactions({ accountId: accountId(), ...tableState.params }));
 

--- a/tests/playwright/pom/account.ts
+++ b/tests/playwright/pom/account.ts
@@ -21,6 +21,21 @@ type EditTransactionParams = {
 
 export class AccountPage extends BasePage {
 	/**
+	 * Adds a category filter through the filter dropdown and picks one category by
+	 * name. The multi-select listbox stays open after a pick, so Escape closes it.
+	 */
+	async applyCategoryFilter(categoryName: string) {
+		await this.page.getByRole('button', { name: 'Filter' }).click();
+		await this.page.getByRole('menuitem', { name: 'Category Filter' }).click();
+
+		await this.page.getByRole('button', { name: 'All Categories' }).click();
+		await this.page.getByRole('option', { name: categoryName }).click();
+		await this.page.keyboard.press('Escape');
+
+		await expect(this.categoryFilterTrigger()).toHaveText('1 selected');
+	}
+
+	/**
 	 * Adds a notes filter through the filter dropdown. The input debounces
 	 * before the list refreshes; callers assert on the resulting list state.
 	 */
@@ -56,6 +71,11 @@ export class AccountPage extends BasePage {
 		return this.page
 			.locator('div:has(> .font-currency)')
 			.filter({ has: this.page.getByText(label, { exact: true }) });
+	}
+
+	/** The category filter chip's multi-select trigger; absent until the filter is active. */
+	categoryFilterTrigger(): Locator {
+		return this.page.getByRole('button', { name: /^(All Categories|\d+ selected)$/ });
 	}
 
 	/** The filtered-empty state's clear-filters action. */

--- a/tests/playwright/pom/budget.ts
+++ b/tests/playwright/pom/budget.ts
@@ -102,6 +102,24 @@ export class BudgetPage extends BasePage {
 		await expect(this.page.getByRole('heading', { name: 'Add New Account' })).toBeHidden();
 	}
 
+	/**
+	 * Creates a further budget once the user already has one — the `/new` page
+	 * drops the "first budget" heading once a budget exists, so `createBudget`
+	 * (which asserts it) can't be reused.
+	 */
+	async createAdditionalBudget(name: string) {
+		await this.page.goto('/new');
+		await expect(this.page.getByRole('heading', { name: 'Create New Budget Plan' })).toBeVisible();
+
+		await this.page.getByRole('textbox', { name: 'Budget Name' }).fill(name);
+		await this.page.getByRole('button', { name: 'Create Budget' }).click();
+
+		await expect(this.page.getByRole('heading', { name })).toBeVisible();
+		this.ctx.budgetName = name;
+		this.ctx.budgetUrl = this.page.url();
+		this.ctx.budgetId = new URL(this.page.url()).pathname.split('/')[1];
+	}
+
 	async createBudget(name: string) {
 		await this.page.goto('/new');
 		await expect(

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -379,3 +379,53 @@ test('Sort Transactions', async ({ page, pages }) => {
 	// Since we only have 3, just verify page param is absent (defaults to 1)
 	await expect(page).not.toHaveURL(/page=/);
 });
+
+test('Filter state does not persist when switching accounts (#371)', async ({ page, pages }) => {
+	// The desktop side menu (the cross-account switcher used below) only mounts at
+	// the wide breakpoint; pin a desktop viewport so this runs the same way under
+	// the tablet project.
+	await page.setViewportSize({ height: 900, width: 1440 });
+
+	await pages.auth.createUserAndLogin();
+
+	// Budget one: two accounts (same-budget switch) plus a category to filter by.
+	const budgetOne = faker.commerce.department();
+	await pages.budget.createBudget(budgetOne);
+	const accountA = uniqueName(faker.finance.accountName());
+	const accountAsibling = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountA);
+	await pages.budget.createAccount(accountAsibling);
+	const category = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(category);
+
+	// Budget two: a single account in a different budget (cross-budget switch).
+	const budgetTwo = faker.commerce.department();
+	await pages.budget.createAdditionalBudget(budgetTwo);
+	const accountB = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(accountB);
+
+	await pages.account.goto(accountA);
+	await pages.account.applyCategoryFilter(category);
+	await expect(page).toHaveURL(/categoryId=/);
+
+	// Deep-link behaviour is unchanged: reloading the filtered URL restores it.
+	await page.reload();
+	await expect(page).toHaveURL(/categoryId=/);
+	await expect(pages.account.categoryFilterTrigger()).toHaveText('1 selected');
+
+	// Switching to another account in the same budget starts clean: no table
+	// query params in the URL and no active filter chip.
+	await pages.account.switchToAccountViaSideMenu(accountAsibling);
+	await expect(page).toHaveURL(/^[^?]*$/);
+	await expect(pages.account.categoryFilterTrigger()).toHaveCount(0);
+
+	// Re-filter A, then switch to an account in a *different* budget — the foreign
+	// category id must not leak onto its URL or into its filter UI.
+	await pages.account.goto(accountA);
+	await pages.account.applyCategoryFilter(category);
+	await expect(page).toHaveURL(/categoryId=/);
+
+	await pages.account.switchToAccountViaSideMenu(accountB);
+	await expect(page).toHaveURL(/^[^?]*$/);
+	await expect(pages.account.categoryFilterTrigger()).toHaveCount(0);
+});


### PR DESCRIPTION
## What & why

Fixes #371. The transaction table's filter, sort, and pagination state leaked across account pages: all account pages share one route component that SvelteKit reuses on navigation, so the single `TableState` created at mount survived an account switch. The URL-bridge effect then stamped the previous account's params onto the new account's clean URL — including category ids belonging to a **foreign budget**.

## Change

Rebuild `TableState` whenever the account actually changes:

- An intermediate `$derived` of the account id recomputes on every navigation but only *changes value* on a real switch, so Svelte skips notifying the state derived on the query-only navigations that in-page filter/sort/page changes perform. Rebuilding there would fight the URL bridge (and reset the very interaction that triggered it).
- The URL is read `untrack`ed, so a full load or reload still hydrates from it — deep links and reloads keep restoring state for the same account.

## Behaviour

- Switching to another account (same or different budget) via the side menu starts clean: no filter/sort/pagination query params in the URL, empty filter UI.
- In-page filtering, sorting, and paging keep updating the URL as before.
- Reloading/deep-linking an account URL with params still restores that state.

## Tests

Adds a Playwright regression test covering same-budget and cross-budget switches plus deep-link restore. New page-object helpers: `applyCategoryFilter` and `categoryFilterTrigger` on the account POM, and `createAdditionalBudget` on the budget POM. Verified the test fails without the fix (foreign `categoryId` leaks onto the new URL) and passes with it, under both the `chromium` and `tablet` projects. Full unit suite (669) and the transaction e2e spec pass; `npm run check` and `npm run lint` are clean.
