### PR TITLE
fix(responsive-modal): preserve form state across the 640px boundary (#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and dependency bumps get no entry.
 
 ### Fixed
 
+- Rotating a phone across the tablet breakpoint while a modal (e.g. Budget
+  Settings) is open no longer wipes out text you were typing. The modal now
+  keeps its current drawer/dialog layout until you close it, so unsaved form
+  input survives the rotation.
 - Navigating to a nonexistent route now shows a localized "This page could not
   be found." message with no Error ID, instead of the generic "An unexpected
   error occurred." copy and a meaningless lookup id. Genuine unexpected errors

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -29,11 +29,8 @@
 
 	const media = new MediaQuery(DESKTOP_QUERY, true);
 
-	// The chrome variant is frozen for the lifetime of an open modal: while
-	// `open`, we stop tracking the media query so crossing the 640px breakpoint
-	// mid-edit doesn't flip the `{#if}` and remount the slotted content (which
-	// would discard component-local form state — #363). While closed, we keep
-	// syncing so the next open picks the correct variant for the viewport.
+	// Freeze the variant while open so crossing the breakpoint mid-edit doesn't
+	// flip the `{#if}` and remount the slotted content, discarding form state (#363).
 	let isDesktop = $state(media.matches);
 	$effect(() => {
 		if (!open) isDesktop = media.matches;

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte
@@ -29,6 +29,16 @@
 
 	const media = new MediaQuery(DESKTOP_QUERY, true);
 
+	// The chrome variant is frozen for the lifetime of an open modal: while
+	// `open`, we stop tracking the media query so crossing the 640px breakpoint
+	// mid-edit doesn't flip the `{#if}` and remount the slotted content (which
+	// would discard component-local form state — #363). While closed, we keep
+	// syncing so the next open picks the correct variant for the viewport.
+	let isDesktop = $state(media.matches);
+	$effect(() => {
+		if (!open) isDesktop = media.matches;
+	});
+
 	setResponsiveModalContext({
 		close() {
 			open = false;
@@ -37,12 +47,12 @@
 			return dismissible;
 		},
 		get isDesktop() {
-			return media.matches;
+			return isDesktop;
 		}
 	});
 </script>
 
-{#if media.matches}
+{#if isDesktop}
 	<Dialog.Root bind:open {onOpenChangeComplete}>
 		{@render children?.()}
 	</Dialog.Root>

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
@@ -57,9 +57,8 @@ describe('ResponsiveModal drawer variant — dismissible (default)', () => {
 });
 
 describe('ResponsiveModal — breakpoint flip while open', () => {
-	// A controllable matchMedia so a test can flip the query mid-render, the way a
-	// phone rotation crosses the 640px boundary. Returns one MediaQueryList per
-	// call whose `matches` the test can toggle and then notify listeners about.
+	// A controllable matchMedia whose `matches` a test can flip mid-render, the
+	// way a phone rotation crosses the 640px boundary.
 	function installMatchMedia(initialMatches: boolean) {
 		let matches = initialMatches;
 		const listeners = new Set<() => void>();
@@ -96,8 +95,7 @@ describe('ResponsiveModal — breakpoint flip while open', () => {
 		mql.flip(true);
 		await tick();
 
-		// The modal stays open and the slotted content is not remounted, so the
-		// typed value survives the drawer↔dialog swap (#363).
+		// Modal stays open, content isn't remounted, typed value survives (#363).
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
 		expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Household EDITED');
 	});

--- a/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.svelte.test.ts
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import Fixture from './responsive-modal.test-fixture.svelte';
@@ -52,5 +53,68 @@ describe('ResponsiveModal drawer variant — dismissible (default)', () => {
 		await fireEvent.click(closeButton);
 
 		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+});
+
+describe('ResponsiveModal — breakpoint flip while open', () => {
+	// A controllable matchMedia so a test can flip the query mid-render, the way a
+	// phone rotation crosses the 640px boundary. Returns one MediaQueryList per
+	// call whose `matches` the test can toggle and then notify listeners about.
+	function installMatchMedia(initialMatches: boolean) {
+		let matches = initialMatches;
+		const listeners = new Set<() => void>();
+
+		window.matchMedia = ((media: string) =>
+			({
+				addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+				get matches() {
+					return matches;
+				},
+				media,
+				removeEventListener: (_: string, cb: () => void) => listeners.delete(cb)
+			}) as unknown as MediaQueryList) as typeof window.matchMedia;
+
+		return {
+			flip(next: boolean) {
+				matches = next;
+				listeners.forEach((cb) => cb());
+			}
+		};
+	}
+
+	it('keeps typed form state when the viewport crosses the breakpoint', async () => {
+		// Open below the breakpoint (Drawer variant).
+		const mql = installMatchMedia(false);
+		render(Fixture, { props: { open: true } });
+
+		const input = (await screen.findByLabelText('Name')) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'Household EDITED' } });
+		expect(input.value).toBe('Household EDITED');
+
+		// Rotate to landscape: the query now matches the desktop breakpoint.
+		await fireEvent(window, new Event('resize'));
+		mql.flip(true);
+		await tick();
+
+		// The modal stays open and the slotted content is not remounted, so the
+		// typed value survives the drawer↔dialog swap (#363).
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Household EDITED');
+	});
+
+	it('keeps typed form state crossing the breakpoint the other way', async () => {
+		// Open above the breakpoint (Dialog variant), then rotate to portrait.
+		const mql = installMatchMedia(true);
+		render(Fixture, { props: { open: true } });
+
+		const input = (await screen.findByLabelText('Name')) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'Household EDITED' } });
+
+		await fireEvent(window, new Event('resize'));
+		mql.flip(false);
+		await tick();
+
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Household EDITED');
 	});
 });

--- a/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture-field.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture-field.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	// Component-scoped state, standing in for unsaved form input. A breakpoint
+	// flip that remounts the slotted content destroys this component and resets
+	// the value — the regression #363 guards against.
+	let value = $state('');
+</script>
+
+<label>
+	Name
+	<input bind:value />
+</label>

--- a/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture-field.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture-field.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	// Component-scoped state, standing in for unsaved form input. A breakpoint
-	// flip that remounts the slotted content destroys this component and resets
-	// the value — the regression #363 guards against.
+	// Component-scoped state standing in for unsaved form input: a remount would
+	// reset it, which is the regression #363 guards against.
 	let value = $state('');
 </script>
 

--- a/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture.svelte
+++ b/src/lib/components/ui/responsive-modal/responsive-modal.test-fixture.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as ResponsiveModal from './index';
+	import Field from './responsive-modal.test-fixture-field.svelte';
 
 	let {
 		dismissible = true,
@@ -16,6 +17,8 @@
 			<ResponsiveModal.Title>Manage users</ResponsiveModal.Title>
 			<ResponsiveModal.Description>People with access.</ResponsiveModal.Description>
 		</ResponsiveModal.Header>
+
+		<Field />
 
 		<ResponsiveModal.Footer>
 			<ResponsiveModal.Close>Close</ResponsiveModal.Close>


### PR DESCRIPTION
## What & why

Fixes #363. Rotating a phone across the 640px breakpoint while a `ResponsiveModal` was open wiped out unsaved form input (verified live: a Budget Settings field edited to a new value reverted on rotation).

The shell rendered its Dialog and Drawer variants as two separate `{#if}` subtrees keyed on a live `min-width: 640px` media query. Crossing the breakpoint while open flipped the branch, which remounted the slotted content and destroyed its component-local state.

## Approach

Freeze the chrome variant for the lifetime of an open modal:

- while `open`, stop tracking the media query so the `{#if}` never flips — no remount, so unsaved input survives the crossing;
- while closed, resume syncing so the next open picks the correct variant for the current viewport.

This is a deliberate scope choice over the portal/teleport restructure the triage brief speculated about: the acceptance criteria require state retention, not live chrome-swapping mid-open. Trade-off: a modal opened as a drawer stays a drawer until closed even if the viewport crosses 640px (and vice-versa) — preferable to swapping chrome out from under an active edit. Escape/dismiss parity and the `ResponsiveModalContext` contract are untouched, so every consumer keeps working.

## Acceptance criteria

- [x] Typed value survives crossing 640px in either direction
- [x] Modal stays open across the crossing
- [x] Escape/dismiss behaviour unchanged for both variants (`dismissible` true/false)
- [x] Existing consumers render and function unchanged at both breakpoints
- [x] Existing component tests pass; added coverage for state retention across a simulated breakpoint flip

## Testing

- New tests simulate a breakpoint flip in both directions with a component-scoped form field; confirmed failing before the fix, passing after.
- `npm run check` — 0 errors
- `npm run lint` — clean
- `npm run test:unit` — 679 passed

Closes #363
