### PR TITLE
fix(transactions): drop category filter ids foreign to the current budget (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and dependency bumps get no entry.
   account, and no stale query params in the URL. This includes switching to an
   account in a different budget, whose filters previously carried over. Reloading
   or deep-linking an account URL with those params still restores that state.
+- The transaction register now discards `categoryId` filter values that don't
+  belong to the current budget (foreign or deleted categories) when an account
+  page loads from a bookmark, shared link, or history. Such ids no longer appear
+  in the filter, ride along in the URL, or reach the query; valid ids and the
+  unassigned/transfer filters keep working.
 
 ## [2026.07.6] - 2026-07-30
 

--- a/src/lib/components/features/transaction/index.ts
+++ b/src/lib/components/features/transaction/index.ts
@@ -1,3 +1,4 @@
+export { pruneForeignCategoryIds } from './transaction-filter.svelte';
 export { default as TransactionTableRowCreate } from './transaction-table-row-create.svelte';
 export { type TableParams, TableState } from './transaction-table-state.svelte';
 export { default as TransactionTable } from './transaction-table.svelte';

--- a/src/lib/components/features/transaction/transaction-filter.svelte.test.ts
+++ b/src/lib/components/features/transaction/transaction-filter.svelte.test.ts
@@ -1,8 +1,9 @@
+import { TRANSFER, UNASSIGNED } from '$lib/constants';
 import { TransactionsURLParamsSchema } from '$lib/schemas/transaction';
 import { parse } from 'valibot';
 import { describe, expect, it } from 'vitest';
 
-import { TransactionFilter } from './transaction-filter.svelte';
+import { pruneForeignCategoryIds, TransactionFilter } from './transaction-filter.svelte';
 
 function params(input: Record<string, unknown> = {}) {
 	return parse(TransactionsURLParamsSchema, input);
@@ -85,5 +86,40 @@ describe('TransactionFilter', () => {
 		filter.clearAll();
 
 		expect(filter.anyActive).toBe(false);
+	});
+});
+
+describe('pruneForeignCategoryIds', () => {
+	it('keeps IDs that belong to the current budget', () => {
+		expect(pruneForeignCategoryIds(['cat-1', 'cat-2'], ['cat-1', 'cat-2', 'cat-3'])).toEqual([
+			'cat-1',
+			'cat-2'
+		]);
+	});
+
+	it('drops IDs that are foreign to the budget or deleted', () => {
+		expect(pruneForeignCategoryIds(['cat-1', 'foreign', 'gone'], ['cat-1', 'cat-2'])).toEqual([
+			'cat-1'
+		]);
+	});
+
+	it('keeps the unassigned and transfer sentinels regardless of the budget set', () => {
+		expect(pruneForeignCategoryIds([UNASSIGNED, TRANSFER], [])).toEqual([UNASSIGNED, TRANSFER]);
+	});
+
+	it('keeps valid IDs and sentinels while dropping foreign IDs, preserving order', () => {
+		expect(pruneForeignCategoryIds([UNASSIGNED, 'foreign', 'cat-1', TRANSFER], ['cat-1'])).toEqual([
+			UNASSIGNED,
+			'cat-1',
+			TRANSFER
+		]);
+	});
+
+	it('returns an empty array when every ID is foreign', () => {
+		expect(pruneForeignCategoryIds(['foreign-1', 'foreign-2'], ['cat-1'])).toEqual([]);
+	});
+
+	it('accepts a Set as the budget category source', () => {
+		expect(pruneForeignCategoryIds(['cat-1', 'foreign'], new Set(['cat-1']))).toEqual(['cat-1']);
 	});
 });

--- a/src/lib/components/features/transaction/transaction-filter.svelte.ts
+++ b/src/lib/components/features/transaction/transaction-filter.svelte.ts
@@ -1,5 +1,6 @@
 import type { TransactionsURLParams } from '$lib/schemas/transaction';
 
+import { TRANSFER, UNASSIGNED } from '$lib/constants';
 import { m } from '$lib/paraglide/messages';
 
 export type CategoryFilter = {
@@ -86,4 +87,17 @@ export class TransactionFilter {
 		const f = this.items.find((f) => f.type === type)!;
 		(f.value as string | string[]) = value;
 	}
+}
+
+/**
+ * Drops category IDs not in the budget's own set — foreign or deleted categories —
+ * while keeping the unassigned/transfer sentinels. Order is preserved (#372).
+ */
+export function pruneForeignCategoryIds(
+	ids: string[],
+	budgetCategoryIds: Iterable<string>
+): string[] {
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity -- pure lookup Set, not reactive state
+	const known = new Set(budgetCategoryIds);
+	return ids.filter((id) => id === UNASSIGNED || id === TRANSFER || known.has(id));
 }

--- a/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
+++ b/src/routes/(app)/[budgetId=id]/accounts/[accountId=id]/+page.svelte
@@ -5,12 +5,17 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { AccountArchivedNotice, AccountBalances } from '$lib/components/features/account';
-	import { TableState, TransactionTable } from '$lib/components/features/transaction';
+	import {
+		pruneForeignCategoryIds,
+		TableState,
+		TransactionTable
+	} from '$lib/components/features/transaction';
 	import { Button } from '$lib/components/ui/button';
 	import * as Page from '$lib/components/ui/page';
 	import { m } from '$lib/paraglide/messages';
 	import { getAccount, getAccountBalances } from '$lib/remote-functions/account.remote';
 	import { getBudget } from '$lib/remote-functions/budget.remote';
+	import { getCategories } from '$lib/remote-functions/category.remote';
 	import { listTransactions } from '$lib/remote-functions/transaction.remote';
 	import { TransactionsURLParamsSchema } from '$lib/schemas/transaction';
 	import { getBudgetId } from '$lib/utils/budget-id-context';
@@ -66,6 +71,12 @@
 		return searchParams.toString();
 	}
 
+	// Read tracked so filter hydration waits for the list; it is stable per budget,
+	// so pruning adds no table rebuild beyond the account switch below (#371/#372).
+	const knownCategoryIds = $derived(
+		new Set((await getCategories({ budgetId: budgetId() })).map((c) => c.id))
+	);
+
 	// One table state per account. The route component is shared across all
 	// account pages and reused on navigation, so a single state object would carry
 	// account A's filters onto account B and the URL bridge below would stamp those
@@ -77,7 +88,9 @@
 	const currentAccountId = $derived(accountId());
 	const tableState = $derived.by(() => {
 		const _accountId = currentAccountId;
-		return new TableState(untrack(() => parseURLParams(page.url)));
+		const params = untrack(() => parseURLParams(page.url));
+		params.categoryId = pruneForeignCategoryIds(params.categoryId, knownCategoryIds);
+		return new TableState(params);
 	});
 
 	const result = $derived(await listTransactions({ accountId: accountId(), ...tableState.params }));

--- a/tests/playwright/transaction.spec.ts
+++ b/tests/playwright/transaction.spec.ts
@@ -429,3 +429,65 @@ test('Filter state does not persist when switching accounts (#371)', async ({ pa
 	await expect(page).toHaveURL(/^[^?]*$/);
 	await expect(pages.account.categoryFilterTrigger()).toHaveCount(0);
 });
+
+test('Deep link drops category filter ids foreign to the budget (#372)', async ({
+	page,
+	pages
+}) => {
+	// The filter dropdown used to capture real category ids lives in the desktop
+	// register; pin a desktop viewport so this runs the same way under tablet.
+	await page.setViewportSize({ height: 900, width: 1440 });
+
+	await pages.auth.createUserAndLogin();
+
+	// Budget one owns the account we deep-link into and one valid category.
+	const budgetOne = faker.commerce.department();
+	await pages.budget.createBudget(budgetOne);
+	const account = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(account);
+	const ownCategory = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(ownCategory);
+
+	// Budget two owns a category that is foreign to budget one's account.
+	const budgetTwo = faker.commerce.department();
+	await pages.budget.createAdditionalBudget(budgetTwo);
+	const foreignAccount = uniqueName(faker.finance.accountName());
+	await pages.budget.createAccount(foreignAccount);
+	const foreignCategory = uniqueName(faker.commerce.department());
+	await pages.budget.createCategory(foreignCategory);
+
+	// Capture the foreign budget's real category id by filtering with it and
+	// reading it back off the URL.
+	await pages.account.goto(foreignAccount);
+	await pages.account.applyCategoryFilter(foreignCategory);
+	await expect(page).toHaveURL(/categoryId=/);
+	const foreignId = new URL(page.url()).searchParams.get('categoryId')!;
+
+	// Capture budget one's own category id the same way, and remember the
+	// account's base path for the deep links below.
+	await pages.account.goto(account);
+	const accountPath = new URL(page.url()).pathname;
+	await pages.account.applyCategoryFilter(ownCategory);
+	await expect(page).toHaveURL(/categoryId=/);
+	const ownId = new URL(page.url()).searchParams.get('categoryId')!;
+
+	// A foreign-only deep link normalizes to a clean URL with no active filter.
+	await page.goto(`${accountPath}?categoryId=${foreignId}`);
+	await expect(page.getByRole('heading', { name: account })).toBeVisible();
+	await expect(page).toHaveURL(/^[^?]*$/);
+	await expect(pages.account.categoryFilterTrigger()).toHaveCount(0);
+
+	// A mixed deep link keeps the budget's own id and drops only the foreign one.
+	await page.goto(`${accountPath}?categoryId=${ownId}&categoryId=${foreignId}`);
+	await expect(page.getByRole('heading', { name: account })).toBeVisible();
+	await expect(pages.account.categoryFilterTrigger()).toHaveText('1 selected');
+	await expect.poll(() => new URL(page.url()).searchParams.getAll('categoryId')).toEqual([ownId]);
+
+	// The unassigned sentinel is budget-agnostic and survives the deep link.
+	await page.goto(`${accountPath}?categoryId=__none__`);
+	await expect(page.getByRole('heading', { name: account })).toBeVisible();
+	await expect(pages.account.categoryFilterTrigger()).toHaveText('1 selected');
+	await expect
+		.poll(() => new URL(page.url()).searchParams.getAll('categoryId'))
+		.toEqual(['__none__']);
+});


### PR DESCRIPTION
## What & why

Fixes #372. A `categoryId` query param whose id belongs to **another budget** or a **deleted category** used to survive filter hydration on the transaction register: the filter badge counted it, the URL kept carrying it, and the server query filtered on an id that can never match. Such URLs arrive via bookmarks, browser history, shared links, or the #371 navigation leak.

## Change

Prune the parsed `categoryId` list against the current budget's own category ids — keeping the `__none__` (unassigned) and `__transfer__` sentinels — before it hydrates the table state. Foreign or deleted ids therefore never reach the filter UI, the URL, or the transaction query; valid ids in a mixed URL keep filtering.

- New pure seam `pruneForeignCategoryIds(ids, budgetCategoryIds)` in `transaction-filter.svelte.ts` (barrel-exported), unit-tested in isolation.
- The account page reads the budget's category ids as a tracked awaited `$derived`, so hydration waits for the list. In practice the list is stable per budget, so this adds no table rebuild beyond the account switch that #371 already handles — the URL is still read `untrack`ed, so deep links and reloads keep restoring state.

## Behaviour

- A foreign-only deep link normalizes to a clean URL with an empty category filter (badge count 0).
- A mixed valid+foreign deep link keeps the valid ids filtering and drops only the foreign ones.
- The unassigned/transfer sentinel filters continue to work.

## Tests

- Unit: `pruneForeignCategoryIds` — valid/foreign/deleted/sentinel/mixed/Set-input cases.
- Playwright: a deep-link regression covering foreign-only, mixed valid+foreign, and sentinel URLs, capturing a **real** foreign-budget category id and asserting URL normalization plus the filter badge. Runs under both `chromium` and `tablet`.

Full unit suite (675) and the transaction e2e spec (14) pass; `npm run check` and `npm run lint` are clean.
