### PR TITLE
fix(admin): reopen generated-password modal for every reveal (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and dependency bumps get no entry.
   be found." message with no Error ID, instead of the generic "An unexpected
   error occurred." copy and a meaningless lookup id. Genuine unexpected errors
   still show the generic message and an Error ID.
+- The admin generated-password modal now reopens for every password reset. Once
+  a user had been created (or any password revealed) in the same page visit, a
+  subsequent reset changed the password server-side but never showed it, leaving
+  the admin unable to see the new password and the user locked out. Each reveal
+  — user creation and every reset — now opens the modal with its own freshly
+  generated password.
 - Several interface strings that were still hardcoded English now translate:
   the admin page's "Danger Zone" heading and "Reset Instance" button, the mobile
   navigation toggle, and the accessible labels on the users list, generated

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -30,21 +30,24 @@
 
 	const admin = $derived(await getUser());
 
-	const createUserSubmit = createFormSubmit(() => createUser, {
-		onSuccess: (form) => form.element.reset(),
-		toast: {}
-	});
-
 	let openDialog = $state(false);
 	let openAlertDialog = $state(false);
 	let selectedUserId = $state('');
-	let resetPassword = $state<string>();
-	let generatedPassword = $derived(createUser.result?.password ?? resetPassword);
+	// Single source each reveal handler assigns directly, so a later reveal is
+	// never masked by an earlier result the way a two-source derive was (#362).
+	let generatedPassword = $state<string>();
 
-	$effect(() => {
-		if (generatedPassword) {
-			openDialog = true;
-		}
+	const revealPassword = (password: string) => {
+		generatedPassword = password;
+		openDialog = true;
+	};
+
+	const createUserSubmit = createFormSubmit(() => createUser, {
+		onSuccess: (form) => {
+			form.element.reset();
+			if (createUser.result?.password) revealPassword(createUser.result.password);
+		},
+		toast: {}
 	});
 
 	const resetForm = (userId: string) =>
@@ -115,10 +118,7 @@
 							{:else}
 								<!-- Persistent form outside the portalled menu, so its submit
 								     lifecycle survives the menu closing on select. -->
-								<ResetPasswordForm
-									userId={user.id}
-									onReset={(newPassword) => (resetPassword = newPassword)}
-								/>
+								<ResetPasswordForm userId={user.id} onReset={revealPassword} />
 
 								<DropdownMenu.Root>
 									<DropdownMenu.Trigger

--- a/tests/playwright/admin.spec.ts
+++ b/tests/playwright/admin.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { test } from './fixture';
 
 test('Create User', async ({ pages }) => {
@@ -8,4 +10,21 @@ test('Delete User', async ({ pages }) => {
 	await pages.auth.login(...pages.auth.admin);
 	const [username] = await pages.auth.createUser();
 	await pages.admin.deleteUser(username);
+});
+
+// #362: after an earlier reveal (user creation) the old code masked the reset
+// behind the create result, so the modal never reopened and the user was
+// locked out. Each reset must reopen it with its own distinct new password.
+test('Reset Password reopens the modal after an earlier reveal', async ({ pages }) => {
+	await pages.auth.login(...pages.auth.admin);
+	const [username, createdPassword] = await pages.auth.createUser();
+
+	const firstReset = await pages.admin.resetPassword(username);
+	expect(firstReset).not.toBe(createdPassword);
+
+	const secondReset = await pages.admin.resetPassword(username);
+	expect(secondReset).not.toBe(firstReset);
+
+	await pages.auth.signout();
+	await pages.auth.login(username, secondReset);
 });

--- a/tests/playwright/pom/admin.ts
+++ b/tests/playwright/pom/admin.ts
@@ -31,4 +31,30 @@ export class AdminPage extends BasePage {
 
 		await this.page.waitForURL('/login/first');
 	}
+
+	/**
+	 * Reset a user's password via the row's ⋮ menu and return the new password
+	 * revealed in the modal. Deliberately does NOT navigate — it runs on the
+	 * current `/admin` visit so it can chain after an earlier reveal, the
+	 * same-visit condition that regressed in #362.
+	 */
+	async resetPassword(username: string) {
+		const row = this.page.getByRole('listitem').filter({ hasText: username });
+		await row.getByRole('button', { name: 'User actions' }).click();
+		await this.page.getByRole('menuitem', { name: 'Reset Password' }).click();
+
+		const passwordLocator = this.page.getByLabel('Generated password', { exact: true });
+		await expect(passwordLocator).toBeVisible();
+
+		// Read before closing: the dialog unmounts on close (instantly under the
+		// reduced-motion e2e context), so the locator is gone afterwards.
+		const password = await passwordLocator.textContent();
+
+		await this.page.getByRole('button', { name: 'Close' }).first().click();
+		await expect(passwordLocator).toBeHidden();
+
+		if (!password) throw new Error('Could not read reset password');
+
+		return password;
+	}
 }


### PR DESCRIPTION
Fixes #362.

## Problem

The admin page derived the shown password from two sources:

```svelte
let generatedPassword = $derived(createUser.result?.password ?? resetPassword);
$effect(() => { if (generatedPassword) openDialog = true; });
```

Once a user was created, `createUser.result` stayed populated, so `??` permanently masked `resetPassword`. A subsequent **Reset Password** changed the password server-side (200) but never changed `generatedPassword`, so the open-modal `$effect` never re-fired — the admin never saw the new password and the target user was locked out. It also affected two consecutive resets in one page visit after any earlier reveal.

## Fix

Replace the two-source derived value with a single `generatedPassword` state that each success handler assigns through one helper, opening the modal directly:

```svelte
let generatedPassword = $state<string>();
const revealPassword = (password: string) => {
	generatedPassword = password;
	openDialog = true;
};
```

- `createUserSubmit.onSuccess` → `revealPassword(createUser.result.password)`
- `ResetPasswordForm`'s `onReset` callback → `revealPassword`

A stale prior result can no longer mask a new reveal, in any order.

## Testing

- New e2e regression test: create user → reset → reset within one page visit, asserting each modal opens with a distinct password and the latest one authenticates. Verified it fails against the pre-fix code (modal never appears) and passes with the fix.
- `npm run check` and `npm run lint` clean.
- Full suites pass: 675 unit tests, 136 e2e tests.

## Acceptance criteria

- [x] Creating a user opens the modal with the generated password (existing behavior preserved).
- [x] After creating a user, resetting any user's password opens the modal showing that reset's new password.
- [x] Two consecutive resets in one page visit each open the modal with the correct, distinct new password.
- [x] The password displayed and the value copied always match the most recent reveal event.
- [x] Closing the modal and triggering a new reveal reopens it.
