### PR TITLE
test(e2e): fix flaky theme-toggle click swallowed before hydration (#350)

### DIFF
--- a/tests/playwright/pom/settings.ts
+++ b/tests/playwright/pom/settings.ts
@@ -80,6 +80,24 @@ export class SettingsPage extends BasePage {
 
 	async setTheme(label: 'Dark' | 'Light' | 'System') {
 		// A single-type toggle group exposes its items as radios.
-		await this.page.getByRole('radio', { exact: true, name: label }).click();
+		const radio = this.page.getByRole('radio', { exact: true, name: label });
+		const html = this.page.locator('html');
+
+		// The theme is applied entirely client-side: the change handler toggles
+		// the `dark`/`light` class only after Svelte hydration attaches its
+		// listener. A click that lands in the paint→hydration window hits the DOM
+		// node but fires no handler, so the class is never set. Re-click until the
+		// effect actually lands rather than trusting a single (possibly swallowed)
+		// click. `toPass` retries the click+assert without a fixed sleep.
+		await expect(async () => {
+			await radio.click();
+			if (label === 'System') {
+				await expect(html).not.toHaveClass(/dark|light/, { timeout: 1000 });
+			} else {
+				await expect(html).toHaveClass(label === 'Dark' ? /dark/ : /light/, {
+					timeout: 1000
+				});
+			}
+		}).toPass({ timeout: 10_000 });
 	}
 }


### PR DESCRIPTION
Fixes #350.

The theme control applies the `dark`/`light` class entirely client-side, in a
change handler that only runs once Svelte hydration attaches its listener. The
`setTheme` page-object helper clicked the radio once with no wait, so a click
landing in the paint→hydration window hit the DOM node but fired no handler:
the class was never set and the "Change Theme applies instantly and persists
across a reload" e2e test waited out its timeout against `<html class="">`.

## Fix

Wrap the click in `expect(...).toPass()`: each attempt clicks the radio, then
asserts the resulting class effect on `<html>`, retrying the whole block if it
hasn't landed. Condition-based (no fixed sleep). Test-side only — the theme
control's runtime behaviour is unchanged.

## Verification

- `npm run check` — clean.
- Theme test under `--repeat-each=20` across chromium + tablet: 42 passed, 0 failures.
- Full `npm run test:e2e`: green apart from a pre-existing, unrelated auth-POM
  flake (confirmed independent by an isolated 3/3 re-run).