### PR TITLE
fix(security): resolve CodeQL biased-random and regex-escape alerts

### DIFF
--- a/src/lib/server/db/auth/user.ts
+++ b/src/lib/server/db/auth/user.ts
@@ -142,13 +142,30 @@ export function setUsername({
 /**
  * Generates a random password that satisfies `PasswordSchema` by construction:
  * 16 characters (within the 8–20 bounds) ending in a guaranteed digit and
- * special character, from the same crypto-random source as `createSessionToken`.
+ * special character, each drawn uniformly via `randomIndex`.
  */
 function generatePassword() {
 	const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
-	const bytes = crypto.getRandomValues(new Uint8Array(16));
-	const body = Array.from(bytes.subarray(0, 14), (byte) => alphabet[byte % alphabet.length]);
-	const digit = '0123456789'[bytes[14] % 10];
-	const special = '!@#$%^&*?'[bytes[15] % 9];
+	const digits = '0123456789';
+	const specials = '!@#$%^&*?';
+	const body = Array.from({ length: 14 }, () => alphabet[randomIndex(alphabet.length)]);
+	const digit = digits[randomIndex(digits.length)];
+	const special = specials[randomIndex(specials.length)];
 	return body.join('') + digit + special;
+}
+
+/**
+ * Returns an unbiased integer in `[0, max)` drawn from the same crypto-random
+ * source as `createSessionToken`. Plain `randomByte % max` skews toward the low
+ * end whenever `max` does not divide 256 evenly, so bytes in the biased tail are
+ * rejected and re-rolled (rejection sampling) before the modulo is taken.
+ */
+function randomIndex(max: number): number {
+	const limit = 256 - (256 % max);
+	const buffer = new Uint8Array(1);
+	let byte: number;
+	do {
+		byte = crypto.getRandomValues(buffer)[0];
+	} while (byte >= limit);
+	return byte % max;
 }

--- a/src/lib/server/db/auth/user.ts
+++ b/src/lib/server/db/auth/user.ts
@@ -148,10 +148,10 @@ function generatePassword() {
 	const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
 	const digits = '0123456789';
 	const specials = '!@#$%^&*?';
-	const body = Array.from({ length: 14 }, () => alphabet[randomIndex(alphabet.length)]);
-	const digit = digits[randomIndex(digits.length)];
-	const special = specials[randomIndex(specials.length)];
-	return body.join('') + digit + special;
+	const chars = Array.from({ length: 14 }, () => alphabet[randomIndex(alphabet.length)]);
+	chars.push(digits[randomIndex(digits.length)]);
+	chars.push(specials[randomIndex(specials.length)]);
+	return chars.join('');
 }
 
 /**

--- a/src/lib/version/calver.ts
+++ b/src/lib/version/calver.ts
@@ -34,7 +34,7 @@ const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
  */
 export function nextVersion(tags: string[], today: string): string {
 	const prefix = monthPrefix(today);
-	const micro = new RegExp(`^${prefix.replace(/\./g, '\\.')}\\.(\\d+)$`);
+	const micro = new RegExp(`^${escapeRegExp(prefix)}\\.(\\d+)$`);
 
 	const highest = tags.reduce((max, tag) => {
 		const match = micro.exec(tag);
@@ -42,6 +42,11 @@ export function nextVersion(tags: string[], today: string): string {
 	}, -1);
 
 	return `${prefix}.${highest + 1}`;
+}
+
+/** Escapes every regex metacharacter (including backslash) so a literal string can be embedded in a pattern. */
+function escapeRegExp(literal: string): string {
+	return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /** Splits an ISO `YYYY-MM-DD` string into its `YYYY.0M` prefix, throwing if malformed. */


### PR DESCRIPTION
Resolves the open GitHub code-scanning alerts.

## Changes

- **`generatePassword()`** (`src/lib/server/db/auth/user.ts`) — alerts #1–#3, `js/biased-cryptographic-random`. Each character was picked with `randomByte % n`, which biases toward the low end of any alphabet that doesn't divide 256 evenly. Indices now go through a new `randomIndex()` helper that rejection-samples the biased tail before taking the modulo, so every character is uniform. This also clears the #3 false positive (string concatenation) by removing the tainted flow.

- **`nextVersion()`** (`src/lib/version/calver.ts`) — alert #4, `js/incomplete-sanitization`. The month prefix was embedded into a `RegExp` escaping only `.`, leaving a backslash unescaped. Replaced with a full-metacharacter `escapeRegExp()`. Not exploitable given the digits-only prefix, but now correct.

## Not a code change

- **Alert #5** (`js/clear-text-logging`, `scripts/reset-password.ts`) — intentional per ADR-0015: the server-shell recovery CLI prints the freshly reset password once to the operator's stdout. Dismissed on GitHub as "won't fix" with an explanatory comment.

## Verification

- `user.test.ts` (16), `calver.test.ts` + `auth.test.ts` (35) pass
- ESLint clean on both changed files

No CHANGELOG entry: internal security hardening, no user-visible behavior change.