### PR TITLE
fix(security): patch undici and fast-uri vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "genug",
-	"version": "2026.07.6",
+	"version": "2026.07.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "genug",
-			"version": "2026.07.6",
+			"version": "2026.07.7",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@fontsource-variable/ibm-plex-sans": "^5.3.0",
@@ -4549,9 +4549,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -7619,9 +7619,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"//overrides": "Rationale and per-pin removal conditions: https://github.com/lj-n/genug/issues/213",
 	"overrides": {
 		"cookie": "^0.7.0",
-		"undici": "^7.28.0",
+		"undici": "^7.29.0",
 		"esbuild": "$esbuild"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Resolves all five open Dependabot alerts (#17–#21), which all point at the same package: **undici < 7.29.0** (1 high, 4 medium), transitive via jsdom. Bumps the existing `overrides` pin (#213) from `^7.28.0` to `^7.29.0`; undici now resolves to 7.29.0.

Also updates transitive **fast-uri** to 3.1.5 (high, GHSA-7p8r-x3mc-p8w7, via ajv), which `npm audit` surfaced but Dependabot had not yet flagged.

- `npm audit`: 0 vulnerabilities
- `npm run check`: clean
- Unit tests: 679 passed

No changelog entry per repo rules (dependency bumps).